### PR TITLE
fix: case ID and title showing undefined in filing success message

### DIFF
--- a/frontend/nyaysetu-frontend/src/pages/litigant/VakilFriendPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/VakilFriendPage.jsx
@@ -636,8 +636,8 @@ export default function VakilFriendChat() {
 
             // Build success message with all details
             let successMessage = `✅ **Case Filed Successfully!**\n\n`;
-            successMessage += `📋 **Case ID:** ${data.caseId}\n`;
-            successMessage += `📝 **Title:** ${data.caseTitle}\n`;
+            successMessage += `📋 **Case ID:** ${data.id}\n`;
+             successMessage += `📝 **Title:** ${data.title}\n`;
             successMessage += `🏷️ **Type:** ${data.caseType}\n`;
             successMessage += `⚡ **Urgency:** ${data.urgency}\n`;
             successMessage += `👤 **Petitioner:** ${data.petitioner}\n`;


### PR DESCRIPTION

## Description
Fixes `Case ID` and `Title` showing `undefined` in the success message after completing a case filing through Nyay Saarthi (Vakil Friend).

The frontend was reading `data.caseId` and `data.caseTitle` but the backend returns `data.id` and `data.title`, causing a field name mismatch.

Closes #565 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

<img width="1366" height="768" alt="Screenshot (388)" src="https://github.com/user-attachments/assets/96bdeb4a-1cc1-4657-93ab-2f569d084f2b" />
