### PR TITLE
fix: query real document count in CaseManagementService (#525)

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/DocumentRepository.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/DocumentRepository.java
@@ -10,5 +10,6 @@ import java.util.UUID;
 @Repository
 public interface DocumentRepository extends JpaRepository<DocumentEntity, UUID> {
     List<DocumentEntity> findByCaseId(UUID caseId);
+    long countByCaseId(UUID caseId);
     List<DocumentEntity> findByCategoryAndDescriptionContaining(String category, String description);
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
@@ -6,6 +6,7 @@ import com.nyaysetu.backend.dto.CreateCaseRequest;
 import com.nyaysetu.backend.entity.CaseEntity;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.repository.CaseRepository;
+import com.nyaysetu.backend.repository.DocumentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +30,7 @@ public class CaseManagementService {
     private final HearingRepository hearingRepository;
     private final com.nyaysetu.backend.notification.service.NotificationService notificationService;
     private final com.nyaysetu.backend.service.CaseTimelineService timelineService;
+    private final DocumentRepository documentRepository;
 
     @Transactional
     public CaseDTO createCase(CreateCaseRequest request, User client) {
@@ -254,7 +256,7 @@ public class CaseManagementService {
                 .assignedJudge(entity.getAssignedJudge())
                 .clientId(entity.getClient() != null ? entity.getClient().getId() : null)
                 .clientName(entity.getClient() != null ? entity.getClient().getName() : null)
-                .documentsCount(0) // TODO: Count from documents table
+                .documentsCount((int) documentRepository.countByCaseId(entity.getId()))
                 .lawyerProposalStatus(entity.getLawyerProposalStatus())
                 .draftPetition(entity.getDraftPetition())
                 .lawyerId(entity.getLawyer() != null ? entity.getLawyer().getId() : null)


### PR DESCRIPTION
## 🛠️ Related Issue
Closes: #525

## 📌 Description
This PR resolves an issue where the document count returned inside the `CaseDTO` was hardcoded to a static value of zero. As a result, litigant, lawyer, and judge dashboards always displayed a total of `0` documents, even after files or evidence were successfully uploaded to the Forensic Evidence Vault for a specific case.

We now dynamically calculate and return the true number of documents linked to the case ID from the database.

## ✨ Changes Made
- Added `long countByCaseId(UUID caseId);` query method to `com.nyaysetu.backend.repository.DocumentRepository` to query document totals directly from the database.
- Injected `DocumentRepository` into `com.nyaysetu.backend.service.CaseManagementService`.
- Updated the conversion helper method `convertToDTO(CaseEntity entity)` in `CaseManagementService` to map the actual document count using `(int) documentRepository.countByCaseId(entity.getId())` instead of the hardcoded `0` value.

## 🧪 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Documentation update

## ✔️ Checklist
- [x] My code follows project style guidelines
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] No unnecessary files are included