### PR TITLE
fix: wrap console.log statements with DEV environment check

### DIFF
--- a/frontend/nyaysetu-frontend/src/services/api.js
+++ b/frontend/nyaysetu-frontend/src/services/api.js
@@ -37,12 +37,12 @@ api.interceptors.request.use((config) => {
     }
 
     if (import.meta.env.DEV) {
-    console.log('API Request:', {
-        method: config.method,
-        url: config.url,
-        hasAuth: !!config.headers.Authorization,
-        contentType: config.headers['Content-Type']
-    });
+        console.log('API Request:', {
+            method: config.method,
+            url: config.url,
+            hasAuth: !!config.headers.Authorization,
+            contentType: config.headers['Content-Type']
+        });
     }
 
     return config;
@@ -86,13 +86,13 @@ export const documentAPI = {
             formData.append('caseId', metadata.caseId);
         }
 
-        if(import.meta.env.DEV) {
-        console.log('Uploading with FormData:', {
-            file: file.name,
-            category: metadata.category,
-            description: metadata.description
-        });
-    }
+        if (import.meta.env.DEV) {
+            console.log('Uploading with FormData:', {
+                file: file.name,
+                category: metadata.category,
+                description: metadata.description
+            });
+        }
         // CRITICAL: Don't set Content-Type header - let browser set it with boundary
         return api.post('/api/documents/upload', formData);
     },

--- a/frontend/nyaysetu-frontend/src/services/api.js
+++ b/frontend/nyaysetu-frontend/src/services/api.js
@@ -36,12 +36,14 @@ api.interceptors.request.use((config) => {
         delete config.headers['Content-Type'];
     }
 
+    if (import.meta.env.DEV) {
     console.log('API Request:', {
         method: config.method,
         url: config.url,
         hasAuth: !!config.headers.Authorization,
         contentType: config.headers['Content-Type']
     });
+    }
 
     return config;
 });
@@ -84,12 +86,13 @@ export const documentAPI = {
             formData.append('caseId', metadata.caseId);
         }
 
+        if(import.meta.env.DEV) {
         console.log('Uploading with FormData:', {
             file: file.name,
             category: metadata.category,
             description: metadata.description
         });
-
+    }
         // CRITICAL: Don't set Content-Type header - let browser set it with boundary
         return api.post('/api/documents/upload', formData);
     },


### PR DESCRIPTION
Fixes #185

## Changes Made
- Wrapped `console.log` in the API request interceptor with `if (import.meta.env.DEV)` check
- Wrapped `console.log` in the document upload function with `if (import.meta.env.DEV)` check

## Why
Console logs in production expose request details and clutter the 
browser console. These logs now only run in development mode.

## Files Changed
- `frontend/nyaysetu-frontend/src/services/api.js`

## Type of change
- Bug fix (non-breaking change which fixes an issue)