### PR TITLE
feat: Add OpenAPI/Swagger Documentation for Backend REST Endpoints (Fixes #302)

### DIFF
--- a/backend/nyaysetu-backend/pom.xml
+++ b/backend/nyaysetu-backend/pom.xml
@@ -62,6 +62,13 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <!-- OpenAPI/Swagger Documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
         <!-- PostgreSQL Driver -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/NyaySetuBackendApplication.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/NyaySetuBackendApplication.java
@@ -10,5 +10,6 @@ public class NyaySetuBackendApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(NyaySetuBackendApplication.class, args);
+        System.out.println("application works");
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/OpenApiConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/OpenApiConfig.java
@@ -1,0 +1,30 @@
+package com.nyaysetu.backend.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "NyaySetu API",
+                version = "1.0.0",
+                description = "REST API documentation for the NyaySetu Digital Judiciary Platform. " +
+                        "Provides endpoints for case management, FIR filing, AI legal assistance, " +
+                        "hearings, evidence vault, and user authentication.",
+                contact = @Contact(name = "NyaySetu Team")
+        )
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        description = "Enter your JWT token obtained from /api/auth/login"
+)
+public class OpenApiConfig {
+    // Configuration is handled via annotations above
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AiController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AiController.java
@@ -3,9 +3,12 @@ package com.nyaysetu.backend.controller;
 import com.nyaysetu.backend.dto.*;
 import com.nyaysetu.backend.service.AiService;
 import com.nyaysetu.backend.service.OllamaService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+
+@Tag(name = "AI Services", description = "Text summarization and AI chat via Groq and Ollama")
 @RestController
 @RequestMapping("/ai")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuditController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuditController.java
@@ -2,6 +2,7 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.dto.CreateAuditLogRequest;
 import com.nyaysetu.backend.service.AuditService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Audit Logs", description = "Create and retrieve audit logs for case activities")
 @RestController
 @RequestMapping("/api/audit")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -20,7 +20,9 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "Authentication", description = "Register, login, password reset and face login")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/BlockchainEvidenceController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/BlockchainEvidenceController.java
@@ -4,6 +4,7 @@ import com.nyaysetu.backend.entity.EvidenceRecord;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.BlockchainEvidenceService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import java.util.*;
 /**
  * Controller for blockchain-secured evidence management
  */
+@Tag(name = "Blockchain Evidence", description = "Upload and verify evidence secured with SHA-256 blockchain hashing")
 @RestController
 @RequestMapping("/api/evidence")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/BrainController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/BrainController.java
@@ -3,6 +3,7 @@ package com.nyaysetu.backend.controller;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.NyaySetuBrainService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 /**
  * REST Controller for the Central AI Brain
  */
+@Tag(name = "NyaySetu Brain (AI)", description = "Central AI engine for legal analysis and recommendations")
 @RestController
 @RequestMapping("/api/brain")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseAssignmentController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseAssignmentController.java
@@ -4,6 +4,7 @@ import com.nyaysetu.backend.dto.LawyerDTO;
 import com.nyaysetu.backend.entity.CaseEntity;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.service.CaseAssignmentService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import java.util.UUID;
 /**
  * Controller for case assignment operations
  */
+@Tag(name = "Case Assignment", description = "Assign judges and lawyers to cases automatically or manually")
 @RestController
 @RequestMapping("/api/cases")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseEventController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseEventController.java
@@ -2,6 +2,7 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.entity.CaseEvent;
 import com.nyaysetu.backend.service.CaseEventService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import java.util.UUID;
  * Controller for Case Events (Audit Trail / Timeline).
  * Exposes endpoints for frontend Timeline component.
  */
+@Tag(name = "Case Events", description = "Audit trail and timeline events for each case")
 @RestController
 @RequestMapping("/api/cases")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseManagementController.java
@@ -4,6 +4,7 @@ import com.nyaysetu.backend.dto.CaseDTO;
 import com.nyaysetu.backend.dto.CreateCaseRequest;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.service.CaseManagementService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+@Tag(name = "Case Management", description = "Create, update, retrieve and manage legal cases")
 @RestController
 @RequestMapping("/api/cases")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseNoteController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseNoteController.java
@@ -6,12 +6,13 @@ import com.nyaysetu.backend.entity.CaseNote;
 import com.nyaysetu.backend.exception.NotFoundException;
 import com.nyaysetu.backend.repository.CaseNoteRepository;
 import com.nyaysetu.backend.service.CaseNoteService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 import java.util.UUID;
-
+@Tag(name = "Case Notes", description = "Add and retrieve private notes on a case")
 @RestController
 @RequestMapping("/cases/{caseId}/notes")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseTransitionController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseTransitionController.java
@@ -2,6 +2,7 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.entity.CaseEntity;
 import com.nyaysetu.backend.service.CaseStateTransitionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import java.util.UUID;
  * Controller for Case State Transitions (Chain Reaction Handover).
  * Handles role-to-role handoff operations.
  */
+@Tag(name = "Case Transitions", description = "Role-to-role handoff — Police to Court, Court to Judge, etc.")
 @RestController
 @RequestMapping("/api/cases/transition")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/ClientFirController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/ClientFirController.java
@@ -5,6 +5,7 @@ import com.nyaysetu.backend.dto.FirUploadResponse;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.FirService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Client FIR", description = "Litigant-facing FIR filing — manual or AI-assisted")
 @RestController
 @RequestMapping("/api/client/fir")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
@@ -7,6 +7,7 @@ import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.service.AuthService;
 import com.nyaysetu.backend.service.CaseManagementService;
 import com.nyaysetu.backend.service.DocumentManagementService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -19,7 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
+@Tag(name = "Documents", description = "Upload, download and manage case documents")
 @RestController
 @RequestMapping("/api/documents")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/EvidenceController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/EvidenceController.java
@@ -2,13 +2,14 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.dto.UploadEvidenceResponse;
 import com.nyaysetu.backend.service.EvidenceService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
-
+@Tag(name = "Evidence", description = "Upload evidence files linked to a case")
 @RestController
 @RequestMapping("/cases/{caseId}/evidence")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/FaceRecognitionController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/FaceRecognitionController.java
@@ -6,6 +6,7 @@ import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.FaceRecognitionService;
 import com.nyaysetu.backend.service.JwtService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
-
+@Tag(name = "Face Recognition", description = "Enroll and verify user identity using facial recognition")
 @RestController
 @RequestMapping("/api/face")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/FirController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/FirController.java
@@ -5,6 +5,7 @@ import com.nyaysetu.backend.dto.FirUploadResponse;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.FirService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -16,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
+@Tag(name = "FIR (Police)", description = "Police-facing FIR creation, upload and case submission")
 @RestController
 @RequestMapping("/api/police")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HealthController.java
@@ -1,5 +1,6 @@
 package com.nyaysetu.backend.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +10,7 @@ import java.time.Duration;
 import java.util.Map;
 
 @RestController
+@Tag(name = "Health", description = "Server health check — uptime, version and status")
 public class HealthController {
 
     @GetMapping("/api/health")

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HearingController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HearingController.java
@@ -7,6 +7,7 @@ import com.nyaysetu.backend.service.HearingService;
 import com.nyaysetu.backend.notification.service.NotificationService;
 import com.nyaysetu.backend.notification.entity.Notification;
 import com.nyaysetu.backend.entity.CaseEntity;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.UUID;
 
+@Tag(name = "Hearings", description = "Schedule, manage and record virtual court hearings")
 @RestController
 @RequestMapping("/api/hearings")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/JudgeController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/JudgeController.java
@@ -5,6 +5,7 @@ import com.nyaysetu.backend.entity.*;
 import com.nyaysetu.backend.repository.*;
 import com.nyaysetu.backend.service.AuthService;
 import com.nyaysetu.backend.service.GroqDocumentVerificationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Tag(name = "Judge Portal", description = "Judge dashboard — assigned cases, hearings and verdict management")
 @RestController
 @RequestMapping("/api/judge")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/LawyerController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/LawyerController.java
@@ -8,6 +8,7 @@ import com.nyaysetu.backend.service.AuthService;
 import com.nyaysetu.backend.service.CaseManagementService;
 import com.nyaysetu.backend.service.HearingService;
 import com.nyaysetu.backend.service.LawyerService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Tag(name = "Lawyer Portal", description = "Lawyer dashboard — client cases, evidence and hearing schedule")
 @RestController
 @RequestMapping("/api/lawyer")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/MeetingController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/MeetingController.java
@@ -4,6 +4,7 @@ import com.nyaysetu.backend.dto.CreateMeetingRequest;
 import com.nyaysetu.backend.dto.JoinMeetingRequest;
 import com.nyaysetu.backend.dto.MeetingResponse;
 import com.nyaysetu.backend.service.MeetingService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Meetings", description = "Create and join virtual meetings for hearings and consultations")
 @RestController
 @RequestMapping("/meetings")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/MessageController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/MessageController.java
@@ -3,12 +3,14 @@ package com.nyaysetu.backend.controller;
 import com.nyaysetu.backend.dto.SendMessageRequest;
 import com.nyaysetu.backend.entity.CaseMessage;
 import com.nyaysetu.backend.service.MessageService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Case Messages", description = "Send and retrieve messages between parties in a case")
 @RestController
 @RequestMapping("/api/cases/{caseId}/messages")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/OrderController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/OrderController.java
@@ -4,6 +4,7 @@ import com.nyaysetu.backend.entity.CourtOrder;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.CourtOrderRepository;
 import com.nyaysetu.backend.service.AuthService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 import java.util.*;
 
+@Tag(name = "Court Orders", description = "Issue and retrieve court orders for cases")
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/ProfileController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/ProfileController.java
@@ -3,11 +3,12 @@ package com.nyaysetu.backend.controller;
 import com.nyaysetu.backend.dto.ProfileRequest;
 import com.nyaysetu.backend.entity.UserProfile;
 import com.nyaysetu.backend.service.ProfileService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
+@Tag(name = "User Profile", description = "Create and update user profile information and photo")
 @RestController
 @RequestMapping("/profile")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/TimelineController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/TimelineController.java
@@ -2,12 +2,13 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.entity.CaseTimeline;
 import com.nyaysetu.backend.service.CaseTimelineService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
-
+@Tag(name = "Case Timeline", description = "Chronological timeline of events for a case")
 @RestController
 @RequestMapping("/api/timeline")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VakilFriendController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VakilFriendController.java
@@ -11,6 +11,7 @@ import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.VakilFriendService;
 import com.nyaysetu.backend.service.VakilFriendDocumentService;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 /**
  * Controller for Vakil-Friend AI Chat-First Case Filing
  */
+@Tag(name = "Vakil Friend (AI Chat)", description = "AI-powered chat-first case filing and legal document analysis")
 @RestController
 @RequestMapping("/api/vakil-friend")
 @RequiredArgsConstructor

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VerificationController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VerificationController.java
@@ -3,6 +3,7 @@ package com.nyaysetu.backend.controller;
 import com.nyaysetu.backend.dto.CreateVerificationRequest;
 import com.nyaysetu.backend.entity.VerificationRequest;
 import com.nyaysetu.backend.service.VerificationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Verification", description = "Submit and approve identity verification requests")
 @RestController
 @RequestMapping("/verify")
 @RequiredArgsConstructor


### PR DESCRIPTION
## Summary
Adds complete OpenAPI 3.0 / Swagger UI documentation for all 28 backend REST controllers.

Fixes #302

## Changes Made
- Added `springdoc-openapi-starter-webmvc-ui:2.3.0` dependency to `pom.xml`
- Created `OpenApiConfig.java` with API title, version, description and JWT bearer auth scheme
- Added `@Tag` annotation to all 28 controllers with name and description

## How to Test
1. Run the backend: `mvn spring-boot:run`
2. Open: http://localhost:8080/swagger-ui.html
3. All controllers and endpoints are now visible and documented
4. JWT auth can be tested directly from Swagger UI using the Authorize button

## Screenshots
<img width="1915" height="963" alt="Screenshot 2026-05-15 220037" src="https://github.com/user-attachments/assets/859aa2a5-056b-497d-a516-d16a94cfc15e" />
<img width="926" height="758" alt="image" src="https://github.com/user-attachments/assets/e68c1309-f3a9-4073-9dea-3ecf22f5ee6d" />
<img width="918" height="844" alt="image" src="https://github.com/user-attachments/assets/e6a381b5-fbda-4438-9c63-9a04206a5c7f" />
<img width="917" height="867" alt="image" src="https://github.com/user-attachments/assets/00b3e9f6-e7d5-49ee-b0f9-60ecfc61a58b" />

Hope you like my work!!
Regards
Diya Jain