### PR TITLE
ci: update frontend test job to execute vitest suite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Frontend Dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run Frontend Tests
         run: |
           cd frontend/nyaysetu-frontend
-          npm run build
+          npm run test -- --run
 
 
   nlp-tests:


### PR DESCRIPTION
# Pull Request

## Description
This PR updates the CI/CD pipeline to properly execute the newly added frontend test suite instead of just running a production build. 

Previously, because there were no frontend unit tests, the `frontend-tests` job only ran `npm run build` to verify compilation. Since PR #321 successfully introduced Vitest and state management tests, this workflow step has been updated to run `npm run test -- --run` to ensure all frontend tests pass before allowing a Docker image build.

Closes #321 (Follow-up)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
