### PR TITLE
security: P0 hardening — authorization, JWT secret, role escalation, document ownership, FIR access control

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final UserDetailsService userDetailsService;
@@ -48,8 +50,7 @@ public class SecurityConfig {
     @Bean
     public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
         org.springframework.web.cors.CorsConfiguration configuration = new org.springframework.web.cors.CorsConfiguration();
-        
-        // Use origins from application.properties / Env Var
+
         if (allowedOrigins != null && !allowedOrigins.isEmpty()) {
             java.util.List<String> origins = java.util.Arrays.stream(allowedOrigins.split(","))
                     .map(String::trim)
@@ -57,29 +58,17 @@ public class SecurityConfig {
                     .collect(java.util.stream.Collectors.toList());
 
             if (origins.isEmpty()) {
-                // SAFE DEFAULT: Allow local development origins only
-                configuration.setAllowedOrigins(java.util.Arrays.asList(
-                    "http://localhost:5173",
-                    "http://localhost:3000",
-                    "http://localhost"
-                ));
+                configuration.setAllowedOrigins(java.util.Arrays.asList("http://localhost:5173", "http://localhost:3000"));
                 configuration.setAllowCredentials(true);
             } else {
-                // Security: reject bare "*" — it allows any origin to make credentialed requests
                 boolean hasBareWildcard = origins.stream().anyMatch(o -> o.trim().equals("*"));
                 if (hasBareWildcard) {
                     java.util.logging.Logger.getLogger("SecurityConfig")
-                        .warning("CORS_ALLOWED_ORIGINS contains bare '*'. "
-                            + "This is unsafe with credentials. Falling back to localhost defaults.");
-                    configuration.setAllowedOrigins(java.util.Arrays.asList(
-                        "http://localhost:5173",
-                        "http://localhost:3000",
-                        "http://localhost"
-                    ));
+                        .warning("CORS_ALLOWED_ORIGINS contains bare '*'. Falling back to localhost defaults.");
+                    configuration.setAllowedOrigins(java.util.Arrays.asList("http://localhost:5173", "http://localhost:3000"));
                 } else {
                     boolean hasPattern = origins.stream().anyMatch(o -> o.contains("*"));
                     if (hasPattern) {
-                        // Specific patterns like https://*.example.com are safe with credentials
                         configuration.setAllowedOriginPatterns(origins);
                     } else {
                         configuration.setAllowedOrigins(origins);
@@ -88,37 +77,57 @@ public class SecurityConfig {
                 configuration.setAllowCredentials(true);
             }
         } else {
-            // SAFE DEFAULT: Allow local development origins only
-            configuration.setAllowedOrigins(java.util.Arrays.asList(
-                "http://localhost:5173", 
-                "http://localhost:3000", 
-                "http://localhost"
-            ));
+            configuration.setAllowedOrigins(java.util.Arrays.asList("http://localhost:5173", "http://localhost:3000"));
             configuration.setAllowCredentials(true);
         }
-        
+
         configuration.setAllowedMethods(java.util.Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(java.util.Arrays.asList("*"));
-        
+        // Explicit allowlist instead of wildcard "*" — prevents X-Forwarded-For spoofing from browser
+        configuration.setAllowedHeaders(java.util.Arrays.asList(
+            "Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With", "Cache-Control"
+        ));
+
         org.springframework.web.cors.UrlBasedCorsConfigurationSource source = new org.springframework.web.cors.UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(
-            HttpSecurity http,
-            JwtAuthFilter jwtAuthFilter) throws Exception {
-
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll())
-                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(authenticationProvider())
-                .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                // ── Public: auth endpoints ──────────────────────────────────────
+                .requestMatchers(
+                    "/api/auth/register",
+                    "/api/auth/login",
+                    "/api/auth/ping",
+                    "/api/auth/test",
+                    "/api/auth/forgot-password",
+                    "/api/auth/verify-reset-token",
+                    "/api/auth/reset-password",
+                    "/api/auth/face/login"
+                ).permitAll()
+                // ── Public: docs & health ───────────────────────────────────────
+                .requestMatchers(
+                    "/actuator/health",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/v3/api-docs/**"
+                ).permitAll()
+                // ── Role-restricted endpoints ───────────────────────────────────
+                // SECURITY FIX (P0 Finding 1 & 6): police and judge endpoints
+                // were fully public. Now require proper role assignment.
+                .requestMatchers("/api/police/**").hasAnyRole("POLICE", "ADMIN")
+                .requestMatchers("/api/judge/**").hasAnyRole("JUDGE", "ADMIN")
+                // ── Everything else requires a valid JWT ────────────────────────
+                .anyRequest().authenticated()
+            )
+            .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authenticationProvider(authenticationProvider())
+            .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
@@ -41,202 +42,169 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest req) {
         try {
-            authService.register(
-                    req.getEmail(),
-                    req.getName(),
-                    req.getPassword(),
-                    req.getRole() != null ? req.getRole() : Role.LITIGANT // default to LITIGANT
-            );
-            
-            // Auto-login after registration
+            // SECURITY FIX (P0 — Finding 23): Role self-assignment prevented.
+            // The role field from the request body is INTENTIONALLY IGNORED.
+            // All self-registered users are always LITIGANT.
+            // Privileged roles (JUDGE, POLICE, ADMIN) must be granted by an administrator.
+            authService.register(req.getEmail(), req.getName(), req.getPassword(), Role.LITIGANT);
+
             UserDetails userDetails = userDetailsService.loadUserByUsername(req.getEmail());
             String token = jwtService.generateToken(new HashMap<>(), userDetails);
             var user = authService.findByEmail(req.getEmail());
-            
+
             return ResponseEntity.ok(Map.of(
-                    "token", token,
-                    "user", Map.of(
-                            "id", user.getId(),
-                            "email", user.getEmail(),
-                            "name", user.getName(),
-                            "role", user.getRole().name()
-                    )
+                "token", token,
+                "user", Map.of("id", user.getId(), "email", user.getEmail(),
+                               "name", user.getName(), "role", user.getRole().name())
             ));
         } catch (org.springframework.dao.DataIntegrityViolationException e) {
-            return ResponseEntity.badRequest()
-                    .body(Map.of("message", "Email already exists. Please use a different email or login."));
+            return ResponseEntity.badRequest().body(Map.of("message", "Email already exists. Please login instead."));
         } catch (Exception e) {
             log.error("Registration error", e);
-            return ResponseEntity.badRequest()
-                    .body(Map.of("message", "Registration failed: " + e.getMessage()));
+            // SECURITY: Do not leak internal exception details to the caller
+            return ResponseEntity.badRequest().body(Map.of("message", "Registration failed. Please check your details."));
         }
     }
 
     @GetMapping("/ping")
-    public ResponseEntity<String> ping() {
-        return ResponseEntity.ok("pong");
-    }
+    public ResponseEntity<String> ping() { return ResponseEntity.ok("pong"); }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest req) {
-        log.debug("Login endpoint reached for email: {}", req.getEmail());
         try {
             authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(req.getEmail(), req.getPassword())
-            );
-
+                new UsernamePasswordAuthenticationToken(req.getEmail(), req.getPassword()));
             UserDetails userDetails = userDetailsService.loadUserByUsername(req.getEmail());
             String token = jwtService.generateToken(new HashMap<>(), userDetails);
-
             var user = authService.findByEmail(req.getEmail());
-
-            Map<String, Object> response = new HashMap<>();
-            response.put("token", token);
-            response.put("user", Map.of(
-                "id", user.getId(),
-                "name", user.getName(),
-                "email", user.getEmail(),
-                "role", user.getRole().name()
+            return ResponseEntity.ok(Map.of(
+                "token", token,
+                "user", Map.of("id", user.getId(), "name", user.getName(),
+                               "email", user.getEmail(), "role", user.getRole().name())
             ));
-
-            return ResponseEntity.ok(response);
-        }
-        catch (BadCredentialsException ex) {
+        } catch (BadCredentialsException ex) {
             return ResponseEntity.status(401).body(Map.of("message", "Invalid credentials"));
         }
     }
 
-    // ==================== PASSWORD RESET ENDPOINTS ====================
+    // ==================== PASSWORD RESET ====================
 
     @PostMapping("/forgot-password")
     public ResponseEntity<?> forgotPassword(@RequestBody ForgotPasswordRequest req) {
+        // SECURITY FIX (P2 — user enumeration): Always return the same response body
+        // regardless of whether the email is registered. Different status codes or
+        // messages leaked which emails had accounts.
         try {
             emailService.sendPasswordResetEmail(req.getEmail());
-            return ResponseEntity.ok(Map.of(
-                "message", "Password reset email sent successfully",
-                "email", req.getEmail()
-            ));
         } catch (MessagingException e) {
             log.error("Failed to send password reset email", e);
-            return ResponseEntity.status(500).body(Map.of("message", "Failed to send email"));
         } catch (Exception e) {
-            log.error("Error in forgot password", e);
-            return ResponseEntity.status(400).body(Map.of("message", e.getMessage()));
+            log.warn("Forgot-password for unknown/error email (suppressed to prevent enumeration)");
         }
+        return ResponseEntity.ok(Map.of("message",
+            "If an account with that email exists, a password reset link has been sent."));
     }
 
     @GetMapping("/verify-reset-token")
     public ResponseEntity<?> verifyResetToken(@RequestParam String token) {
         try {
-            PasswordResetToken resetToken = tokenRepository.findByToken(token)
-                    .orElseThrow(() -> new RuntimeException("Invalid token"));
-
-            if (resetToken.isUsed()) {
-                return ResponseEntity.status(400).body(Map.of("valid", false, "message", "Token already used"));
-            }
-
-            if (resetToken.getExpiryDate().isBefore(LocalDateTime.now())) {
-                return ResponseEntity.status(400).body(Map.of("valid", false, "message", "Token expired"));
-            }
-
+            PasswordResetToken t = tokenRepository.findByToken(token)
+                .orElseThrow(() -> new RuntimeException("Invalid"));
+            if (t.isUsed()) return ResponseEntity.badRequest().body(Map.of("valid", false, "message", "Token already used"));
+            if (t.getExpiryDate().isBefore(LocalDateTime.now())) return ResponseEntity.badRequest().body(Map.of("valid", false, "message", "Token expired"));
             return ResponseEntity.ok(Map.of("valid", true));
         } catch (Exception e) {
-            return ResponseEntity.status(400).body(Map.of("valid", false, "message", e.getMessage()));
+            return ResponseEntity.badRequest().body(Map.of("valid", false, "message", "Invalid or expired token"));
         }
     }
 
     @PostMapping("/reset-password")
     public ResponseEntity<?> resetPassword(@RequestBody ResetPasswordRequest req) {
         try {
-            PasswordResetToken resetToken = tokenRepository.findByToken(req.getToken())
-                    .orElseThrow(() -> new RuntimeException("Invalid token"));
-
-            if (resetToken.isUsed()) {
-                return ResponseEntity.status(400).body(Map.of("message", "Token already used"));
-            }
-
-            if (resetToken.getExpiryDate().isBefore(LocalDateTime.now())) {
-                return ResponseEntity.status(400).body(Map.of("message", "Token expired"));
-            }
-
-            // Update password
-            User user = resetToken.getUser();
+            PasswordResetToken t = tokenRepository.findByToken(req.getToken())
+                .orElseThrow(() -> new RuntimeException("Invalid token"));
+            if (t.isUsed()) return ResponseEntity.badRequest().body(Map.of("message", "Token already used"));
+            if (t.getExpiryDate().isBefore(LocalDateTime.now())) return ResponseEntity.badRequest().body(Map.of("message", "Token expired"));
+            User user = t.getUser();
             user.setPassword(passwordEncoder.encode(req.getNewPassword()));
             authService.updateUser(user);
-
-            // Mark token as used
-            resetToken.setUsed(true);
-            tokenRepository.save(resetToken);
-
+            t.setUsed(true);
+            tokenRepository.save(t);
             log.info("Password reset successful for user: {}", user.getEmail());
             return ResponseEntity.ok(Map.of("message", "Password reset successful"));
         } catch (Exception e) {
             log.error("Error resetting password", e);
-            return ResponseEntity.status(400).body(Map.of("message", e.getMessage()));
+            return ResponseEntity.badRequest().body(Map.of("message", "Password reset failed. The link may be invalid or expired."));
         }
     }
 
-    // ==================== FACE LOGIN ENDPOINTS ====================
+    // ==================== FACE AUTH ====================
 
-    @PostMapping("/face/enroll")
-    public ResponseEntity<?> enrollFace(@RequestBody FaceEnrollRequest req) {
-        try {
-            faceRecognitionService.enrollFace(req.getUserId(), req.getFaceDescriptor());
-            return ResponseEntity.ok(Map.of("message", "Face enrolled successfully"));
-        } catch (Exception e) {
-            log.error("Error enrolling face", e);
-            return ResponseEntity.status(400).body(Map.of("message", e.getMessage()));
-        }
-    }
-
+    /** Face login is public — it IS the authentication mechanism. */
     @PostMapping("/face/login")
     public ResponseEntity<?> loginWithFace(@RequestBody FaceLoginRequest req) {
         try {
             User user = faceRecognitionService.verifyFace(req.getEmail(), req.getFaceDescriptor());
-
-            // Generate JWT token
             UserDetails userDetails = userDetailsService.loadUserByUsername(user.getEmail());
             String token = jwtService.generateToken(new HashMap<>(), userDetails);
-
-            Map<String, Object> response = new HashMap<>();
-            response.put("token", token);
-            response.put("user", Map.of(
-                "id", user.getId(),
-                "name", user.getName(),
-                "email", user.getEmail(),
-                "role", user.getRole().name()
+            return ResponseEntity.ok(Map.of(
+                "token", token,
+                "user", Map.of("id", user.getId(), "name", user.getName(),
+                               "email", user.getEmail(), "role", user.getRole().name())
             ));
-
-            log.info("Face login successful for user: {}", user.getEmail());
-            return ResponseEntity.ok(response);
         } catch (Exception e) {
             log.error("Face login failed", e);
             return ResponseEntity.status(401).body(Map.of("message", "Face verification failed"));
         }
     }
 
-    @DeleteMapping("/face/disable")
-    public ResponseEntity<?> disableFaceLogin(@RequestParam Long userId) {
+    /**
+     * SECURITY FIX (P0 — Finding 2): Face enroll now requires authentication.
+     * userId is derived from the JWT principal — callers cannot enroll a face
+     * for a different user's account by passing an arbitrary userId in the body.
+     */
+    @PostMapping("/face/enroll")
+    public ResponseEntity<?> enrollFace(@RequestBody FaceEnrollRequest req, Authentication authentication) {
         try {
-            faceRecognitionService.disableFaceLogin(userId);
-            return ResponseEntity.ok(Map.of("message", "Face login disabled"));
+            User me = authService.findByEmail(authentication.getName());
+            faceRecognitionService.enrollFace(me.getId(), req.getFaceDescriptor());
+            return ResponseEntity.ok(Map.of("message", "Face enrolled successfully"));
         } catch (Exception e) {
-            return ResponseEntity.status(400).body(Map.of("message", e.getMessage()));
+            log.error("Error enrolling face", e);
+            return ResponseEntity.badRequest().body(Map.of("message", "Face enrollment failed"));
         }
     }
 
-    @GetMapping("/face/status")
-    public ResponseEntity<?> getFaceLoginStatus(@RequestParam Long userId) {
+    /**
+     * SECURITY FIX (P0 — Finding 2): disableFaceLogin now derives userId from JWT.
+     * Previously accepted userId as a query param — any user could disable any other user's face login.
+     */
+    @DeleteMapping("/face/disable")
+    public ResponseEntity<?> disableFaceLogin(Authentication authentication) {
         try {
-            boolean enrolled = faceRecognitionService.hasFaceEnrolled(userId);
+            User me = authService.findByEmail(authentication.getName());
+            faceRecognitionService.disableFaceLogin(me.getId());
+            return ResponseEntity.ok(Map.of("message", "Face login disabled"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Failed to disable face login"));
+        }
+    }
+
+    /**
+     * SECURITY FIX (P0 — Finding 2): getFaceLoginStatus derives userId from JWT.
+     * Previously accepted userId as a query param — exposed enrollment state of arbitrary users.
+     */
+    @GetMapping("/face/status")
+    public ResponseEntity<?> getFaceLoginStatus(Authentication authentication) {
+        try {
+            User me = authService.findByEmail(authentication.getName());
+            boolean enrolled = faceRecognitionService.hasFaceEnrolled(me.getId());
             return ResponseEntity.ok(Map.of("enrolled", enrolled));
         } catch (Exception e) {
-            return ResponseEntity.status(400).body(Map.of("message", e.getMessage()));
+            return ResponseEntity.badRequest().body(Map.of("message", "Failed to check face login status"));
         }
     }
 
     @GetMapping("/test")
-    public ResponseEntity<String> test() {
-        return ResponseEntity.ok("ok");
-    }
+    public ResponseEntity<String> test() { return ResponseEntity.ok("ok"); }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
@@ -3,6 +3,7 @@ package com.nyaysetu.backend.controller;
 import com.nyaysetu.backend.dto.DocumentDto;
 import com.nyaysetu.backend.dto.CaseSummaryDto;
 import com.nyaysetu.backend.dto.UploadDocumentRequest;
+import com.nyaysetu.backend.entity.Role;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.service.AuthService;
 import com.nyaysetu.backend.service.CaseManagementService;
@@ -21,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 @Slf4j
 @Tag(name = "Documents", description = "Upload, download and manage case documents")
 @RestController
@@ -45,213 +47,176 @@ public class DocumentManagementController {
     ) {
         try {
             User user = authService.findByEmail(authentication.getName());
-            
-            // Extract client IP address for audit trail
             String uploadIp = getClientIp(request);
-            
             UUID caseId = null;
             if (caseIdStr != null && !caseIdStr.isEmpty() && !caseIdStr.equals("null")) {
-                try {
-                    caseId = UUID.fromString(caseIdStr);
-                } catch (Exception e) {
-                    // Invalid UUID, ignore
-                }
+                try { caseId = UUID.fromString(caseIdStr); } catch (Exception ignored) {}
             }
-            
             UploadDocumentRequest uploadRequest = UploadDocumentRequest.builder()
-                    .category(category)
-                    .description(description)
-                    .caseId(caseId)
-                    .build();
-
+                .category(category).description(description).caseId(caseId).build();
             DocumentDto document = documentManagementService.uploadDocument(file, uploadRequest, user, uploadIp);
-            
-            // Auto-trigger AI verification
-            try {
-                documentManagementService.triggerAnalysis(document.getId());
-            } catch (Exception e) {
-                // Log but don't fail upload if analysis fails
+            try { documentManagementService.triggerAnalysis(document.getId()); } catch (Exception e) {
                 log.warn("AI analysis trigger failed: {}", e.getMessage());
             }
-            
             return ResponseEntity.ok(document);
         } catch (Exception e) {
-            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(500).body(Map.of("error", "Upload failed"));
         }
     }
-    
-    /**
-     * Extract client IP address from request
-     */
+
     private String getClientIp(jakarta.servlet.http.HttpServletRequest request) {
         String ip = request.getHeader("X-Forwarded-For");
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("X-Real-IP");
-        }
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getRemoteAddr();
-        }
-        // Handle multiple IPs in X-Forwarded-For
-        if (ip != null && ip.contains(",")) {
-            ip = ip.split(",")[0].trim();
-        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) ip = request.getHeader("X-Real-IP");
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) ip = request.getRemoteAddr();
+        if (ip != null && ip.contains(",")) ip = ip.split(",")[0].trim();
         return ip;
     }
 
-    /**
-     * Trigger AI analysis for a document
-     */
     @PostMapping("/{id}/analyze")
-    public ResponseEntity<?> analyzeDocument(@PathVariable UUID id) {
+    public ResponseEntity<?> analyzeDocument(@PathVariable UUID id, Authentication authentication) {
+        // SECURITY FIX (P0 — Finding 4): verify caller has access to this document before triggering analysis
+        User user = authService.findByEmail(authentication.getName());
+        DocumentDto doc = documentManagementService.getDocumentById(id);
+        if (!isAuthorizedForDocument(doc, user)) {
+            return ResponseEntity.status(403).body(Map.of("error", "Access denied"));
+        }
         try {
-            // Trigger async analysis
             documentManagementService.triggerAnalysis(id);
-            return ResponseEntity.ok(Map.of(
-                "message", "Analysis started",
-                "documentId", id.toString()
-            ));
+            return ResponseEntity.ok(Map.of("message", "Analysis started", "documentId", id.toString()));
         } catch (Exception e) {
-            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(500).body(Map.of("error", "Analysis trigger failed"));
         }
     }
 
-    /**
-     * Get AI analysis for a document
-     */
     @GetMapping("/{id}/analysis")
-    public ResponseEntity<?> getDocumentAnalysis(@PathVariable UUID id) {
+    public ResponseEntity<?> getDocumentAnalysis(@PathVariable UUID id, Authentication authentication) {
+        User user = authService.findByEmail(authentication.getName());
+        DocumentDto doc = documentManagementService.getDocumentById(id);
+        if (!isAuthorizedForDocument(doc, user)) {
+            return ResponseEntity.status(403).body(Map.of("error", "Access denied"));
+        }
         try {
-            if (!documentAnalysisService.hasAnalysis(id)) {
-                return ResponseEntity.status(404).body(Map.of("error", "Analysis not found"));
-            }
-            
-            com.nyaysetu.backend.entity.DocumentAnalysis analysis = 
-                documentAnalysisService.getAnalysisByDocumentId(id);
-                
-            return ResponseEntity.ok(analysis);
+            if (!documentAnalysisService.hasAnalysis(id)) return ResponseEntity.status(404).body(Map.of("error", "Analysis not found"));
+            return ResponseEntity.ok(documentAnalysisService.getAnalysisByDocumentId(id));
         } catch (Exception e) {
-            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(500).body(Map.of("error", "Failed to retrieve analysis"));
         }
     }
 
-    /**
-     * Check if document has analysis
-     */
     @GetMapping("/{id}/has-analysis")
-    public ResponseEntity<?> checkAnalysis(@PathVariable UUID id) {
+    public ResponseEntity<?> checkAnalysis(@PathVariable UUID id, Authentication authentication) {
+        User user = authService.findByEmail(authentication.getName());
+        DocumentDto doc = documentManagementService.getDocumentById(id);
+        if (!isAuthorizedForDocument(doc, user)) return ResponseEntity.status(403).body(Map.of("error", "Access denied"));
         try {
-            boolean hasAnalysis = documentAnalysisService.hasAnalysis(id);
-            return ResponseEntity.ok(Map.of(
-                "documentId", id.toString(),
-                "hasAnalysis", hasAnalysis
-            ));
+            return ResponseEntity.ok(Map.of("documentId", id.toString(), "hasAnalysis", documentAnalysisService.hasAnalysis(id)));
         } catch (Exception e) {
-            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(500).body(Map.of("error", "Check failed"));
         }
     }
 
     @GetMapping
     public ResponseEntity<List<DocumentDto>> getUserDocuments(Authentication authentication) {
         User user = authService.findByEmail(authentication.getName());
-        List<DocumentDto> documents = documentManagementService.getUserDocuments(user.getId());
-        return ResponseEntity.ok(documents);
+        return ResponseEntity.ok(documentManagementService.getUserDocuments(user.getId()));
     }
 
     @GetMapping("/user/cases")
     public ResponseEntity<List<CaseSummaryDto>> getUserCases(Authentication authentication) {
         User user = authService.findByEmail(authentication.getName());
-        List<CaseSummaryDto> cases = caseManagementService.getUserCaseSummaries(user);
-        return ResponseEntity.ok(cases);
+        return ResponseEntity.ok(caseManagementService.getUserCaseSummaries(user));
     }
 
     @GetMapping("/case/{caseId}")
-    public ResponseEntity<List<DocumentDto>> getCaseDocuments(
-            @PathVariable UUID caseId,
-            Authentication authentication
-    ) {
+    public ResponseEntity<List<DocumentDto>> getCaseDocuments(@PathVariable UUID caseId, Authentication authentication) {
         User user = authService.findByEmail(authentication.getName());
-        
-        // Get the case to determine user's role
         com.nyaysetu.backend.dto.CaseDTO caseData = caseManagementService.getCaseById(caseId);
-        
-        // Determine user's role in this case
-        String userRole = "VISITOR"; // Default
-        if (user.getRole() == com.nyaysetu.backend.entity.Role.JUDGE) {
-            userRole = "JUDGE";
-        } else if (caseData.getClientId() != null && caseData.getClientId().equals(user.getId())) {
-            userRole = "PETITIONER";
-        } else if (user.getEmail().equals(caseData.getRespondentEmail())) {
-            userRole = "RESPONDENT";
-        }
-        
-        // Get filtered documents based on role
-        List<DocumentDto> documents = documentManagementService.getCaseDocumentsWithAccessControl(
-            caseId, user.getId(), userRole
-        );
-        return ResponseEntity.ok(documents);
+        String userRole = "VISITOR";
+        if (user.getRole() == Role.JUDGE) userRole = "JUDGE";
+        else if (caseData.getClientId() != null && caseData.getClientId().equals(user.getId())) userRole = "PETITIONER";
+        else if (user.getEmail().equals(caseData.getRespondentEmail())) userRole = "RESPONDENT";
+        return ResponseEntity.ok(documentManagementService.getCaseDocumentsWithAccessControl(caseId, user.getId(), userRole));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<DocumentDto> getDocument(@PathVariable UUID id) {
+    public ResponseEntity<?> getDocument(@PathVariable UUID id, Authentication authentication) {
+        // SECURITY FIX (P0 — Finding 4): metadata endpoint now requires ownership check
+        User user = authService.findByEmail(authentication.getName());
         DocumentDto document = documentManagementService.getDocumentById(id);
+        if (!isAuthorizedForDocument(document, user)) {
+            return ResponseEntity.status(403).body(Map.of("error", "Access denied"));
+        }
         return ResponseEntity.ok(document);
     }
 
     @GetMapping("/{id}/download")
-    public ResponseEntity<?> downloadDocument(@PathVariable UUID id) {
+    public ResponseEntity<?> downloadDocument(@PathVariable UUID id, Authentication authentication) {
         try {
+            // SECURITY FIX (P0 — Finding 4): Document download had NO ownership check.
+            // Any authenticated user could download any document by guessing the UUID.
+            // Now: only the document owner, a JUDGE, or a POLICE officer may download.
+            User user = authService.findByEmail(authentication.getName());
             DocumentDto metadata = documentManagementService.getDocumentById(id);
-            Resource resource = documentManagementService.downloadDocument(id);
 
+            if (!isAuthorizedForDocument(metadata, user)) {
+                log.warn("Unauthorized download attempt: user {} tried to download document {}", user.getEmail(), id);
+                return ResponseEntity.status(403).body(Map.of("error", "Access denied"));
+            }
+
+            Resource resource = documentManagementService.downloadDocument(id);
             return ResponseEntity.ok()
-                    .contentType(MediaType.parseMediaType(metadata.getContentType()))
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + metadata.getFileName() + "\"")
-                    .body(resource);
+                .contentType(MediaType.parseMediaType(metadata.getContentType()))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + metadata.getFileName() + "\"")
+                .body(resource);
         } catch (RuntimeException e) {
             String msg = e.getMessage();
-            if (msg.contains("not found")) {
-                return ResponseEntity.status(404).body(Map.of("error", msg));
-            }
-            return ResponseEntity.status(500).body(Map.of("error", "Download failed: " + msg));
+            if (msg != null && msg.contains("not found")) return ResponseEntity.status(404).body(Map.of("error", "Document not found"));
+            return ResponseEntity.status(500).body(Map.of("error", "Download failed"));
         } catch (Exception e) {
-            return ResponseEntity.status(500).body(Map.of("error", "Unexpected error: " + e.getMessage()));
+            return ResponseEntity.status(500).body(Map.of("error", "Unexpected error"));
         }
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, String>> deleteDocument(
-            @PathVariable UUID id,
-            Authentication authentication
-    ) {
+    public ResponseEntity<Map<String, String>> deleteDocument(@PathVariable UUID id, Authentication authentication) {
         User user = authService.findByEmail(authentication.getName());
         documentManagementService.deleteDocument(id, user.getId());
         return ResponseEntity.ok(Map.of("message", "Document deleted successfully"));
     }
 
-    /**
-     * Download Section 63(4) Evidence Certificate for a document
-     */
     @GetMapping("/{id}/certificate")
-    public ResponseEntity<?> downloadCertificate(@PathVariable UUID id) {
+    public ResponseEntity<?> downloadCertificate(@PathVariable UUID id, Authentication authentication) {
+        // SECURITY FIX: Ownership check before issuing legal certificate
+        User user = authService.findByEmail(authentication.getName());
+        DocumentDto doc = documentManagementService.getDocumentById(id);
+        if (!isAuthorizedForDocument(doc, user)) return ResponseEntity.status(403).body(Map.of("error", "Access denied"));
         try {
             byte[] pdfBytes = certificateService.generateDocumentCertificate(id);
-            
             return ResponseEntity.ok()
-                    .contentType(org.springframework.http.MediaType.APPLICATION_PDF)
-                    .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION, 
-                            "attachment; filename=\"Certificate_" + id + ".pdf\"")
-                    .body(pdfBytes);
+                .contentType(org.springframework.http.MediaType.APPLICATION_PDF)
+                .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"Certificate_" + id + ".pdf\"")
+                .body(pdfBytes);
         } catch (Exception e) {
-            e.printStackTrace(); // Log stack trace to console
-            return ResponseEntity.status(500).body(Map.of("error", "Certificate generation failed: " + e.getMessage()));
+            log.error("Certificate generation failed for document {}", id, e);
+            return ResponseEntity.status(500).body(Map.of("error", "Certificate generation failed"));
         }
     }
-    /**
-     * Verify document hash (SHA-256) againts stored fingerprint
-     */
+
     @GetMapping("/{id}/verify-hash")
     public ResponseEntity<?> verifyHash(@PathVariable UUID id) {
         boolean isValid = documentManagementService.verifyDocumentHash(id);
         return ResponseEntity.ok(Map.of("id", id, "valid", isValid));
+    }
+
+    /**
+     * Authorization helper: returns true if the given user may access this document.
+     * Policy: owner | JUDGE | POLICE | ADMIN
+     */
+    private boolean isAuthorizedForDocument(DocumentDto document, User user) {
+        if (user.getRole() == Role.JUDGE || user.getRole() == Role.POLICE || user.getRole() == Role.ADMIN) {
+            return true;
+        }
+        // Owners are identified by the uploadedBy field on the document DTO
+        return document.getUploadedBy() != null && document.getUploadedBy().equals(user.getId());
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/FirController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/FirController.java
@@ -2,6 +2,7 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.dto.FirUploadRequest;
 import com.nyaysetu.backend.dto.FirUploadResponse;
+import com.nyaysetu.backend.entity.Role;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.UserRepository;
 import com.nyaysetu.backend.service.FirService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,11 +19,16 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 @Tag(name = "FIR (Police)", description = "Police-facing FIR creation, upload and case submission")
 @RestController
 @RequestMapping("/api/police")
 @RequiredArgsConstructor
 @Slf4j
+// SECURITY FIX (P0 — Finding 6): The entire /api/police/** path is already
+// restricted to POLICE/ADMIN by SecurityConfig. The @PreAuthorize annotations
+// here provide defence-in-depth at the method level and make intent explicit.
+@PreAuthorize("hasAnyRole('POLICE', 'ADMIN')")
 public class FirController {
 
     private final FirService firService;
@@ -29,16 +36,17 @@ public class FirController {
     private final com.nyaysetu.backend.repository.CaseRepository caseRepository;
 
     /**
-     * Get pending summons delivery tasks for police
+     * Get pending summons delivery tasks for police.
+     * SECURITY FIX (P0 — Finding 6b): Replaced caseRepository.findAll() full-table
+     * scan (OOM DoS vector) with a targeted query by summons status.
      */
     @GetMapping("/summons/pending")
     public ResponseEntity<?> getSummonsTasks() {
         try {
-            // Find cases where summons status is IN_TRANSIT
-            List<com.nyaysetu.backend.entity.CaseEntity> cases = caseRepository.findAll().stream()
-                .filter(c -> "IN_TRANSIT".equals(c.getSummonsStatus()))
-                .collect(java.util.stream.Collectors.toList());
-                
+            // FIX: Use a targeted query instead of findAll() + in-memory filter
+            List<com.nyaysetu.backend.entity.CaseEntity> cases =
+                caseRepository.findBySummonsStatus("IN_TRANSIT");
+
             List<Map<String, Object>> tasks = cases.stream().map(c -> {
                 Map<String, Object> task = new java.util.HashMap<>();
                 task.put("id", c.getId());
@@ -48,35 +56,28 @@ public class FirController {
                 task.put("type", "SUMMONS");
                 return task;
             }).collect(java.util.stream.Collectors.toList());
-            
+
             return ResponseEntity.ok(tasks);
         } catch (Exception e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+            log.error("Error fetching summons tasks", e);
+            return ResponseEntity.badRequest().body(Map.of("error", "Failed to retrieve summons tasks"));
         }
     }
 
-    /**
-     * Mark summons as served
-     */
     @PostMapping("/summons/{caseId}/complete")
     public ResponseEntity<?> completeSummonsTask(@PathVariable UUID caseId, Authentication auth) {
         try {
             com.nyaysetu.backend.entity.CaseEntity caseEntity = caseRepository.findById(caseId)
                 .orElseThrow(() -> new RuntimeException("Case not found"));
-            
             caseEntity.setSummonsStatus("SERVED");
             caseEntity.setStatus(com.nyaysetu.backend.entity.CaseStatus.SUMMONS_SERVED);
             caseRepository.save(caseEntity);
-            
             return ResponseEntity.ok(Map.of("message", "Summons marked as SERVED"));
         } catch (Exception e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+            return ResponseEntity.badRequest().body(Map.of("error", "Failed to complete summons task"));
         }
     }
 
-    /**
-     * Upload FIR document with SHA-256 digital stamping
-     */
     @PostMapping(value = "/fir/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<FirUploadResponse> uploadFir(
             @RequestParam("file") MultipartFile file,
@@ -86,93 +87,61 @@ public class FirController {
             Authentication auth) {
 
         User user = getCurrentUser(auth);
-        
         UUID caseId = null;
         if (caseIdStr != null && !caseIdStr.isEmpty()) {
-            try {
-                caseId = UUID.fromString(caseIdStr);
-            } catch (IllegalArgumentException e) {
+            try { caseId = UUID.fromString(caseIdStr); } catch (IllegalArgumentException e) {
                 log.warn("Invalid caseId format: {}", caseIdStr);
             }
         }
-
         FirUploadRequest request = FirUploadRequest.builder()
-                .title(title)
-                .description(description)
-                .caseId(caseId)
-                .build();
-
+            .title(title).description(description).caseId(caseId).build();
         FirUploadResponse response = firService.uploadFir(file, request, user);
-        
-        log.info("FIR uploaded successfully: {} with hash {}", response.getFirNumber(), response.getFileHash());
-        
+        log.info("FIR uploaded by {}: {} hash={}", user.getEmail(), response.getFirNumber(), response.getFileHash());
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * Get all FIRs uploaded by the current officer
-     */
     @GetMapping("/fir/list")
     public ResponseEntity<List<FirUploadResponse>> getMyFirs(Authentication auth) {
         User user = getCurrentUser(auth);
-        List<FirUploadResponse> firs = firService.getFirsByUploader(user.getId());
-        return ResponseEntity.ok(firs);
+        return ResponseEntity.ok(firService.getFirsByUploader(user.getId()));
     }
 
-    /**
-     * Get FIR details by ID
-     */
     @GetMapping("/fir/{id}")
     public ResponseEntity<FirUploadResponse> getFirById(@PathVariable Long id) {
-        FirUploadResponse fir = firService.getFirById(id);
-        return ResponseEntity.ok(fir);
+        return ResponseEntity.ok(firService.getFirById(id));
     }
 
-    /**
-     * Verify FIR integrity by re-hashing uploaded file
-     */
     @PostMapping(value = "/fir/{id}/verify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<FirUploadResponse> verifyFir(
-            @PathVariable Long id,
-            @RequestParam("file") MultipartFile file) {
-        
-        FirUploadResponse response = firService.verifyFirIntegrity(id, file);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<FirUploadResponse> verifyFir(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        return ResponseEntity.ok(firService.verifyFirIntegrity(id, file));
     }
 
-    /**
-     * Get police dashboard statistics
-     */
     @GetMapping("/stats")
     public ResponseEntity<FirService.FirStatsResponse> getStats(Authentication auth) {
-        User user = getCurrentUser(auth);
-        FirService.FirStatsResponse stats = firService.getStats(user.getId());
-        return ResponseEntity.ok(stats);
+        return ResponseEntity.ok(firService.getStats(getCurrentUser(auth).getId()));
     }
 
-    /**
-     * Health check endpoint
-     */
     @GetMapping("/health")
     public ResponseEntity<Map<String, String>> health() {
-        return ResponseEntity.ok(Map.of(
-                "status", "OK",
-                "service", "Police FIR Portal",
-                "message", "SHA-256 Digital Stamping Active"
-        ));
+        return ResponseEntity.ok(Map.of("status", "OK", "service", "Police FIR Portal",
+            "message", "SHA-256 Digital Stamping Active"));
     }
 
     /**
-     * Get all FIRs pending police review (client-filed FIRs)
+     * SECURITY FIX (P0 — Finding 6): getPendingFirs had no role check and
+     * was accessible to any authenticated user including litigants — allowing
+     * a suspect to view and potentially manipulate their own FIR status.
+     * Now enforced by class-level @PreAuthorize("hasAnyRole('POLICE','ADMIN')").
      */
     @GetMapping("/fir/pending")
     public ResponseEntity<List<FirUploadResponse>> getPendingFirs() {
-        List<FirUploadResponse> firs = firService.getPendingReviewFirs();
-        return ResponseEntity.ok(firs);
+        return ResponseEntity.ok(firService.getPendingReviewFirs());
     }
 
     /**
-     * Update FIR status (REGISTERED or REJECTED)
+     * SECURITY FIX (P0 — Finding 6): FIR status update (REGISTERED/REJECTED)
+     * was accessible to any authenticated user. A litigant could approve or
+     * reject their own FIR. Now restricted to POLICE/ADMIN at class level.
      */
     @PutMapping("/fir/{id}/status")
     public ResponseEntity<FirUploadResponse> updateFirStatus(
@@ -180,98 +149,53 @@ public class FirController {
             @RequestParam("status") String status,
             @RequestParam(value = "reviewNotes", required = false) String reviewNotes,
             Authentication auth) {
-        
-        User user = getCurrentUser(auth);
-        
+
         if (!status.equals("REGISTERED") && !status.equals("REJECTED")) {
             return ResponseEntity.badRequest().build();
         }
-        
-        FirUploadResponse response = firService.updateFirStatus(id, status, reviewNotes, user);
-        log.info("FIR {} status updated to {} by {}", response.getFirNumber(), status, user.getName());
-        
-        return ResponseEntity.ok(response);
-    }
-
-    /**
-     * Start investigation on an FIR
-     */
-    @PostMapping("/investigation/{id}/start")
-    public ResponseEntity<FirUploadResponse> startInvestigation(
-            @PathVariable Long id,
-            Authentication auth) {
-        
         User user = getCurrentUser(auth);
-        FirUploadResponse response = firService.startInvestigation(id, user);
+        FirUploadResponse response = firService.updateFirStatus(id, status, reviewNotes, user);
+        log.info("FIR {} updated to {} by officer {}", response.getFirNumber(), status, user.getEmail());
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * Submit investigation findings to court
-     */
+    @PostMapping("/investigation/{id}/start")
+    public ResponseEntity<FirUploadResponse> startInvestigation(@PathVariable Long id, Authentication auth) {
+        return ResponseEntity.ok(firService.startInvestigation(id, getCurrentUser(auth)));
+    }
+
     @PostMapping("/investigation/{id}/submit")
     public ResponseEntity<FirUploadResponse> submitInvestigation(
-            @PathVariable Long id,
-            @RequestBody Map<String, String> request,
-            Authentication auth) {
-        
-        User user = getCurrentUser(auth);
+            @PathVariable Long id, @RequestBody Map<String, String> request, Authentication auth) {
         String findings = request.get("findings");
-        
-        if (findings == null || findings.trim().isEmpty()) {
-            return ResponseEntity.badRequest().build();
-        }
-        
-        FirUploadResponse response = firService.submitToCourt(id, findings, user);
-        return ResponseEntity.ok(response);
+        if (findings == null || findings.trim().isEmpty()) return ResponseEntity.badRequest().build();
+        return ResponseEntity.ok(firService.submitToCourt(id, findings, getCurrentUser(auth)));
     }
 
-    /**
-     * Get FIRs currently under investigation
-     */
     @GetMapping("/investigation/list")
     public ResponseEntity<List<FirUploadResponse>> getFirsUnderInvestigation() {
-        List<FirUploadResponse> firs = firService.getFirsUnderInvestigation();
-        return ResponseEntity.ok(firs);
+        return ResponseEntity.ok(firService.getFirsUnderInvestigation());
     }
 
-    /**
-     * Upload additional evidence to FIR
-     */
     @PostMapping(value = "/investigation/{id}/evidence", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<FirUploadResponse> uploadeEvidence(
-            @PathVariable Long id,
-            @RequestParam("file") MultipartFile file,
-            @RequestParam("description") String description,
-            Authentication auth) {
-        
-        User user = getCurrentUser(auth);
-        FirUploadResponse response = firService.addEvidence(id, file, description, user);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<FirUploadResponse> uploadEvidence(
+            @PathVariable Long id, @RequestParam("file") MultipartFile file,
+            @RequestParam("description") String description, Authentication auth) {
+        return ResponseEntity.ok(firService.addEvidence(id, file, description, getCurrentUser(auth)));
     }
 
-    /**
-     * Generate AI Summary using Groq
-     */
     @GetMapping("/investigation/{id}/summary")
     public ResponseEntity<Map<String, String>> generateSummary(@PathVariable Long id) {
-        String summary = firService.generateSummary(id);
-        return ResponseEntity.ok(Map.of("summary", summary));
+        return ResponseEntity.ok(Map.of("summary", firService.generateSummary(id)));
     }
 
-    /**
-     * Draft Court Submission using Groq (Charge Sheet)
-     */
     @GetMapping("/investigation/{id}/draft-submission")
     public ResponseEntity<Map<String, String>> draftSubmission(@PathVariable Long id) {
-        String draft = firService.draftCourtSubmission(id);
-        return ResponseEntity.ok(Map.of("draft", draft));
+        return ResponseEntity.ok(Map.of("draft", firService.draftCourtSubmission(id)));
     }
 
     private User getCurrentUser(Authentication auth) {
-        String email = auth.getName();
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found: " + email));
+        return userRepository.findByEmail(auth.getName())
+            .orElseThrow(() -> new RuntimeException("Authenticated user not found"));
     }
 }
-

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -1,73 +1,53 @@
 # Server Configuration
 server.port=8080
-# Trust reverse proxy headers (X-Forwarded-For, etc.) — required on Render for correct client IP
 server.forward-headers-strategy=NATIVE
-# Removed context-path - endpoints are already prefixed with /api in controllers
-# server.servlet.context-path=/api
 
-# Application Name
 spring.application.name=nyaysetu-backend
 
-# ============================================
-# STARTUP OPTIMIZATION (Render Cold Start Fix)
-# ============================================
-# Delay bean creation until first needed — cuts boot time significantly
-spring.main.lazy-initialization=true
+# Lazy init disabled — config errors (missing env vars, DB) now fail at startup, not first request
+spring.main.lazy-initialization=false
 
-# Database Configuration (Local/Development)
+# Database Configuration
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/nyaysetu}
 spring.datasource.username=${DB_USERNAME:postgres}
 spring.datasource.password=${DB_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# PgBouncer Compatibility (Supabase Transaction Pooler)
-# Disables driver-side prepared statements to prevent "prepared statement already exists" errors
 spring.datasource.hikari.data-source-properties.prepareThreshold=0
 spring.datasource.hikari.data-source-properties.binaryTransfer=false
 spring.datasource.hikari.data-source-properties.cancelSignalTimeout=0
 spring.datasource.hikari.data-source-properties.tcpKeepAlive=true
 
-# JPA Configuration
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=${SHOW_SQL:false}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 
-
-# Flyway Migration - Production Ready
+# Flyway — validation re-enabled to catch schema drift between environments
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
-spring.flyway.validate-on-migrate=false
-spring.flyway.ignore-missing-migrations=true
-# Use a separate connection for Flyway (Direct Connection) to avoid Transaction Pooler issues
-# Defaults to normal datasource if not specified (e.g. locally)
-# spring.flyway.url=${FLYWAY_URL:${spring.datasource.url}}
-# spring.flyway.user=${FLYWAY_USER:${spring.datasource.username}}
-# spring.flyway.password=${FLYWAY_PASSWORD:${spring.datasource.password}}
+spring.flyway.validate-on-migrate=true
+spring.flyway.ignore-missing-migrations=false
 
 # JWT Configuration
-jwt.secret=${JWT_SECRET:nyaysetu-2024-secure-jwt-signing-key-minimum-256-bits-required}
+# SECURITY FIX(P0): No default value. App MUST fail to start if JWT_SECRET is unset.
+# A known default was committed in git history — any deployment without this env var
+# would accept JWTs signed with the public string, allowing full token forgery.
+# Generate a strong secret: openssl rand -hex 64
+jwt.secret=${JWT_SECRET}
 jwt.expiration=${JWT_EXPIRATION_MS:86400000}
 
-# CORS Configuration
-# Ensure no trailing slashes in your environment variables if possible, though Spring usually handles it
 cors.allowed.origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:4174,http://localhost:3000}
 
-# File Upload Configuration
 spring.servlet.multipart.enabled=true
+# SECURITY FIX: Reduced from 200MB — large uploads are a JVM heap DoS vector
+spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-request-size=20MB
 
-# Max upload size limit (200MB) chosen to balance performance and usability
-spring.servlet.multipart.max-file-size=200MB
-spring.servlet.multipart.max-request-size=200MB
-
-# Google Gemini AI Configuration (NOT USED - Using local fake AI instead)
-# gemini.api.key=${GEMINI_API_KEY:}
 gemini.model=gemini-1.5-flash
-
-# File Storage
+gemini.api.key=${GEMINI_API_KEY:}
 file.upload-dir=uploads
 
-# SMTP Configuration (for email verification)
 spring.mail.host=${SMTP_HOST:smtp.gmail.com}
 spring.mail.port=${SMTP_PORT:587}
 spring.mail.username=${SMTP_USERNAME:}
@@ -75,59 +55,35 @@ spring.mail.password=${SMTP_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
-# Frontend Configuration
 app.frontend.url=${FRONTEND_URL:http://localhost:5173}
 app.password-reset.token-validity=1800000
 
-# AI Service Configuration (Google Gemini)
-gemini.api.key=${GEMINI_API_KEY:}
-openai.api.key=${OPENAI_API_KEY:your-openai-api-key-here}
-
-# Ollama Configuration (Local AI)
+openai.api.key=${OPENAI_API_KEY:}
 ollama.base.url=${OLLAMA_BASE_URL:http://localhost:11434}
 ollama.model=${OLLAMA_MODEL:gemma3:1b}
 ai.provider=${AI_PROVIDER:ollama}
 
-# Actuator Configuration
-management.endpoints.web.exposure.include=health,info
-management.endpoint.health.show-details=always
+# Actuator — show-details=never prevents DB/disk info disclosure to unauthenticated callers
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
 
-# Logging
+# Logging — Production levels (DEBUG/TRACE on Security emits JWT tokens to logs)
 logging.level.com.nyaysetu=INFO
-# Debug Logging for Troubleshooting 404
-logging.level.org.springframework.web=DEBUG
-logging.level.org.springframework.security=DEBUG
-logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping=TRACE
+logging.level.org.springframework.web=WARN
+logging.level.org.springframework.security=WARN
 
-
-# ============================================
-# AZURE AI CONFIGURATION (Vakil-Friend System)
-# ============================================
-
-# Azure OpenAI Configuration for Chat-First Filing
-azure.openai.endpoint=${AZURE_OPENAI_ENDPOINT:https://uaenorth.api.cognitive.microsoft.com/}
+azure.openai.endpoint=${AZURE_OPENAI_ENDPOINT:}
 azure.openai.api.key=${AZURE_OPENAI_API_KEY:}
 azure.openai.deployment.name=${AZURE_OPENAI_DEPLOYMENT:nyay-gpt}
-
-# Azure Document Intelligence for Evidence Verification
 azure.document.intelligence.api.key=${AZURE_DOCUMENT_INTELLIGENCE_KEY:}
 azure.document.intelligence.endpoint=${AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT:}
 
-# Chat Session Configuration
 chat.session.timeout.minutes=30
 chat.max.messages.per.session=100
 
-# ============================================
-# GROQ AI CONFIGURATION (Free, Fast Llama API)
-# ============================================
-# Get your free API key at: https://console.groq.com
 groq.api.key=${GROQ_API_KEY:}
 groq.model=llama-3.1-8b-instant
 
-# ============================================
-# BHASHINI CONFIGURATION (National Language Translation Mission)
-# ============================================
-# API for IndicTrans2 and ASR
 bhashini.api.key=${BHASHINI_API_KEY:}
 bhashini.user.id=${BHASHINI_USER_ID:}
 bhashini.pipeline.id=${BHASHINI_PIPELINE_ID:}


### PR DESCRIPTION
## Security Hardening PR — P0 Critical Fixes

This PR addresses **5 critical (P0) security vulnerabilities** identified in a production-readiness audit. The system was **not safe for public deployment** in its prior state. Each fix is documented with the specific attack vector it closes.

---

### Fix 1 — `application.properties`: Remove hardcoded JWT secret

**Attack:** The JWT signing secret `nyaysetu-2024-secure-jwt-signing-key-minimum-256-bits-required` was committed to a public repository with a hardcoded default. Any attacker could forge a valid JWT for any user (including `JUDGE`, `ADMIN`) using this string.

**Fix:** `jwt.secret=${JWT_SECRET}` — no default value. The application will now **refuse to start** if `JWT_SECRET` is not set as an environment variable.

**Additional hardening in this file:**
- `spring.main.lazy-initialization=false` — config errors now surface at startup, not silently at first user request
- Upload limit reduced from 200MB → 20MB (DoS vector)
- Spring Security and Web logging downgraded from DEBUG/TRACE → WARN (JWT tokens were being written to logs)
- Actuator `health.show-details=never` (was `always` — exposed DB and disk state)
- Flyway `validate-on-migrate=true` re-enabled (was disabled — schema drift went undetected)

---

### Fix 2 — `SecurityConfig.java`: Replace `anyRequest().permitAll()` with role-based rules

**Attack:** Every API endpoint — FIR records, court documents, judge rulings, police investigations — was fully accessible without any authentication token. The JWT filter ran but its rejection was overridden by `permitAll()`.

**Fix:** Explicit authorization rules:
```
/api/auth/** + /actuator/health + /swagger-ui/** → public
/api/police/**                                   → POLICE or ADMIN only
/api/judge/**                                    → JUDGE or ADMIN only
everything else                                  → authenticated (valid JWT required)
```
`@EnableMethodSecurity` added to enable `@PreAuthorize` on individual methods for fine-grained control.

---

### Fix 3 — `AuthController.java`: Prevent role self-assignment + fix face endpoint auth

**Attack (Finding 23):** `register()` accepted `role` from the request body. Any caller could POST `{"role": "JUDGE"}` and receive a JUDGE-level JWT immediately.

**Fix:** `role` field from request body is **intentionally ignored**. All self-registrations are hardcoded to `Role.LITIGANT`.

**Attack (Finding 2):** `/face/enroll`, `/face/disable`, `/face/status` were unauthenticated and accepted `userId` from the request body/params. An attacker could enroll their own face as any judge's account, then log in as that judge.

**Fix:** All three endpoints now require a valid JWT. The `userId` is derived from `authentication.getName()` — callers cannot target other accounts.

**Attack (Finding 3):** `/forgot-password` returned different status codes and echoed the submitted email back, acting as a user enumeration oracle.

**Fix:** Always returns the same `200` response body regardless of whether the email is registered.

---

### Fix 4 — `DocumentManagementController.java`: Add ownership checks to all document endpoints

**Attack (Finding 4):** `/documents/{id}/download`, `/{id}`, `/{id}/analysis`, `/{id}/certificate` had no ownership check. Any authenticated user could access sealed legal evidence for any case by guessing or enumerating UUIDs.

**Fix:** All endpoints now call `isAuthorizedForDocument()` before serving data.

**Access policy:** document owner **OR** `JUDGE` **OR** `POLICE` **OR** `ADMIN`.

Internal exception messages are no longer forwarded to HTTP response bodies.

---

### Fix 5 — `FirController.java`: Enforce POLICE role on FIR operations + fix findAll() OOM

**Attack (Finding 6):** `getPendingFirs()` and `updateFirStatus()` had no role check. A litigant who filed an FIR could approve or reject it themselves, or deny it to force a case to be dropped.

**Fix:** Class-level `@PreAuthorize("hasAnyRole('POLICE', 'ADMIN')")` enforces this on every method in the controller (defence-in-depth on top of SecurityConfig path rules).

**DoS fix:** `getSummonsTasks()` called `caseRepository.findAll()` — loading the entire cases table into JVM heap and filtering in-memory. At scale this causes OOM crashes. Replaced with `caseRepository.findBySummonsStatus("IN_TRANSIT")`.

> **Note:** `CaseRepository` needs the method `List<CaseEntity> findBySummonsStatus(String status)` added (Spring Data JPA derives this automatically from the method name — no SQL required).

---

## ⚠️ Required Actions Before Merging

1. **Set `JWT_SECRET` environment variable** on Render/Railway/your platform before deploying. Generate with: `openssl rand -hex 64`
2. **Add `findBySummonsStatus` to `CaseRepository`** (Fix 5 depends on it)
3. **Verify `DocumentDto` has `getUploadedBy()`** returning the owner's `Long` user ID (Fix 4 depends on it)
4. **Rotate the old JWT secret** — it is in git history. All existing sessions will be invalidated once the new secret is deployed, which is the correct behavior.
