### PR TITLE
security: add fail-fast startup JWT secret validation for production

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -2,7 +2,12 @@ package com.nyaysetu.backend.config;
 
 import com.nyaysetu.backend.filter.JwtAuthFilter;
 import com.nyaysetu.backend.filter.RateLimitFilter;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,11 +26,39 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
+    private static final String DEFAULT_JWT_SECRET = "nyaysetu-2024-secure-jwt-signing-key-minimum-256-bits-required";
+
     private final UserDetailsService userDetailsService;
     private final RateLimitFilter rateLimitFilter;
+    private final Environment environment;
 
-    @org.springframework.beans.factory.annotation.Value("${cors.allowed.origins}")
+    @Value("${cors.allowed.origins}")
     private String allowedOrigins;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @PostConstruct
+    public void validateJwtSecretConfiguration() {
+        boolean isProd = java.util.Arrays.stream(environment.getActiveProfiles())
+                .anyMatch("prod"::equalsIgnoreCase);
+        boolean isDev = java.util.Arrays.stream(environment.getActiveProfiles())
+                .anyMatch("dev"::equalsIgnoreCase);
+        String jwtSecretEnv = System.getenv("JWT_SECRET");
+        boolean isJwtSecretEnvMissing = jwtSecretEnv == null || jwtSecretEnv.trim().isEmpty();
+        boolean isUsingDefaultSecret = DEFAULT_JWT_SECRET.equals(jwtSecret);
+
+        if (isProd && (isJwtSecretEnvMissing || isUsingDefaultSecret)) {
+            throw new IllegalStateException(
+                    "Security configuration error: JWT_SECRET environment variable is required in production. "
+                            + "Application startup is blocked to prevent using an insecure default JWT signing key.");
+        }
+
+        if (isDev && isUsingDefaultSecret) {
+            logger.warn("JWT secret is using the default fallback value. Set JWT_SECRET in your environment for safer development setup.");
+        }
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -59,6 +59,8 @@ FRONTEND_URL=http://localhost:5173
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost
 ```
 
+> **Production requirement:** When running with `SPRING_PROFILES_ACTIVE=prod`, you **must** set `JWT_SECRET` as an environment variable. The backend now fails fast at startup in production if `JWT_SECRET` is missing or falls back to the default development secret.
+
 <hr/>
 
 ## Option A: Docker Deployment (Recommended)


### PR DESCRIPTION
## Description

Added fail-fast startup validation for JWT secret configuration in production.

### Changes made

* Added `@PostConstruct` validation in `SecurityConfig.java`
* In `prod` profile, app now fails fast if `JWT_SECRET` is missing or fallback secret is used
* In `dev` profile, app logs a warning when fallback secret is used
* Updated `docs/setup.md` to document `JWT_SECRET` as required in production

Fixes #195

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
