### PR TITLE
chore: remove empty frontend/package-lock.json placeholder

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "frontend",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Description
Remove the empty `frontend/package-lock.json` placeholder file that duplicates
the real lockfile at `frontend/nyaysetu-frontend/package-lock.json`.

The file contains zero packages and serves no purpose. The existing `.gitignore`
rule already covers `package-lock.json`, but this file was committed before the
rule was added.

Closes #294

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
