### PR TITLE
cache legal sections JSON with lru_cache to avoid repeated disk I/O

### DIFF
--- a/nlp-orchestrator/validators/citation_validator.py
+++ b/nlp-orchestrator/validators/citation_validator.py
@@ -2,12 +2,15 @@ import json
 import re
 from pathlib import Path
 from typing import Any
+from functools import lru_cache
+
 
 from legal_utils.citation_extractor import extract_legal_citations
 
 DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "legal_sections.json"
 
 
+@lru_cache(maxsize=1)  
 def _load_legal_sections() -> dict[str, Any]:
     with open(DATA_PATH, "r", encoding="utf-8") as handle:
         return json.load(handle)


### PR DESCRIPTION
## Description
Closes #580 

Wrapped `_load_legal_sections()` with `@lru_cache(maxsize=1)` so the JSON file 
is read from disk only once per process instead of on every `validate_citation()` 
call.

Changes:
- Added `from functools import lru_cache` import
- Added `@lru_cache(maxsize=1)` decorator to `_load_legal_sections()`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes