### PR TITLE
feat: add SkeletonCard component for dashboard stat cards loading state

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/common/SkeletonCard.jsx
+++ b/frontend/nyaysetu-frontend/src/components/common/SkeletonCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import '../../styles/skeleton.css';
+const SkeletonCard = () => {
+    return (
+      <div className="skeleton-card loading-skeleton">
+        <div className="skeleton-icon"></div>
+        <div className="skeleton-title"></div>
+        <div className="skeleton-value"></div>
+      </div>
+    );
+};
+export default SkeletonCard;

--- a/frontend/nyaysetu-frontend/src/pages/litigant/LitigantDashboard.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/LitigantDashboard.jsx
@@ -1,3 +1,4 @@
+import SkeletonCard from '../../components/common/SkeletonCard';
 import { useState, useEffect } from 'react';
 import { FolderOpen, Video, FileText, TrendingUp, Clock, Bot, MessageCircle, MessageSquare, Loader2, Scale, AlertCircle, Eye } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -266,7 +267,15 @@ export default function LitigantDashboard() {
                 gap: '1.5rem',
                 marginBottom: '2rem'
             }}>
-                {stats.map((stat, index) => {
+                {loading ? (
+                    <>
+                        <SkeletonCard />
+                        <SkeletonCard />
+                        <SkeletonCard />
+                        <SkeletonCard />
+                    </>
+                ) 
+                : stats.map((stat, index) => {
                     const Icon = stat.icon;
                     return (
                         <div

--- a/frontend/nyaysetu-frontend/src/styles/skeleton.css
+++ b/frontend/nyaysetu-frontend/src/styles/skeleton.css
@@ -1,36 +1,36 @@
-/*Extends .loading-skeleton from responsive.css with shimmer animation */
+/* Extends .loading-skeleton from responsive.css with shimmer animation */
 @keyframes shimmer {
     0% { background-position: -200% 0; }
     100% { background-position: 200% 0; }
 }
 .loading-skeleton {
     min-height: 200px;
-    background: linear-gradient(90deg, #1a1a2e 25%, #2a2a4e 50%, #1a1a2e 75%);
+    background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
     background-size: 200% 100%;
     animation: shimmer 1.5s infinite;
     border-radius: 12px;
 }
-.skeleton-card{
+.skeleton-card {
     padding: 1.5rem;
     display: flex;
     flex-direction: column;
-    gap:12px;
+    gap: 12px;
 }
-.skeleton-icon{
+.skeleton-icon {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: rgba(255,255,255,0.1);
+    background: rgba(0, 0, 0, 0.06);
 }
 .skeleton-title {
     width: 60%;
     height: 14px;
     border-radius: 6px;
-    background: rgba(255,255,255,0.1); 
+    background: rgba(0, 0, 0, 0.06);
 }
-.skeleton-value{
+.skeleton-value {
     width: 40%;
     height: 24px;
     border-radius: 6px;
-    background: rgba(255,255,255,0.1);
+    background: rgba(0, 0, 0, 0.06);
 }

--- a/frontend/nyaysetu-frontend/src/styles/skeleton.css
+++ b/frontend/nyaysetu-frontend/src/styles/skeleton.css
@@ -1,0 +1,36 @@
+/*Extends .loading-skeleton from responsive.css with shimmer animation */
+@keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+}
+.loading-skeleton {
+    min-height: 200px;
+    background: linear-gradient(90deg, #1a1a2e 25%, #2a2a4e 50%, #1a1a2e 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+    border-radius: 12px;
+}
+.skeleton-card{
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap:12px;
+}
+.skeleton-icon{
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.1);
+}
+.skeleton-title {
+    width: 60%;
+    height: 14px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.1); 
+}
+.skeleton-value{
+    width: 40%;
+    height: 24px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.1);
+}


### PR DESCRIPTION
# Pull Request
Fixes #184

## Changes Made
- Created `SkeletonCard.jsx` component in `src/components/common/`
- Created `src/styles/skeleton.css` with shimmer animation extending existing `.loading-skeleton` class
- Integrated SkeletonCard into `LitigantDashboard.jsx` as reference implementation
- Stat cards now show shimmer skeleton placeholders while API data is loading

## How it works
- While `loading === true`, 4 SkeletonCard components render in the stats grid
- Once data loads, real stat cards replace the skeletons
- Skeleton matches existing card dimensions and dark glassmorphism theme

## Files Changed
- `src/components/common/SkeletonCard.jsx` (new)
- `src/styles/skeleton.css` (new)
- `src/pages/litigant/LitigantDashboard.jsx` (modified)

## Type of change
- New feature (non-breaking change which adds functionality)
## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Closes # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
