### PR TITLE
refactor: add reusable query validation with 2000-character limit acr…

### DIFF
--- a/nlp-orchestrator/main.py
+++ b/nlp-orchestrator/main.py
@@ -79,6 +79,16 @@ def sse_event(event_type: str, data: dict) -> str:
     """Return a JSON-encoded SSE event string."""
     return json.dumps({"type": event_type, **data})
 
+# ─── Query Length Check────────────────────────────────────────────────────────
+
+MAX_QUERY_LENGTH = 2000
+
+def validate_query(query: str):
+    if not query.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty")
+    if len(query) > MAX_QUERY_LENGTH:
+        raise HTTPException(status_code=400,
+                             detail=f"Query exceeds maximum length of {MAX_QUERY_LENGTH} characters")
 
 # ─── Core SSE Pipeline ────────────────────────────────────────────────────────
 
@@ -168,8 +178,9 @@ async def analyze_stream(body: LegalQuery, request: Request):
     Primary SSE endpoint — streams the full legal reasoning pipeline.
     Frontend connects using fetch + ReadableStream for real-time updates.
     """
-    if not body.query.strip():
-        raise HTTPException(status_code=400, detail="Query cannot be empty")
+
+    validate_query(body.query)
+    
 
     logger.info(f"[Stream] New query: {body.query[:80]}")
 
@@ -189,8 +200,7 @@ async def analyze_sync(body: LegalQuery):
     Synchronous endpoint — runs the full pipeline and returns all results at once.
     Use only for testing. In production, use /analyze-stream for real-time UX.
     """
-    if not body.query.strip():
-        raise HTTPException(status_code=400, detail="Query cannot be empty")
+    validate_query(body.query)
 
     logger.info(f"[Sync] Analyzing: {body.query[:80]}")
 
@@ -440,8 +450,7 @@ async def deep_research(body: LegalQuery, request: Request):
     Indian Kanoon context. Frontend connects directly to this for
     the reasoning panel + avatar speech updates.
     """
-    if not body.query.strip():
-        raise HTTPException(status_code=400, detail="Query cannot be empty")
+    validate_query(body.query)
 
     logger.info(f"[Deep Research] New query: {body.query[:80]}")
 


### PR DESCRIPTION
…oss endpoints

# Pull Request

## Description

This PR introduces centralized query validation to enforce consistent input rules across all legal and research endpoints.

A reusable `validate_query()` function has been added to:
- `/api/legal/analyze-stream`
- `/api/legal/analyze`
- `/research/deep`

The validation ensures:
1. Queries cannot be empty
2. Queries cannot exceed 2000 characters

If the query exceeds the maximum length, the API returns:
HTTP 400 with message:
"Query exceeds maximum length of 2000 characters"

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
