### PR TITLE
fix: reduce Render cold start with lazy init + keep-alive cron (#53)

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,22 @@
+name: Keep Render Backend Alive
+
+on:
+  schedule:
+    # Ping every 14 minutes (Render shuts down after 15 min inactivity)
+    - cron: '*/14 * * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Backend Health Endpoint
+        run: |
+          echo "Pinging backend to prevent Render cold start..."
+          response=$(curl -s -o /dev/null -w "%{http_code}" https://nyaysetubackend.onrender.com/api/health --max-time 120)
+          echo "Response code: $response"
+          if [ "$response" = "200" ]; then
+            echo "✅ Backend is alive!"
+          else
+            echo "⚠️ Backend returned: $response (may be waking up)"
+          fi

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
@@ -1,0 +1,25 @@
+package com.nyaysetu.backend.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/api/health")
+    public ResponseEntity<Map<String, Object>> healthCheck() {
+        long uptimeMs = ManagementFactory.getRuntimeMXBean().getUptime();
+        Duration uptime = Duration.ofMillis(uptimeMs);
+
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "service", "nyaysetu-backend",
+                "uptime", String.format("%dh %dm %ds", uptime.toHours(), uptime.toMinutesPart(), uptime.toSecondsPart())
+        ));
+    }
+}

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -6,6 +6,12 @@ server.port=8080
 # Application Name
 spring.application.name=nyaysetu-backend
 
+# ============================================
+# STARTUP OPTIMIZATION (Render Cold Start Fix)
+# ============================================
+# Delay bean creation until first needed — cuts boot time significantly
+spring.main.lazy-initialization=true
+
 # Database Configuration (Local/Development)
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/nyaysetu}
 spring.datasource.username=${DB_USERNAME:postgres}


### PR DESCRIPTION
Backend:
- Enable spring.main.lazy-initialization=true to delay bean creation
- Add /api/health endpoint (returns status + uptime JSON)

DevOps:
- Add GitHub Actions workflow that pings /api/health every 14 min to prevent Render free tier from spinning down (15 min timeout)

Fixes #53

# Pull Request

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Closes #53 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
