### PR TITLE
fix: Face login not working in production deployment #19

### DIFF
--- a/frontend/nyaysetu-frontend/src/hooks/useFaceRecognition.js
+++ b/frontend/nyaysetu-frontend/src/hooks/useFaceRecognition.js
@@ -1,6 +1,14 @@
 import { useState, useEffect } from 'react';
 import * as faceapi from 'face-api.js';
 
+// Smart Base URL detection - same pattern as api.js
+const isLocalhost = typeof window !== 'undefined' &&
+    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+const PROD_BACKEND = 'https://nyaysetubackend.onrender.com';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ||
+    import.meta.env.VITE_API_URL ||
+    (isLocalhost ? 'http://localhost:8080' : PROD_BACKEND);
+
 export const useFaceRecognition = () => {
     const [modelsLoaded, setModelsLoaded] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
@@ -88,7 +96,7 @@ export const useFaceRecognition = () => {
 
     const enrollFace = async (descriptor, token) => {
         try {
-            const response = await fetch('http://localhost:8080/api/face/enroll', {
+            const response = await fetch(`${API_BASE_URL}/api/face/enroll`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -112,7 +120,7 @@ export const useFaceRecognition = () => {
 
     const loginWithFace = async (email, descriptor) => {
         try {
-            const response = await fetch('http://localhost:8080/api/face/verify', {
+            const response = await fetch(`${API_BASE_URL}/api/face/verify`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({


### PR DESCRIPTION
## Summary
Fixed face login feature that was working locally but failing in production deployment.

## Root Cause
The [useFaceRecognition.js](cci:7://file:///Users/virendragadekar/Documents/NYAY-SETU/frontend/nyaysetu-frontend/src/hooks/useFaceRecognition.js:0:0-0:0) hook had hardcoded `localhost:8080` URLs for face enrollment and verification endpoints, which bypassed the production backend URL when deployed to Vercel.

## Changes
- Added smart base URL detection to [useFaceRecognition.js](cci:7://file:///Users/virendragadekar/Documents/NYAY-SETU/frontend/nyaysetu-frontend/src/hooks/useFaceRecognition.js:0:0-0:0)
- Environment-aware: uses `localhost:8080` in dev, `nyaysetubackend.onrender.com` in production
- Uses same pattern as [api.js](cci:7://file:///Users/virendragadekar/Documents/NYAY-SETU/frontend/nyaysetu-frontend/src/services/api.js:0:0-0:0) for consistency

## Testing
- ✅ Tested locally - Face enrollment and login working
- ⏳ Needs verification on production after merge

Closes #19