### PR TITLE
Add unit tests for HealthController

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HealthControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HealthControllerTest.java
@@ -1,0 +1,33 @@
+package com.nyaysetu.backend.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HealthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthEndpoint_shouldReturn200() throws Exception {
+        mockMvc.perform(get("/api/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void healthEndpoint_shouldReturnExpectedFields() throws Exception {
+        mockMvc.perform(get("/api/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.service").value("nyaysetu-backend"))
+                .andExpect(jsonPath("$.uptime").exists());
+    }
+}


### PR DESCRIPTION
## Description

Added unit tests for the `HealthController` health check endpoint using `@WebMvcTest`.

### Changes Made

* Created `HealthControllerTest.java`
* Added test to verify `/api/health` returns HTTP 200 OK
* Verified expected response fields:

  * status
  * service
  * uptime
* Disabled security filters during testing using `@AutoConfigureMockMvc(addFilters = false)`

### Test Result

Successfully passed all tests using:

```bash
mvn test
```
Fixes #206
