### PR TITLE
Add unit tests for decompose_query in decomposer.py

### DIFF
--- a/nlp-orchestrator/tests/test_decomposer.py
+++ b/nlp-orchestrator/tests/test_decomposer.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from decomposer import decompose_query
+
+
+@pytest.mark.asyncio
+@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
+async def test_returns_list_of_strings(mock_create):
+    mock_create.return_value.choices = [
+        type(
+            "obj",
+            (),
+            {
+                "message": type(
+                    "obj",
+                    (),
+                    {
+                        "content": '["What is IPC?", "What is BNS?"]'
+                    }
+                )()
+            }
+        )
+    ]
+
+    result = await decompose_query("Explain IPC and BNS")
+
+    assert isinstance(result, list)
+    assert all(isinstance(q, str) for q in result)
+
+
+@pytest.mark.asyncio
+@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
+async def test_maximum_five_subquestions(mock_create):
+    mock_create.return_value.choices = [
+        type(
+            "obj",
+            (),
+            {
+                "message": type(
+                    "obj",
+                    (),
+                    {
+                        "content": '["Q1", "Q2", "Q3", "Q4", "Q5", "Q6"]'
+                    }
+                )()
+            }
+        )
+    ]
+
+    result = await decompose_query("Complex legal query")
+
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
+async def test_json_parsing_failure_returns_original_query(mock_create):
+    mock_create.return_value.choices = [
+        type(
+            "obj",
+            (),
+            {
+                "message": type(
+                    "obj",
+                    (),
+                    {
+                        "content": "INVALID JSON"
+                    }
+                )()
+            }
+        )
+    ]
+
+    query = "What happens in a road accident case?"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+@pytest.mark.asyncio
+@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
+async def test_api_failure_returns_original_query(mock_create):
+    mock_create.side_effect = Exception("API failure")
+
+    query = "What is Article 21?"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+

--- a/nlp-orchestrator/tests/test_router.py
+++ b/nlp-orchestrator/tests/test_router.py
@@ -1,0 +1,46 @@
+from router import classify_question
+
+
+def test_complex_query_routes_to_gemini():
+    query = (
+        "Explain the constitutional validity and judicial review "
+        "in a supreme court precedent"
+    )
+    assert classify_question(query) == "gemini"
+
+
+def test_simple_query_routes_to_groq():
+    query = "What is the penalty under IPC section 420?"
+    assert classify_question(query) == "groq"
+
+
+def test_short_query_routes_to_groq():
+    query = "What is bail?"
+    assert classify_question(query) == "groq"
+
+
+def test_long_query_routes_to_gemini():
+    query = (
+        "Can you explain the historical development of constitutional "
+        "jurisprudence in India and how judicial interpretation evolved "
+        "through landmark amendments and doctrines?"
+    )
+    assert classify_question(query) == "gemini"
+
+
+def test_empty_query_routes_to_groq():
+    query = ""
+    assert classify_question(query) == "groq"
+
+
+def test_mixed_query_prefers_gemini_when_complex_keywords_dominate():
+    query = (
+        "Explain supreme court precedent and constitutional interpretation "
+        "for bail procedure"
+    )
+    assert classify_question(query) == "gemini"
+
+
+def test_medium_length_without_keywords_defaults_to_groq():
+    query = "Tell me details regarding filing documents before district court"
+    assert classify_question(query) == "groq"


### PR DESCRIPTION
## Description

Added unit tests for the `decompose_query()` function in `decomposer.py`.

The tests cover:

* Returning a list of strings
* Ensuring a maximum of 5 sub-questions
* Graceful fallback on JSON parsing failure
* Graceful fallback on API failure

All tests are passing locally.

Closes #285

## Type of change

* Tests

## Checklist

*  My code follows the style guidelines of this project
*  I have performed a self-review of my own code
*  My changes generate no new warnings
*  I have added tests that prove my fix is effective
*  New and existing unit tests pass locally with my changes
