### PR TITLE
fix: update AI provider names in LanguageContext #278

### DIFF
--- a/frontend/nyaysetu-frontend/src/contexts/LanguageContext.jsx
+++ b/frontend/nyaysetu-frontend/src/contexts/LanguageContext.jsx
@@ -148,7 +148,7 @@ export const translations = {
 
         // AI Chatbot
         aiChatbotTitle: 'AI Legal Assistant',
-        aiChatbotSubtitle: 'Powered by Anthropic Claude',
+        aiChatbotSubtitle: 'Powered by Groq (Llama 3.3) and Google Gemini',
         askQuestion: 'Ask me about law, cases, or the Constitution',
         typeMessage: 'Type your message...',
         send: 'Send',
@@ -302,7 +302,7 @@ export const translations = {
 
         // AI Chatbot
         aiChatbotTitle: 'AI कानूनी सहायक',
-        aiChatbotSubtitle: 'Anthropic Claude द्वारा संचालित',
+        aiChatbotSubtitle: 'Groq (Llama 3.3) और Google Gemini द्वारा संचालित',
         askQuestion: 'मुझसे कानून, मामलों या संविधान के बारे में पूछें',
         typeMessage: 'अपना संदेश टाइप करें...',
         send: 'भेजें',


### PR DESCRIPTION
# Pull Request

## Description
Updated the `aiChatbotSubtitle` strings in `LanguageContext.jsx` for both English and Hindi versions. The labels now correctly reference Groq (Llama 3.3) and Google Gemini instead of Anthropic Claude.

Closes #278

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes