### PR TITLE
Fix direct document-by-ID access control bypass

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
@@ -102,8 +102,11 @@ public class DocumentManagementController {
      * Trigger AI analysis for a document
      */
     @PostMapping("/{id}/analyze")
-    public ResponseEntity<?> analyzeDocument(@PathVariable UUID id) {
+    public ResponseEntity<?> analyzeDocument(@PathVariable UUID id, Authentication authentication) {
         try {
+            User user = authService.findByEmail(authentication.getName());
+            documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
             // Trigger async analysis
             documentManagementService.triggerAnalysis(id);
             return ResponseEntity.ok(Map.of(
@@ -119,8 +122,11 @@ public class DocumentManagementController {
      * Get AI analysis for a document
      */
     @GetMapping("/{id}/analysis")
-    public ResponseEntity<?> getDocumentAnalysis(@PathVariable UUID id) {
+    public ResponseEntity<?> getDocumentAnalysis(@PathVariable UUID id, Authentication authentication) {
         try {
+            User user = authService.findByEmail(authentication.getName());
+            documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
             if (!documentAnalysisService.hasAnalysis(id)) {
                 return ResponseEntity.status(404).body(Map.of("error", "Analysis not found"));
             }
@@ -138,8 +144,11 @@ public class DocumentManagementController {
      * Check if document has analysis
      */
     @GetMapping("/{id}/has-analysis")
-    public ResponseEntity<?> checkAnalysis(@PathVariable UUID id) {
+    public ResponseEntity<?> checkAnalysis(@PathVariable UUID id, Authentication authentication) {
         try {
+            User user = authService.findByEmail(authentication.getName());
+            documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
             boolean hasAnalysis = documentAnalysisService.hasAnalysis(id);
             return ResponseEntity.ok(Map.of(
                 "documentId", id.toString(),
@@ -192,14 +201,20 @@ public class DocumentManagementController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<DocumentDto> getDocument(@PathVariable UUID id) {
+    public ResponseEntity<DocumentDto> getDocument(@PathVariable UUID id, Authentication authentication) {
+        User user = authService.findByEmail(authentication.getName());
+        documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
         DocumentDto document = documentManagementService.getDocumentById(id);
         return ResponseEntity.ok(document);
     }
 
     @GetMapping("/{id}/download")
-    public ResponseEntity<?> downloadDocument(@PathVariable UUID id) {
+    public ResponseEntity<?> downloadDocument(@PathVariable UUID id, Authentication authentication) {
         try {
+            User user = authService.findByEmail(authentication.getName());
+            documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
             DocumentDto metadata = documentManagementService.getDocumentById(id);
             Resource resource = documentManagementService.downloadDocument(id);
 
@@ -232,8 +247,11 @@ public class DocumentManagementController {
      * Download Section 63(4) Evidence Certificate for a document
      */
     @GetMapping("/{id}/certificate")
-    public ResponseEntity<?> downloadCertificate(@PathVariable UUID id) {
+    public ResponseEntity<?> downloadCertificate(@PathVariable UUID id, Authentication authentication) {
         try {
+            User user = authService.findByEmail(authentication.getName());
+            documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
             byte[] pdfBytes = certificateService.generateDocumentCertificate(id);
             
             return ResponseEntity.ok()
@@ -250,7 +268,10 @@ public class DocumentManagementController {
      * Verify document hash (SHA-256) againts stored fingerprint
      */
     @GetMapping("/{id}/verify-hash")
-    public ResponseEntity<?> verifyHash(@PathVariable UUID id) {
+    public ResponseEntity<?> verifyHash(@PathVariable UUID id, Authentication authentication) {
+        User user = authService.findByEmail(authentication.getName());
+        documentManagementService.ensureDocumentAccess(id, user.getId(), user.getRole().name());
+
         boolean isValid = documentManagementService.verifyDocumentHash(id);
         return ResponseEntity.ok(Map.of("id", id, "valid", isValid));
     }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/DocumentManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/DocumentManagementService.java
@@ -96,6 +96,15 @@ public class DocumentManagementService {
                 .map(this::convertToDto)
                 .collect(Collectors.toList());
     }
+
+    public void ensureDocumentAccess(UUID id, Long userId, String userRole) {
+        DocumentEntity document = documentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Document not found"));
+
+        if (!hasDocumentAccess(document, userId, userRole)) {
+            throw new RuntimeException("Unauthorized to access this document");
+        }
+    }
     
     /**
      * Check if user has access to a document


### PR DESCRIPTION
# Pull Request

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
This PR fixes a high-severity security issue in which direct document-by-ID endpoints returned document metadata and file contents without enforcing the same visibility rules as the case-level listing.

Closes #605 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
