### PR TITLE
Fix bookmark icon visibility on Constitution page - Issue #488

### DIFF
--- a/frontend/nyaysetu-frontend/src/pages/Constitution.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/Constitution.jsx
@@ -555,7 +555,7 @@ export default function Constitution() {
                                                     background: bookmarks.find(b => b.number === selectedArticle.number) ? 'var(--color-primary)' : '#F1F5F9',
                                                     border: '1px solid #E2E8F0',
                                                     borderRadius: '0.75rem',
-                                                    color: 'white',
+                                                    color: bookmarks.find(b => b.number === selectedArticle.number) ? 'white' : 'var(--color-primary)',
                                                     cursor: 'pointer',
                                                     transition: 'all 0.3s'
                                                 }}


### PR DESCRIPTION
PR Description
This PR fixes the bookmark action icon on the Constitution page so it remains visible against the button background. The issue was caused by the button text color staying white even when the bookmark button used a light background state.

What changed
The bookmark button color now switches based on bookmark state, which keeps the icon readable in both the bookmarked and unbookmarked states.

Validation
npm test passed

Issue
Closes #488 
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/19c617a9-ce5e-45aa-87a8-0ec249a84e87" />
