### PR TITLE
fix: Gracefully handle missing ML dependencies in NLP tests

### DIFF
--- a/nlp-orchestrator/main.py
+++ b/nlp-orchestrator/main.py
@@ -34,8 +34,7 @@ from synthesizer import synthesize_answers
 from validators.citation_validator import validate_citations_from_text
 from avatar_speech import get_interim_messages, convert_to_hinglish, detect_domain
 from services.kanoon_search import build_kanoon_context
-# from routers.forensics import router as forensics_router
-# from routers.modi_ocr import router as modi_ocr_router
+
 
 # Initialize clients for deep research pipeline
 from groq import AsyncGroq
@@ -77,8 +76,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# app.include_router(forensics_router)
-# app.include_router(modi_ocr_router)
+try:
+    from routers.forensics import router as forensics_router
+    app.include_router(forensics_router)
+    logger.info("Loaded forensics router.")
+except ImportError:
+    logger.warning("Skipping forensics router due to missing dependencies.")
+
+try:
+    from routers.modi_ocr import router as modi_ocr_router
+    app.include_router(modi_ocr_router)
+    logger.info("Loaded modi_ocr router.")
+except ImportError:
+    logger.warning("Skipping modi_ocr router due to missing dependencies.")
 
 
 # ─── Models ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Overview
This PR resolves the GitHub Actions pipeline failure (`ModuleNotFoundError: No module named 'cv2'`) that occurred during `nlp-tests`.

## Root Cause
When `test_health.py` and `test_pipeline.py` import `app` from `main.py`, the entire `main.py` file is evaluated. Because we recently removed heavy ML dependencies (`opencv-python-headless`, `torch`) to comply with Render's 512MB RAM limits, the `main.py` file crashed when trying to import `routers.forensics` and `routers.modi_ocr`.

## The Fix
Instead of permanently commenting out the routers (which breaks local development for anyone who *does* have the ML dependencies installed), this PR wraps the imports in `try/except ImportError` blocks.

If the dependencies are present, the routers are loaded. If they are missing (e.g. in GitHub Actions or Render), the app logs a warning and gracefully skips them, allowing tests to pass and the core app to start successfully.