### PR TITLE
fix: resolve About section light mode colors in dark theme

### DIFF
--- a/frontend/nyaysetu-frontend/src/pages/About.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/About.jsx
@@ -66,8 +66,8 @@ export default function About() {
             <section style={{
                 padding: '10rem 2rem 6rem',
                 textAlign: 'center',
-                background: '#FFFFFF',
-                borderBottom: '1px solid #E5E7EB'
+                background: 'var(--bg-surface)',
+                borderBottom: '1px solid var(--border-light)'
             }}>
                 <motion.div
                     initial={{ opacity: 0, y: 20 }}
@@ -140,8 +140,8 @@ export default function About() {
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         style={{
-                            background: '#FFFFFF',
-                            border: '1px solid #E5E7EB',
+                            background: 'var(--bg-surface)',
+                            border: '1px solid var(--border-light)',
                             borderRadius: '2rem',
                             padding: '3rem',
                             textAlign: 'center',
@@ -200,7 +200,7 @@ export default function About() {
                                     display: 'flex',
                                     alignItems: 'center',
                                     justifyContent: 'center',
-                                    border: '3px solid white',
+                                    border: '3px solid var(--bg-surface)',
                                     opacity: '0',
                                     transition: 'opacity 0.3s'
                                 }}
@@ -330,7 +330,7 @@ export default function About() {
             </section>
 
             {/* Development Roadmap */}
-            <section style={{ padding: '6rem 2rem', background: '#FFFFFF', borderTop: '1px solid #E5E7EB', borderBottom: '1px solid #E5E7EB' }}>
+            <section style={{ padding: '6rem 2rem', background: 'var(--bg-surface)', borderTop: '1px solid var(--border-light)', borderBottom: '1px solid var(--border-light)' }}>
                 <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
                     <motion.div
                         initial={{ opacity: 0, y: 20 }}
@@ -483,8 +483,8 @@ export default function About() {
                         maxWidth: '750px',
                         margin: '0 auto',
                         padding: '5rem 3rem',
-                        background: '#FFFFFF',
-                        border: '1px solid #E5E7EB',
+                        background: 'var(--bg-surface)',
+                        border: '1px solid var(--border-light)',
                         borderRadius: '2rem',
                         boxShadow: '0 10px 40px rgba(30, 42, 68, 0.04)'
                     }}


### PR DESCRIPTION
## Description

Fixed the About section rendering issue where light mode colours were still visible in dark mode.

### Changes Made

* Replaced hardcoded light colours with theme CSS variables
* Updated section backgrounds and borders to use design tokens
* Improved dark mode consistency across the About page

Closes #387

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] My changes generate no new warnings

## Output Screenshots

### Dark Mode Fixed
<img width="1512" height="982" alt="Screenshot 2026-05-17 at 4 12 25 PM" src="https://github.com/user-attachments/assets/b33027ba-69c4-45b8-bf0d-a4bbb8be9f0a" />

<img width="1512" height="982" alt="Screenshot 2026-05-17 at 4 12 33 PM" src="https://github.com/user-attachments/assets/fccdd44f-a9ac-4764-962a-14cc98ad0c40" />

<img width="1512" height="982" alt="Screenshot 2026-05-17 at 4 12 38 PM" src="https://github.com/user-attachments/assets/ea3cd7b0-a6b7-415d-8cc1-53e0baa79b71" />

<img width="1512" height="982" alt="Screenshot 2026-05-17 at 4 12 42 PM" src="https://github.com/user-attachments/assets/9caf29b8-f877-47e5-92ba-1ebb559fcb24" />

<img width="1512" height="982" alt="Screenshot 2026-05-17 at 4 12 45 PM" src="https://github.com/user-attachments/assets/ef8ea9d3-809f-4e96-a76d-ea446f7c2bdc" />

