### PR TITLE
Fix footer quick link navigation

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
@@ -1,14 +1,17 @@
 // footer is always dark navy regardless of theme — conventional behavior
 // fixed GitHub icon hover from #333 (invisible on dark) to a visible grey
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FaLinkedin, FaTwitter, FaGithub, FaEnvelope, FaHeart } from 'react-icons/fa';
 import { Scale } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import AIAssistantModal from './AIAssistantModal';
 
 export default function Footer() {
     const { t } = useTranslation(['landing', 'common']);
     const currentYear = new Date().getFullYear();
+    const [showAIModal, setShowAIModal] = useState(false);
 
     const socialLinks = [
         {
@@ -39,9 +42,9 @@ export default function Footer() {
 
     const quickLinks = [
         { label: t('common:header.nav.features'), href: '#features' },
-        { label: t('common:header.nav.constitution'), href: '#constitution' },
-        { label: t('common:header.nav.aiAssistant'), href: '#chatbot' },
-        { label: t('common:header.nav.about'), href: '#about' }
+        { label: t('common:header.nav.constitution'), href: '/constitution', isRoute: true },
+        { label: t('common:header.nav.aiAssistant'), action: () => setShowAIModal(true) },
+        { label: t('common:header.nav.about'), href: '/about', isRoute: true }
     ];
 
     const legalLinks = [
@@ -162,19 +165,55 @@ export default function Footer() {
                         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                             {quickLinks.map((link) => (
                                 <li key={link.label} style={{ marginBottom: '0.75rem' }}>
-                                    <a
-                                        href={link.href}
-                                        style={{
-                                            color: 'rgba(255, 255, 255, 0.7)',
-                                            textDecoration: 'none',
-                                            fontSize: '0.95rem',
-                                            transition: 'color 0.2s'
-                                        }}
-                                        onMouseEnter={(e) => e.target.style.color = 'white'}
-                                        onMouseLeave={(e) => e.target.style.color = 'rgba(255, 255, 255, 0.7)'}
-                                    >
-                                        {link.label}
-                                    </a>
+                                    {link.action ? (
+                                        <button
+                                            type="button"
+                                            onClick={link.action}
+                                            style={{
+                                                color: 'rgba(255, 255, 255, 0.7)',
+                                                textDecoration: 'none',
+                                                fontSize: '0.95rem',
+                                                transition: 'color 0.2s',
+                                                background: 'none',
+                                                border: 'none',
+                                                padding: 0,
+                                                cursor: 'pointer',
+                                                fontFamily: 'inherit'
+                                            }}
+                                            onMouseEnter={(e) => e.currentTarget.style.color = 'white'}
+                                            onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255, 255, 255, 0.7)'}
+                                        >
+                                            {link.label}
+                                        </button>
+                                    ) : link.isRoute ? (
+                                        <Link
+                                            to={link.href}
+                                            style={{
+                                                color: 'rgba(255, 255, 255, 0.7)',
+                                                textDecoration: 'none',
+                                                fontSize: '0.95rem',
+                                                transition: 'color 0.2s'
+                                            }}
+                                            onMouseEnter={(e) => e.currentTarget.style.color = 'white'}
+                                            onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255, 255, 255, 0.7)'}
+                                        >
+                                            {link.label}
+                                        </Link>
+                                    ) : (
+                                        <a
+                                            href={link.href}
+                                            style={{
+                                                color: 'rgba(255, 255, 255, 0.7)',
+                                                textDecoration: 'none',
+                                                fontSize: '0.95rem',
+                                                transition: 'color 0.2s'
+                                            }}
+                                            onMouseEnter={(e) => e.currentTarget.style.color = 'white'}
+                                            onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255, 255, 255, 0.7)'}
+                                        >
+                                            {link.label}
+                                        </a>
+                                    )}
                                 </li>
                             ))}
                         </ul>
@@ -289,6 +328,7 @@ export default function Footer() {
                     </p>
                 </div>
             </div>
+            <AIAssistantModal isOpen={showAIModal} onClose={() => setShowAIModal(false)} />
         </footer>
     );
 }


### PR DESCRIPTION
Fix the landing footer quick links so they match the app’s actual navigation behavior:
- Constitution and About now use real routes
- AI Assistant opens the modal instead of a dead hash link
- Features remains an in-page anchor

This keeps the footer consistent with the header navigation and avoids broken redirects.


https://github.com/user-attachments/assets/cece30b3-9ee7-4534-b8fa-a9597831da97



I am contributing for GSSoc , please add approved labels .
Fixes #353 