### PR TITLE
fix: add Jakarta Bean Validation to LoginRequest, RegisterRequest, CreateCaseRequest

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -19,6 +19,7 @@ import jakarta.mail.MessagingException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -36,7 +37,7 @@ public class AuthController {
     private final PasswordEncoder passwordEncoder;
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody RegisterRequest req) {
+    public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest req) {
         try {
             authService.register(
                     req.getEmail(),
@@ -75,7 +76,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest req) {
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest req) {
         System.out.println("DEBUG: LOGIN ENDPOINT REACHED for email: " + req.getEmail());
         try {
             authenticationManager.authenticate(

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/CreateCaseRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/CreateCaseRequest.java
@@ -1,13 +1,25 @@
 package com.nyaysetu.backend.dto;
 
 import lombok.*;
+import jakarta.validation.constraints.NotBlank;
 
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class CreateCaseRequest {
+
+    @NotBlank(message = "Title is required")
     private String title;
+
+    @NotBlank(message = "Description is required")
     private String description;
+
+    @NotBlank(message = "Case type is required")
     private String caseType; // CIVIL, CRIMINAL, FAMILY, PROPERTY, COMMERCIAL
+
+    @NotBlank(message = "Petitioner is required")
     private String petitioner;
+
+    @NotBlank(message = "Respondent is required")
     private String respondent;
+
     private String urgency; // NORMAL, URGENT, CRITICAL
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/LoginRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/LoginRequest.java
@@ -1,9 +1,14 @@
 package com.nyaysetu.backend.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 public class LoginRequest {
+    @NotBlank(message="Email is required")
+    @Email(message="Invalid email format")
     private String email;
+    @NotBlank(message="Password required")
     private String password;
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/RegisterRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/RegisterRequest.java
@@ -2,11 +2,20 @@ package com.nyaysetu.backend.dto;
 
 import com.nyaysetu.backend.entity.Role;
 import lombok.Data;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Data
 public class RegisterRequest {
+
+    @NotBlank(message="Email is required")
+    @Email(message="Invalid email format")
     private String email;
     private String name;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 6, message = "Password must be at least 6 characters")
     private String password;
     private Role role; // very important
 }


### PR DESCRIPTION
Description:
Implemented Jakarta Bean Validation for request DTOs to prevent invalid input from reaching the service layer.

Changes Made:
* Added `@NotBlank` validation to required fields
* Added `@Email` validation for email fields
* Added `@Size(min = 6)` validation for passwords
* Added `@Valid` to `@RequestBody` parameters in `AuthController`
* Verified validation dependency configuration

Files Updated:
* `LoginRequest.java`
* `RegisterRequest.java`
* `CreateCaseRequest.java`
* `AuthController.java`

Verification:
* Compilation verified using:
mvn compile

Closes #193

