### PR TITLE
fix: resolve dual state management conflict (issue #566)

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseManagementController.java
@@ -5,6 +5,7 @@ import com.nyaysetu.backend.dto.CreateCaseRequest;
 import com.nyaysetu.backend.entity.CaseEntity;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.service.CaseManagementService;
+import com.nyaysetu.backend.service.CaseStateTransitionService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ import java.util.UUID;
 public class CaseManagementController {
 
     private final CaseManagementService caseManagementService;
+    private final CaseStateTransitionService caseStateTransitionService;
     private final com.nyaysetu.backend.service.AuthService authService;
 
     @PostMapping
@@ -122,19 +124,21 @@ public class CaseManagementController {
 
     /**
      * Handover D: Lawyer files the approved petition in court
-     * Transitions case to COGNIZANCE_PERIOD (stepper Stage 2 - Notice Issued)
+     * Routes through CaseStateTransitionService for audit trail and validation.
      */
     @PostMapping("/{id}/file-in-court")
-    public ResponseEntity<Map<String, Object>> fileInCourt(@PathVariable UUID id) {
-        CaseEntity caseEntity = caseManagementService.getCaseEntity(id);
-        caseEntity.setStatus(com.nyaysetu.backend.entity.CaseStatus.COGNIZANCE_PERIOD);
-        caseEntity.setStage(com.nyaysetu.backend.entity.CaseStage.COGNIZANCE);
-        caseEntity.setCurrentJudicialStage(1);
-        caseManagementService.saveCaseEntity(caseEntity);
+    public ResponseEntity<Map<String, Object>> fileInCourt(
+            @PathVariable UUID id,
+            Authentication authentication
+    ) {
+        User user = authService.findByEmail(authentication.getName());
+        CaseEntity result = caseStateTransitionService.lawyerFileInCourt(
+            id, user.getId().toString(), user.getName()
+        );
         return ResponseEntity.ok(Map.of(
             "success", true,
             "message", "Case filed in court successfully",
-            "newStatus", "COGNIZANCE_PERIOD"
+            "newStatus", result.getStatus().name()
         ));
     }
 

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/CaseEntity.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/CaseEntity.java
@@ -132,6 +132,9 @@ public class CaseEntity {
     @Column(columnDefinition = "TEXT")
     private String blockingErrors;
 
+    @Version
+    private Long version;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
@@ -139,6 +139,7 @@ public class CaseManagementService {
 
         caseEntity.setDraftPetition(draftContent);
         caseEntity.setStatus(com.nyaysetu.backend.entity.CaseStatus.DRAFT_PENDING_CLIENT);
+        caseEntity.setDraftApprovalStatus("AWAITING_CLIENT");
         // Ensure Document Status is set for frontend logic
         caseEntity.setDocumentStatus(com.nyaysetu.backend.entity.DocumentStatus.PENDING_REVIEW);
         

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseStateTransitionService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseStateTransitionService.java
@@ -1,6 +1,7 @@
 package com.nyaysetu.backend.service;
 
 import com.nyaysetu.backend.entity.CaseEntity;
+import com.nyaysetu.backend.entity.CaseStage;
 import com.nyaysetu.backend.entity.CaseStatus;
 import com.nyaysetu.backend.repository.CaseRepository;
 import lombok.RequiredArgsConstructor;
@@ -205,6 +206,7 @@ public class CaseStateTransitionService {
 
         // Update status and stage
         caseEntity.setStatus(CaseStatus.IN_ADMISSION);
+        caseEntity.setStage(CaseStage.COGNIZANCE);
         caseEntity.setJudgeId(judgeId);
         caseEntity.setCurrentJudicialStage(1); // Cognizance stage
         caseEntity = caseRepository.save(caseEntity);
@@ -250,6 +252,9 @@ public class CaseStateTransitionService {
 
         int newStage = currentStage + 1;
         caseEntity.setCurrentJudicialStage(newStage);
+
+        // Update stage enum to stay in sync with currentJudicialStage
+        caseEntity.setStage(mapStageNumberToEnum(newStage));
 
         // Update status based on stage
         if (newStage == 6) {
@@ -359,6 +364,58 @@ public class CaseStateTransitionService {
             );
 
             broadcastCaseUpdate(caseEntity, "Case is now Trial Ready");
+        }
+    }
+
+    /**
+     * LAWYER: File approved petition in court.
+     * Transitions: draftApprovalStatus=APPROVED → COGNIZANCE_PERIOD
+     * Routes through this service to ensure audit trail and validation.
+     */
+    @Transactional
+    public CaseEntity lawyerFileInCourt(UUID caseId, String lawyerId, String lawyerName) {
+        CaseEntity caseEntity = getCaseOrThrow(caseId);
+        CaseStatus previousStatus = caseEntity.getStatus();
+
+        if (!"APPROVED".equals(caseEntity.getDraftApprovalStatus())) {
+            throw new IllegalStateException("Draft must be approved by client before filing in court");
+        }
+
+        caseEntity.setStatus(CaseStatus.COGNIZANCE_PERIOD);
+        caseEntity.setCurrentJudicialStage(1);
+        caseEntity.setStage(CaseStage.COGNIZANCE);
+        caseEntity = caseRepository.save(caseEntity);
+
+        eventService.logStatusChange(
+                caseId,
+                lawyerId,
+                CaseEventService.ROLE_LAWYER,
+                lawyerName,
+                previousStatus,
+                CaseStatus.COGNIZANCE_PERIOD,
+                "Lawyer filed approved petition in court for cognizance"
+        );
+
+        broadcastCaseUpdate(caseEntity, "Petition filed in court - awaiting cognizance");
+
+        log.info("Lawyer {} filed case {} in court", lawyerName, caseId);
+        return caseEntity;
+    }
+
+    /**
+     * Maps judicial stage number (1-7) to the corresponding CaseStage enum value,
+     * keeping the stage enum in sync with currentJudicialStage.
+     */
+    private CaseStage mapStageNumberToEnum(int stageNumber) {
+        switch (stageNumber) {
+            case 1: return CaseStage.COGNIZANCE;
+            case 2: return CaseStage.APPEARANCE;
+            case 3: return CaseStage.FRAMING_OF_CHARGES;
+            case 4: return CaseStage.EVIDENCE;
+            case 5: return CaseStage.ARGUMENTS;
+            case 6: return CaseStage.JUDGMENT;
+            case 7: return CaseStage.VERDICT;
+            default: return null;
         }
     }
 


### PR DESCRIPTION
## Description
Consolidates the two conflicting case state management systems (`CaseStateTransitionService` and `CaseManagementService`) into a single canonical path, preventing silent data corruption from concurrent state writes and eliminating the controller-level bypass that skipped all audit trails.

Closes #566

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes