### PR TITLE
fix: add clickjacking protection and rate limit forgot-password endpoint

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -154,6 +154,11 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.deny())
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives("frame-ancestors 'none';"))
+                )
                 .authorizeHttpRequests(auth -> auth
 
                         // ── Public endpoints ──────────────────────────────────────────────

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/filter/RateLimitFilter.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/filter/RateLimitFilter.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Protected endpoints:
  * - /api/auth/login
  * - /api/auth/register
+ * - /api/auth/forgot-password
  */
 @Component
 @Slf4j
@@ -189,7 +190,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
      */
     private boolean isRateLimitedEndpoint(String path) {
 
-        return path.matches("^/api/auth/(login|register)$");
+        return path.matches("^/api/auth/(login|register|forgot-password)$");
     }
 
     /**


### PR DESCRIPTION
## Description
This PR resolves security gaps and introduces hardening configurations to prevent unauthorized brute-force attempts and Clickjacking attacks.

closes #273 

### Changes Implemented:
1. **Password Reset Protection (Rate Limiting):**
   - Extended the `RateLimitFilter` to target `/api/auth/forgot-password`.
   - Protects this public, resource-intensive (email sending) endpoint from high-frequency spam, automated abuse, and potential denial-of-service attempts.
   - Updated class documentation comments detailing protected routes.

2. **Frame / Clickjacking Mitigation (Security Headers):**
   - Explicitly configured Spring Security headers in `SecurityConfig.java` to strictly deny framing (`.frameOptions(frame -> frame.deny())`).
   - Implemented a strict Content Security Policy (`frame-ancestors 'none';`) to reject any framing attempts on a browser level.

## Verification
- **Prinstine codebase:** Verified that changes only touch the target security files.
- **Syntactical correctness:** All Spring Security and rate-limiting adjustments are syntactically standard and utilize standard configurations.