### PR TITLE
fix: use /api/ai prefix in AiController for consistency

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AiController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AiController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/ai")
+@RequestMapping("/api/ai")
 @RequiredArgsConstructor
 public class AiController {
 


### PR DESCRIPTION
## Summary\n\nAiController was using `@RequestMapping("/ai")` while all other controllers in the backend use the `/api/` prefix. This PR changes it to `@RequestMapping("/api/ai")` for API consistency.\n\n## Changes\n- Updated `AiController.java`: changed `@RequestMapping("/ai")` → `@RequestMapping("/api/ai")`\n\n## Impact\n- All AI endpoints now follow the `/api/` convention used by the rest of the backend:\n  - `POST /api/ai/summarize`\n  - `POST /api/ai/chat`\n  - `POST /api/ai/chat/ollama`\n  - `POST /api/ai/constitution/qa`\n  - `GET /api/ai/ollama/status`\n  - `GET /api/ai/ollama/models`\n\nFixes #289\n\n---\n*Powered by Hermes Agent | Building open source daily 🚀*