### PR TITLE
Fix accidental mobile sidebar collapse behavior

### DIFF
--- a/frontend/nyaysetu-frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/nyaysetu-frontend/src/layouts/DashboardLayout.jsx
@@ -55,7 +55,8 @@ export default function DashboardLayout() {
     };
 
     const handleMobileClose = () => {
-        setIsMobileSidebarOpen(false);
+        // Sidebar should close only using toggle button
+        return;
     };
 
     return (


### PR DESCRIPTION
# Pull Request

## Description

Fixes the mobile sidebar behavior where clicking outside the sidebar unintentionally collapsed it.

### Changes made
- Prevented automatic sidebar closing on outside click
- Sidebar now closes only through the explicit toggle button
- Improved mobile navigation usability and accessibility
- Preserved intentional user interaction behavior

Closes #592

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings