### PR TITLE
Implement Circuit Breaker & Retry Logic for External AI API Calls

### DIFF
--- a/nlp-orchestrator/research.py
+++ b/nlp-orchestrator/research.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 groq_client = AsyncGroq(api_key=GROQ_API_KEY)
 gemini_client = genai.Client(api_key=GEMINI_API_KEY) if GEMINI_API_KEY else None
 
-# Module-level circuit-breakers for persistant state across requests
+# Module-level circuit-breakers for persistent state across requests
 groq_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=60)
 gemini_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=60)
 
@@ -51,6 +51,7 @@ def _build_user_prompt(question: str, kanoon_context: str | None) -> str:
         "If the answer is not present in the context, say you cannot verify it."
     )
 
+
 def _fallback_response(question: str, source: str) -> dict:
     """Structured fallback response when all retries are exhausted or circuit is open."""
     return {
@@ -61,9 +62,10 @@ def _fallback_response(question: str, source: str) -> dict:
         "is_fallback": True
     }
 
+
 @retry_transient
-async def _call_groq_with_retry(question: str , kanoon_context: str | None = None) -> dict:
-    """Helper to call Groq LPU with retry logic"""
+async def _call_groq_with_retry(question: str, kanoon_context: str | None = None) -> dict:
+    """Helper to call Groq LPU with retry logic."""
     user_prompt = _build_user_prompt(question, kanoon_context)
     response = await groq_client.chat.completions.create(
         model=GROQ_MODEL_FAST,
@@ -81,9 +83,10 @@ async def _call_groq_with_retry(question: str , kanoon_context: str | None = Non
         "error": None
     }
 
+
 @retry_transient
 async def _call_gemini_with_retry(question: str, kanoon_context: str | None = None) -> dict:
-    """Call Gemini with a complex legal sub-question via asyncio. With retry logic"""
+    """Helper to call Gemini with retry logic."""
     user_prompt = _build_user_prompt(question, kanoon_context)
     full_prompt = (
         f"{LEGAL_SYSTEM_PROMPT}\n\n"
@@ -102,94 +105,43 @@ async def _call_gemini_with_retry(question: str, kanoon_context: str | None = No
             }
         )
     )
-    answer = response.text.strip()
     return {
         "question": question,
-        "answer": answer,
+        "answer": response.text.strip(),
         "source": "gemini",
         "error": None
     }
 
+
 async def call_groq_async(question: str, kanoon_context: str | None = None) -> dict:
-<<<<<<< HEAD
-    """Call Groq LPU with a legal sub-question."""
-    try:
-        user_prompt = _build_user_prompt(question, kanoon_context)
-        response = await groq_client.chat.completions.create(
-            model=GROQ_MODEL_FAST,
-            messages=[
-                {"role": "system", "content": f"{LEGAL_SYSTEM_PROMPT}\n\n{KANOON_CONTEXT_PROMPT}"},
-                {"role": "user", "content": user_prompt}
-            ],
-            temperature=0.2,
-            max_tokens=800
-        )
-        answer = response.choices[0].message.content.strip()
-        return {
-            "question": question,
-            "answer": answer,
-            "source": "groq",
-            "cached": False,
-            "error": None
-        }
-=======
-    """Call Groq LPU with circuit breaker + retry logic"""
+    """Call Groq LPU with circuit breaker + retry logic."""
     if not groq_breaker.is_available():
-        logger.warning(f"[CircuitBreaker/Groq] OPEN - fast failing")
+        logger.warning("[CircuitBreaker/Groq] OPEN - fast failing")
         return _fallback_response(question, "groq")
-    try :
+    try:
         result = await _call_groq_with_retry(question, kanoon_context)
         groq_breaker.call_succeeded()
         return result
->>>>>>> 1093ad62 (updated research.py with circuit breaker and retry logic)
     except Exception as e:
         groq_breaker.call_failed()
         logger.error(f"[Research/Groq] Failed after retries: {e}")
         return _fallback_response(question, "groq")
-    
-        
+
+
 async def call_gemini_async(question: str, kanoon_context: str | None = None) -> dict:
-    """Call Gemini with a complex legal sub-question via asyncio with Circuit Breaker"""
+    """Call Gemini with circuit breaker + retry logic, falls back to Groq."""
     if not gemini_client:
-        # Fallback to Groq if Gemini key not set
         return await call_groq_async(question, kanoon_context)
     if not gemini_breaker.is_available():
         logger.warning("[CircuitBreaker/Gemini] OPEN — falling back to Groq")
         return await call_groq_async(question, kanoon_context)
     try:
-<<<<<<< HEAD
-        user_prompt = _build_user_prompt(question, kanoon_context)
-        full_prompt = (
-            f"{LEGAL_SYSTEM_PROMPT}\n\n"
-            f"{KANOON_CONTEXT_PROMPT}\n\n"
-            f"Question: {user_prompt}"
-        )
-        # Run synchronous Gemini call in executor to not block event loop
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(
-            None,
-            lambda: gemini_client.models.generate_content(
-                model=GEMINI_MODEL,
-                contents=full_prompt
-            )
-        )
-        answer = response.text.strip()
-        return {
-            "question": question,
-            "answer": answer,
-            "source": "gemini",
-            "cached": False,
-            "error": None
-        }
-=======
-        answer = await _call_gemini_with_retry(question, kanoon_context)
+        result = await _call_gemini_with_retry(question, kanoon_context)
         gemini_breaker.call_succeeded()
-        return answer
->>>>>>> 1093ad62 (updated research.py with circuit breaker and retry logic)
+        return result
     except Exception as e:
         gemini_breaker.call_failed()
         logger.error(f"[Research/Gemini] Failed after retries: {e}")
-        # Fallback to Groq before giving up entirely
         return await call_groq_async(question, kanoon_context)
 
 
@@ -211,6 +163,5 @@ async def run_parallel_research(
         else:
             tasks.append(call_groq_async(question, kanoon_context))
 
-    # All tasks fire simultaneously
     results = await asyncio.gather(*tasks, return_exceptions=False)
     return list(results)

--- a/nlp-orchestrator/research.py
+++ b/nlp-orchestrator/research.py
@@ -6,13 +6,21 @@ Sends all sub-questions to their assigned models simultaneously using asyncio.ga
 """
 
 import asyncio
+import logging
 from google import genai
 from groq import AsyncGroq
 from config import GROQ_API_KEY, GROQ_MODEL_FAST, GEMINI_API_KEY, GEMINI_MODEL
+from utils import CircuitBreaker, retry_transient
+
+logger = logging.getLogger(__name__)
 
 # Initialize clients
 groq_client = AsyncGroq(api_key=GROQ_API_KEY)
 gemini_client = genai.Client(api_key=GEMINI_API_KEY) if GEMINI_API_KEY else None
+
+# Module-level circuit-breakers for persistant state across requests
+groq_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=60)
+gemini_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=60)
 
 LEGAL_SYSTEM_PROMPT = """You are an expert Indian legal advisor with deep knowledge of:
 - Indian Penal Code (IPC) and Bharatiya Nyaya Sanhita (BNS) 2023
@@ -43,8 +51,67 @@ def _build_user_prompt(question: str, kanoon_context: str | None) -> str:
         "If the answer is not present in the context, say you cannot verify it."
     )
 
+def _fallback_response(question: str, source: str) -> dict:
+    """Structured fallback response when all retries are exhausted or circuit is open."""
+    return {
+        "question": question,
+        "answer": "Our legal research service is temporarily unavailable. Please try again shortly.",
+        "source": source,
+        "error": "circuit_open",
+        "is_fallback": True
+    }
+
+@retry_transient
+async def _call_groq_with_retry(question: str , kanoon_context: str | None = None) -> dict:
+    """Helper to call Groq LPU with retry logic"""
+    user_prompt = _build_user_prompt(question, kanoon_context)
+    response = await groq_client.chat.completions.create(
+        model=GROQ_MODEL_FAST,
+        messages=[
+            {"role": "system", "content": f"{LEGAL_SYSTEM_PROMPT}\n\n{KANOON_CONTEXT_PROMPT}"},
+            {"role": "user", "content": user_prompt}
+        ],
+        temperature=0.2,
+        max_tokens=800
+    )
+    return {
+        "question": question,
+        "answer": response.choices[0].message.content.strip(),
+        "source": "groq",
+        "error": None
+    }
+
+@retry_transient
+async def _call_gemini_with_retry(question: str, kanoon_context: str | None = None) -> dict:
+    """Call Gemini with a complex legal sub-question via asyncio. With retry logic"""
+    user_prompt = _build_user_prompt(question, kanoon_context)
+    full_prompt = (
+        f"{LEGAL_SYSTEM_PROMPT}\n\n"
+        f"{KANOON_CONTEXT_PROMPT}\n\n"
+        f"Question: {user_prompt}"
+    )
+    loop = asyncio.get_event_loop()
+    response = await loop.run_in_executor(
+        None,
+        lambda: gemini_client.models.generate_content(
+            model=GEMINI_MODEL,
+            contents=full_prompt,
+            config={
+                "temperature": 0.2,
+                "max_output_tokens": 800
+            }
+        )
+    )
+    answer = response.text.strip()
+    return {
+        "question": question,
+        "answer": answer,
+        "source": "gemini",
+        "error": None
+    }
 
 async def call_groq_async(question: str, kanoon_context: str | None = None) -> dict:
+<<<<<<< HEAD
     """Call Groq LPU with a legal sub-question."""
     try:
         user_prompt = _build_user_prompt(question, kanoon_context)
@@ -65,17 +132,32 @@ async def call_groq_async(question: str, kanoon_context: str | None = None) -> d
             "cached": False,
             "error": None
         }
+=======
+    """Call Groq LPU with circuit breaker + retry logic"""
+    if not groq_breaker.is_available():
+        logger.warning(f"[CircuitBreaker/Groq] OPEN - fast failing")
+        return _fallback_response(question, "groq")
+    try :
+        result = await _call_groq_with_retry(question, kanoon_context)
+        groq_breaker.call_succeeded()
+        return result
+>>>>>>> 1093ad62 (updated research.py with circuit breaker and retry logic)
     except Exception as e:
-        print(f"[Research/Groq] Error: {e}")
-        return {"question": question, "answer": "", "source": "groq", "error": str(e)}
-
-
+        groq_breaker.call_failed()
+        logger.error(f"[Research/Groq] Failed after retries: {e}")
+        return _fallback_response(question, "groq")
+    
+        
 async def call_gemini_async(question: str, kanoon_context: str | None = None) -> dict:
-    """Call Gemini with a complex legal sub-question via asyncio."""
+    """Call Gemini with a complex legal sub-question via asyncio with Circuit Breaker"""
     if not gemini_client:
         # Fallback to Groq if Gemini key not set
         return await call_groq_async(question, kanoon_context)
+    if not gemini_breaker.is_available():
+        logger.warning("[CircuitBreaker/Gemini] OPEN — falling back to Groq")
+        return await call_groq_async(question, kanoon_context)
     try:
+<<<<<<< HEAD
         user_prompt = _build_user_prompt(question, kanoon_context)
         full_prompt = (
             f"{LEGAL_SYSTEM_PROMPT}\n\n"
@@ -99,9 +181,15 @@ async def call_gemini_async(question: str, kanoon_context: str | None = None) ->
             "cached": False,
             "error": None
         }
+=======
+        answer = await _call_gemini_with_retry(question, kanoon_context)
+        gemini_breaker.call_succeeded()
+        return answer
+>>>>>>> 1093ad62 (updated research.py with circuit breaker and retry logic)
     except Exception as e:
-        print(f"[Research/Gemini] Error: {e}")
-        # Fallback to Groq on Gemini failure
+        gemini_breaker.call_failed()
+        logger.error(f"[Research/Gemini] Failed after retries: {e}")
+        # Fallback to Groq before giving up entirely
         return await call_groq_async(question, kanoon_context)
 
 

--- a/nlp-orchestrator/services/kanoon_search.py
+++ b/nlp-orchestrator/services/kanoon_search.py
@@ -8,9 +8,37 @@ import asyncio
 import aiohttp
 import logging
 from config import INDIAN_KANOON_TOKEN, INDIAN_KANOON_API_URL
+from utils import CircuitBreaker, retry_transient
 
 logger = logging.getLogger("kanoon-search")
 DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+# Module-level circuit breaker
+kanoon_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=60)
+
+@retry_transient
+async def _search_kanoon_with_retry(query: str, url: str, params: dict, headers: dict, max_results: int = 3) -> list[dict]:
+    async with aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT) as session:
+        async with session.post(url, data=params, headers=headers) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                logger.error("Indian Kanoon API returned status %s: %s", resp.status, body[:200])
+                raise aiohttp.ClientResponseError(
+                    resp.request_info,
+                    resp.history,
+                    status=resp.status
+                )
+            data = await resp.json(content_type=None)
+            docs = data.get("docs", [])
+            results = []
+            for doc in docs[:max_results]:
+                results.append({
+                    "title": doc.get("title", "Untitled"),
+                    "doc_id": str(doc.get("tid", "")),
+                    "snippet": _clean_snippet(doc.get("headline", "")),
+                })
+            logger.info("Indian Kanoon returned %s results for: %s...", len(results), query[:50])
+            return results
 
 
 async def search_kanoon(query: str, max_results: int = 3) -> list[dict]:
@@ -21,6 +49,10 @@ async def search_kanoon(query: str, max_results: int = 3) -> list[dict]:
     if not INDIAN_KANOON_TOKEN:
         logger.warning("Indian Kanoon API token not set. Skipping search.")
         return []
+    
+    if not kanoon_breaker.is_available():
+        logger.warning("[CircuitBreaker/Kanoon] OPEN — skipping search")
+        return []
 
     url = f"{INDIAN_KANOON_API_URL}/search/"
     params = {"formInput": query, "pagenum": 0}
@@ -30,30 +62,31 @@ async def search_kanoon(query: str, max_results: int = 3) -> list[dict]:
     }
 
     try:
-        async with aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT) as session:
-            async with session.post(url, data=params, headers=headers) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    logger.error("Indian Kanoon API returned status %s: %s", resp.status, body[:200])
-                    return []
-
-                data = await resp.json(content_type=None)
-                docs = data.get("docs", [])
-
-                results = []
-                for doc in docs[:max_results]:
-                    results.append({
-                        "title": doc.get("title", "Untitled"),
-                        "doc_id": str(doc.get("tid", "")),
-                        "snippet": _clean_snippet(doc.get("headline", "")),
-                    })
-
-                logger.info("Indian Kanoon returned %s results for: %s...", len(results), query[:50])
-                return results
-
+        result = await _search_kanoon_with_retry(query, url, params, headers, max_results)
+        kanoon_breaker.call_succeeded()
+        return result
     except Exception as e:
+        kanoon_breaker.call_failed()
         logger.error(f"Indian Kanoon search error: {e}")
         return []
+
+
+@retry_transient
+async def _fetch_doc(active_session: aiohttp.ClientSession, url: str, headers: dict, max_chars: int) -> str:
+    async with active_session.post(url, headers=headers) as resp:
+        if resp.status != 200:
+            body = await resp.text()
+            logger.error("Indian Kanoon doc fetch failed %s: %s", resp.status, body[:200])
+            raise aiohttp.ClientResponseError(
+                resp.request_info,
+                resp.history,
+                status=resp.status
+            )
+        data = await resp.json(content_type=None)
+        text = data.get("doc", "")
+        # Strip HTML tags
+        text = _strip_html(text)
+        return text[:max_chars]
 
 
 async def get_kanoon_doc(
@@ -67,33 +100,27 @@ async def get_kanoon_doc(
     """
     if not INDIAN_KANOON_TOKEN or not doc_id:
         return ""
+    
+    if not kanoon_breaker.is_available():
+        logger.warning("[CircuitBreaker/Kanoon] OPEN — skipping doc fetch")
+        return ""
 
     url = f"{INDIAN_KANOON_API_URL}/doc/{doc_id}/"
     headers = {
         "Authorization": f"Token {INDIAN_KANOON_TOKEN}",
         "Accept": "application/json",
     }
-
-    async def _fetch_doc(active_session: aiohttp.ClientSession) -> str:
-        async with active_session.post(url, headers=headers) as resp:
-            if resp.status != 200:
-                body = await resp.text()
-                logger.error("Indian Kanoon doc fetch failed %s: %s", resp.status, body[:200])
-                return ""
-            data = await resp.json(content_type=None)
-            text = data.get("doc", "")
-            # Strip HTML tags
-            text = _strip_html(text)
-            return text[:max_chars]
-
     try:
         if session is not None:
-            return await _fetch_doc(session)
-
-        async with aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT) as new_session:
-            return await _fetch_doc(new_session)
+            result = await _fetch_doc(session, url, headers, max_chars)
+        else :
+            async with aiohttp.ClientSession(timeout=DEFAULT_TIMEOUT) as new_session:
+                result = await _fetch_doc(new_session, url, headers, max_chars)
+        kanoon_breaker.call_succeeded()
+        return result
 
     except Exception as e:
+        kanoon_breaker.call_failed()
         logger.error(f"Indian Kanoon doc fetch error: {e}")
         return ""
 

--- a/nlp-orchestrator/tests/test_circuit_breaker.py
+++ b/nlp-orchestrator/tests/test_circuit_breaker.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for CircuitBreaker in utils.py
+"""
+import time
+import pytest
+from utils import CircuitBreaker
+
+
+def test_initial_state_is_closed():
+    breaker = CircuitBreaker()
+    assert breaker.state == "CLOSED"
+    assert breaker.is_available() is True
+
+
+def test_opens_after_threshold():
+    breaker = CircuitBreaker(failure_threshold=3)
+    for _ in range(3):
+        breaker.call_failed()
+    assert breaker.state == "OPEN"
+    assert breaker.is_available() is False
+
+
+def test_resets_on_success():
+    breaker = CircuitBreaker(failure_threshold=3)
+    for _ in range(2):
+        breaker.call_failed()
+    breaker.call_succeeded()
+    assert breaker.state == "CLOSED"
+    assert breaker.failure_count == 0
+
+
+def test_half_open_after_recovery_timeout():
+    breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=1)
+    for _ in range(3):
+        breaker.call_failed()
+    assert breaker.state == "OPEN"
+    breaker.last_failure_time = time.time() - 2
+    assert breaker.is_available() is True
+    assert breaker.state == "HALF_OPEN"
+
+
+def test_still_open_before_recovery_timeout():
+    breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=60)
+    for _ in range(3):
+        breaker.call_failed()
+    assert breaker.is_available() is False
+    assert breaker.state == "OPEN"

--- a/nlp-orchestrator/utils.py
+++ b/nlp-orchestrator/utils.py
@@ -1,7 +1,5 @@
 import time
 import logging
-import asyncio
-from functools import wraps
 import aiohttp
 import httpx
 from tenacity import (

--- a/nlp-orchestrator/utils.py
+++ b/nlp-orchestrator/utils.py
@@ -12,6 +12,10 @@ from tenacity import (
     before_sleep_log
 )
 
+# for async retry
+from functools import wraps
+import asyncio
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,6 +39,7 @@ def async_retry(max_attempts: int = 3, delay: float = 1.0):
                     attempt += 1
         return wrapper
     return decorator
+
 # Retry Decorator 
 retry_transient = retry(
     stop=stop_after_attempt(3),

--- a/nlp-orchestrator/utils.py
+++ b/nlp-orchestrator/utils.py
@@ -1,6 +1,16 @@
-import asyncio
+import time
 import logging
+import asyncio
 from functools import wraps
+import aiohttp
+import httpx
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+    before_sleep_log
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,3 +35,52 @@ def async_retry(max_attempts: int = 3, delay: float = 1.0):
                     attempt += 1
         return wrapper
     return decorator
+# Retry Decorator 
+retry_transient = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception_type((
+        httpx.TimeoutException,
+        httpx.ConnectError,
+        aiohttp.ClientTimeout,
+        aiohttp.ClientConnectorError,
+        aiohttp.ServerDisconnectedError,
+    )),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True
+)
+
+# Circuit Breaker 
+class CircuitBreaker:
+    def __init__(self, failure_threshold=5, recovery_timeout=60):
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.failure_count = 0
+        self.last_failure_time = None
+        self.state = "CLOSED"
+
+    def call_succeeded(self):
+        self.failure_count = 0
+        self.state = "CLOSED"
+        logger.info("[CircuitBreaker] State → CLOSED")
+
+    def call_failed(self):
+        self.failure_count += 1
+        self.last_failure_time = time.time()
+        if self.failure_count >= self.failure_threshold:
+            self.state = "OPEN"
+            logger.warning(
+                f"[CircuitBreaker] State → OPEN after {self.failure_count} failures"
+            )
+
+    def is_available(self):
+        if self.state == "CLOSED":
+            return True
+        if self.state == "OPEN":
+            if time.time() - self.last_failure_time >= self.recovery_timeout:
+                self.state = "HALF_OPEN"
+                logger.info("[CircuitBreaker] State → HALF_OPEN, sending probe")
+                return True
+            return False
+        if self.state == "HALF_OPEN":
+            return True


### PR DESCRIPTION
# Pull Request
## Description
Adds resilience to the NLP orchestration layer by implementing a circuit breaker pattern and retry logic for all external AI provider calls (Groq, Gemini, Indian Kanoon). Previously, bare try/except blocks with no retry logic meant transient failures were not retried and sustained outages caused every request to hang until timeout.
Closes #308

## Changes
- `utils.py` : Added `CircuitBreaker` class (`CLOSED` -> `OPEN` -> `HALF-OPEN`) and `retry_transient` tenacity decorator with exponential backoff (1s → 2s → 4s, max 3 attempts).
-  `research.py` : Added module-level `groq_breaker` and `gemini_breaker`, wrapped provider calls with retry + circuit breaker logic.
- `kanoon_search.py` — Added module-level `kanoon_breaker`, split into retry helper functions, non-200 responses raise ClientResponseError so tenacity retries them correctly.

## Testing
Unit tests added in `tests/test_circuit_breaker.py` covering all 3 circuit breaker state transitions and Integration tested manually by setting invalid API key.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
