### PR TITLE
chore: Link frontend to deployed NLP Orchestrator on Render

### DIFF
--- a/frontend/nyaysetu-frontend/.env.production
+++ b/frontend/nyaysetu-frontend/.env.production
@@ -1,0 +1,2 @@
+VITE_API_URL=https://nyaysetu-backend.onrender.com
+VITE_NLP_BASE_URL=https://nyay-setu-nlp.onrender.com


### PR DESCRIPTION
## Overview
This PR connects the React frontend to the newly deployed NLP Orchestrator hosted on Render. 

## Changes Made
- Added a `.env.production` file to the frontend directory containing `VITE_NLP_BASE_URL=https://nyay-setu-nlp.onrender.com`.
- This ensures that when the frontend is built and deployed for production, the Vakil Friend AI Chat will route traffic to the live Render server instead of looking for `localhost:8001`.

## Required Manual Action ⚠️
To ensure Vercel properly injects this URL at build time, please complete the following steps in the Vercel dashboard after merging:
1. Go to your **Nyay-Setu Vercel Dashboard**.
2. Navigate to **Settings** → **Environment Variables**.
3. Add a new variable:
   - **Key**: `VITE_NLP_BASE_URL`
   - **Value**: `https://nyay-setu-nlp.onrender.com`
4. Trigger a new deployment.