### PR TITLE
fix(security): restrict default logging level, closes #424

### DIFF
--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -95,9 +95,9 @@ management.endpoint.health.show-details=always
 # Logging
 logging.level.com.nyaysetu=INFO
 # Debug Logging for Troubleshooting 404
-logging.level.org.springframework.web=DEBUG
-logging.level.org.springframework.security=DEBUG
-logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping=TRACE
+# logging.level.org.springframework.web=DEBUG
+# logging.level.org.springframework.security=DEBUG
+# logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping=TRACE
 
 
 # ============================================


### PR DESCRIPTION
#424 Pull Request

## Description

Restricts backend logging to INFO level by default for production safety. Removes all DEBUG and TRACE level logging from the Spring Boot backend configuration so that sensitive application internals are not exposed in default backend logs.
Closes #424.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<img width="918" height="682" alt="Screenshot 2026-05-22 150006" src="https://github.com/user-attachments/assets/fb186c25-85b7-42d2-8ab6-d20542ff459a" />