### PR TITLE
Add version and Java runtime info to health endpoint

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
@@ -27,9 +27,6 @@ public class HealthController {
                 "uptime", String.format("%dh %dm %ds", uptime.toHours(), uptime.toMinutesPart(), uptime.toSecondsPart()),
                     "version", version,
                 "java", javaVersion
-
-
-
         ));
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
@@ -15,11 +15,21 @@ public class HealthController {
     public ResponseEntity<Map<String, Object>> healthCheck() {
         long uptimeMs = ManagementFactory.getRuntimeMXBean().getUptime();
         Duration uptime = Duration.ofMillis(uptimeMs);
+        String version = getClass().getPackage().getImplementationVersion();
+        if (version == null) {
+            version = "dev";
+        }
+        String javaVersion = System.getProperty("java.version");
 
         return ResponseEntity.ok(Map.of(
                 "status", "UP",
                 "service", "nyaysetu-backend",
-                "uptime", String.format("%dh %dm %ds", uptime.toHours(), uptime.toMinutesPart(), uptime.toSecondsPart())
+                "uptime", String.format("%dh %dm %ds", uptime.toHours(), uptime.toMinutesPart(), uptime.toSecondsPart()),
+                    "version", version,
+                "java", javaVersion
+
+
+
         ));
     }
 }


### PR DESCRIPTION
## Summary

fixes #194 

This PR enhances the `/api/health` endpoint by adding runtime metadata.

## Changes

* Added `version` field (with fallback to `dev` if unavailable)
* Added `java` field using `System.getProperty("java.version")`
* Preserved existing fields (`status`, `service`, `uptime`)

## Notes

No changes to existing logic or dependencies. Only response enrichment.
