### PR TITLE
fix: replace inline HTML on /unauthorized route with proper page component

### DIFF
--- a/frontend/nyaysetu-frontend/src/App.jsx
+++ b/frontend/nyaysetu-frontend/src/App.jsx
@@ -22,6 +22,7 @@ const About = lazy(() => import('./pages/About'));
 const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
 const Terms = lazy(() => import('./pages/Terms'));
 const Disclaimer = lazy(() => import('./pages/Disclaimer'));
+const Unauthorized = lazy(() => import('./pages/Unauthorized'));
 
 // Dashboard Layout
 const DashboardLayout = lazy(() => import('./layouts/DashboardLayout'));
@@ -218,12 +219,7 @@ function App({ swRegistration }) {
                                     <Route path="profile" element={<ProfilePage />} />
                                 </Route>
 
-                                <Route path="/unauthorized" element={
-                                    <div style={{ textAlign: 'center', padding: '3rem' }}>
-                                        <h1>Unauthorized</h1>
-                                        <p>You don't have permission to access this page.</p>
-                                    </div>
-                                } />
+                                <Route path="/unauthorized" element={<Unauthorized />} />
                             </Routes>
                         </Suspense>
                     </BrowserRouter>

--- a/frontend/nyaysetu-frontend/src/pages/Unauthorized.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/Unauthorized.jsx
@@ -1,0 +1,141 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { ShieldAlert, Home, ArrowLeft } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useLanguage } from '../contexts/LanguageContext.jsx';
+
+// Self-contained translations so this page has i18n support without
+// touching the shared LanguageContext translations table.
+const STRINGS = {
+    en: {
+        title: 'Unauthorized',
+        message: "You don't have permission to access this page.",
+        backHome: 'Back to Home',
+        goBack: 'Go Back'
+    },
+    hi: {
+        title: 'अनधिकृत',
+        message: 'आपके पास इस पृष्ठ तक पहुंचने की अनुमति नहीं है।',
+        backHome: 'होम पर वापस जाएं',
+        goBack: 'वापस जाएं'
+    }
+};
+
+export default function Unauthorized() {
+    const navigate = useNavigate();
+    const { language } = useLanguage();
+    const t = STRINGS[language] || STRINGS.en;
+
+    const buttonBase = {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.75rem 1.5rem',
+        borderRadius: '0.75rem',
+        fontWeight: '600',
+        fontSize: '0.95rem',
+        cursor: 'pointer',
+        textDecoration: 'none',
+        transition: 'all 0.2s ease',
+        border: '1px solid var(--border-light)'
+    };
+
+    return (
+        <div style={{
+            minHeight: '100vh',
+            background: 'var(--bg-main)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '2rem'
+        }}>
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+                style={{
+                    maxWidth: '480px',
+                    width: '100%',
+                    textAlign: 'center',
+                    background: 'var(--bg-surface)',
+                    border: '1px solid var(--border-light)',
+                    borderRadius: '1.5rem',
+                    padding: '3rem 2rem',
+                    boxShadow: 'var(--shadow-glass)'
+                }}
+            >
+                <div style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '72px',
+                    height: '72px',
+                    background: 'linear-gradient(135deg, #3F5DCC, #7C5CFF)',
+                    borderRadius: '18px',
+                    marginBottom: '1.5rem'
+                }}>
+                    <ShieldAlert size={36} color="white" />
+                </div>
+
+                <h1 style={{
+                    fontSize: 'clamp(1.75rem, 4vw, 2.5rem)',
+                    fontWeight: '800',
+                    color: 'var(--color-primary)',
+                    marginBottom: '0.75rem',
+                    letterSpacing: '-0.02em'
+                }}>
+                    {t.title}
+                </h1>
+
+                <p style={{
+                    color: 'var(--text-secondary)',
+                    fontSize: '1.05rem',
+                    lineHeight: '1.7',
+                    marginBottom: '2rem'
+                }}>
+                    {t.message}
+                </p>
+
+                <div style={{
+                    display: 'flex',
+                    gap: '1rem',
+                    justifyContent: 'center',
+                    flexWrap: 'wrap'
+                }}>
+                    <Link
+                        to="/"
+                        onMouseEnter={e => { e.currentTarget.style.opacity = '0.85'; }}
+                        onMouseLeave={e => { e.currentTarget.style.opacity = '1'; }}
+                        style={{
+                            ...buttonBase,
+                            background: 'linear-gradient(135deg, #3F5DCC, #7C5CFF)',
+                            color: 'white',
+                            border: 'none'
+                        }}
+                    >
+                        <Home size={18} />
+                        {t.backHome}
+                    </Link>
+
+                    <button
+                        type="button"
+                        onClick={() => navigate(-1)}
+                        onMouseEnter={e => {
+                            e.currentTarget.style.borderColor = 'rgba(63,93,204,0.4)';
+                        }}
+                        onMouseLeave={e => {
+                            e.currentTarget.style.borderColor = 'var(--border-light)';
+                        }}
+                        style={{
+                            ...buttonBase,
+                            background: 'transparent',
+                            color: 'var(--color-secondary)'
+                        }}
+                    >
+                        <ArrowLeft size={18} />
+                        {t.goBack}
+                    </button>
+                </div>
+            </motion.div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Description

The `/unauthorized` route in `App.jsx` rendered inline JSX (`<div><h1>...`)
instead of a dedicated, reusable page component. This replaces it with a
proper `Unauthorized` page that matches the app's design system.

Closes #283

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- **Added** `src/pages/Unauthorized.jsx` — a reusable page component:
  - **Consistent UI**: uses the project's theme CSS variables
    (`--bg-main`, `--color-primary`, `--shadow-glass`, …), a card layout,
    `framer-motion` entrance animation, and a `lucide-react` icon —
    matching `Disclaimer.jsx` / `Terms.jsx`.
  - **Navigation**: "Back to Home" link (`/`) and a "Go Back" button
    (`navigate(-1)`).
  - **i18n support**: renders English/Hindi based on the existing
    `useLanguage()` context, so it follows the app-wide language toggle.
- **Updated** `src/App.jsx`:
  - Lazy-imported the new component.
  - Replaced the 6 lines of inline JSX with `<Route path="/unauthorized"
    element={<Unauthorized />} />`.

Scope: only `App.jsx` was modified among existing files (per the issue).
i18n strings are kept inside the new component so the shared
`LanguageContext.jsx` is left untouched.

## How to test

1. Log in as any role (e.g. `LITIGANT`).
2. Manually visit a route for a different role (e.g. `/admin`) — you are
   redirected to `/unauthorized`.
3. Verify the styled page renders with both navigation buttons working.
4. Toggle the language and confirm the text switches between English/Hindi.

## Screenshots

<img width="638" height="314" alt="Screenshot 2026-05-19 024035" src="https://github.com/user-attachments/assets/40d5875e-ef8a-44ca-b965-e4bb1c503954" />

