### PR TITLE
Fix:197 add maximum query length validation to NLP and research endpo…

### DIFF
--- a/nlp-orchestrator/main.py
+++ b/nlp-orchestrator/main.py
@@ -170,6 +170,8 @@ async def analyze_stream(body: LegalQuery, request: Request):
     """
     if not body.query.strip():
         raise HTTPException(status_code=400, detail="Query cannot be empty")
+    if len(body.query) > 2000:
+        raise HTTPException(status_code=400, detail="Query exceeds maximum length of 2000 characters")
 
     logger.info(f"[Stream] New query: {body.query[:80]}")
 
@@ -191,6 +193,8 @@ async def analyze_sync(body: LegalQuery):
     """
     if not body.query.strip():
         raise HTTPException(status_code=400, detail="Query cannot be empty")
+    if len(body.query) > 2000:
+        raise HTTPException(status_code=400, detail="Query exceeds maximum length of 2000 characters")
 
     logger.info(f"[Sync] Analyzing: {body.query[:80]}")
 
@@ -442,6 +446,8 @@ async def deep_research(body: LegalQuery, request: Request):
     """
     if not body.query.strip():
         raise HTTPException(status_code=400, detail="Query cannot be empty")
+    if len(body.query) > 2000:
+        raise HTTPException(status_code=400, detail="Query exceeds maximum length of 2000 characters")
 
     logger.info(f"[Deep Research] New query: {body.query[:80]}")
 


### PR DESCRIPTION
…ints

# Pull Request

## Description
Issue Summary
The NLP orchestrator endpoints (/api/legal/analyze, /api/legal/analyze-stream, and /research/deep) lacked a maximum query length validation. While the system correctly identified empty queries, it allowed arbitrarily large inputs to be processed.

This oversight posed a significant risk for:

Excessive Token Consumption: Large payloads lead to massive token counts being sent to downstream LLM providers (Groq and Gemini).

Increased API Costs: Unchecked input lengths directly correlate to higher operational expenses.

Resource Exhaustion: Processing extremely long strings can degrade service performance or lead to timeouts.
Closes #197 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
