### PR TITLE
Fix: Implement global ScrollToTop on route change (#255)

### DIFF
--- a/frontend/nyaysetu-frontend/src/App.jsx
+++ b/frontend/nyaysetu-frontend/src/App.jsx
@@ -4,6 +4,7 @@ import useAuthStore from './store/authStore';
 import { LanguageProvider } from './contexts/LanguageContext.jsx';
 import ErrorBoundary from './components/ErrorBoundary';
 import LoadingSpinner from './components/LoadingSpinner';
+import ScrollToTop from './components/ScrollToTop';
 
 // PWA Components
 import OfflineIndicator from './components/OfflineIndicator';
@@ -105,6 +106,7 @@ function App({ swRegistration }) {
                         v7_relativeSplatPath: true
                     }}
                 >
+                    <ScrollToTop />
                     <Suspense fallback={<LoadingSpinner fullScreen message="Loading NyaySetu..." />}>
                         <Routes>
                             <Route path="/" element={<Landing />} />

--- a/frontend/nyaysetu-frontend/src/components/ScrollToTop.jsx
+++ b/frontend/nyaysetu-frontend/src/components/ScrollToTop.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo({
+            top: 0,
+            left: 0,
+            behavior: 'smooth'
+        });
+    }, [pathname]);
+
+    return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
# Pull Request

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
This PR addresses the navigation behavior where newly opened pages would retain the scroll position of the previous page. I implemented a **`ScrollToTop`** component utilizing React Router's **`useLocation`** hook and placed it within the **`BrowserRouter`** in **`App.jsx`**. 
Now, whenever the route path changes, the window automatically and smoothly scrolls to the top (`0, 0`), providing a consistent user experience.

Closes #255 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
