### PR TITLE
 feat: improve multilingual language support and language persistence

### DIFF
--- a/frontend/nyaysetu-frontend/src/App.jsx
+++ b/frontend/nyaysetu-frontend/src/App.jsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect, Suspense, lazy } from 'react';
 import useAuthStore from './store/authStore';
-import { LanguageProvider } from './contexts/LanguageContext.jsx';
 // CHANGED: ThemeProvider added — wraps the entire app so all components can access theme
 import { ThemeProvider } from './contexts/ThemeContext.jsx';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -108,7 +107,6 @@ function App({ swRegistration }) {
         // is set on <html> before any child renders — prevents flash of wrong theme
         <ThemeProvider>
             <ErrorBoundary>
-                <LanguageProvider>
                     {/* Global PWA Components */}
                     <OfflineIndicator />
                     <UpdateNotification registration={swRegistration} />
@@ -236,7 +234,6 @@ function App({ swRegistration }) {
                             </Routes>
                         </Suspense>
                     </BrowserRouter>
-                </LanguageProvider>
             </ErrorBoundary>
         </ThemeProvider>
     );

--- a/frontend/nyaysetu-frontend/src/contexts/LanguageContext.jsx
+++ b/frontend/nyaysetu-frontend/src/contexts/LanguageContext.jsx
@@ -322,10 +322,15 @@ export const translations = {
 };
 
 export function LanguageProvider({ children }) {
-    const [language, setLanguage] = useState('en');
+    const [language, setLanguage] = useState(
+        localStorage.getItem('preferredLanguage') || 'en'
+    );
 
     const toggleLanguage = () => {
-        setLanguage(prev => prev === 'en' ? 'hi' : 'en');
+    const newLanguage = language === 'en' ? 'hi' : 'en';
+
+    setLanguage(newLanguage);
+    localStorage.setItem('preferredLanguage', newLanguage);
     };
 
     const t = (key) => {

--- a/frontend/nyaysetu-frontend/src/i18n.js
+++ b/frontend/nyaysetu-frontend/src/i18n.js
@@ -31,7 +31,7 @@ i18n
         detection: {
             order: ['localStorage', 'navigator'],
             caches: ['localStorage'],
-            lookupLocalStorage: 'i18nextLng',
+            lookupLocalStorage: 'preferredLanguage',
         },
 
         // Interpolation settings

--- a/frontend/nyaysetu-frontend/src/layouts/DashboardHeader.jsx
+++ b/frontend/nyaysetu-frontend/src/layouts/DashboardHeader.jsx
@@ -4,6 +4,7 @@ import { LogOut, ChevronDown, User, Menu, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import useAuthStore from '../store/authStore';
 import NotificationBell from '../components/NotificationBell';
+import { languages } from '../utils/languages';
 
 export default function DashboardHeader({ user, isMobile, onMobileMenuToggle }) {
     const [showProfileMenu, setShowProfileMenu] = useState(false);
@@ -15,18 +16,7 @@ export default function DashboardHeader({ user, isMobile, onMobileMenuToggle }) 
         logout();
         navigate('/login');
     };
-    const languages = [
-    { code: 'en', label: 'English' },
-    { code: 'hi', label: 'हिंदी' },
-    { code: 'mr', label: 'मराठी' },
-    { code: 'ta', label: 'தமிழ்' },
-    { code: 'te', label: 'తెలుగు' },
-    { code: 'gu', label: 'ગુજરાતી' },
-    { code: 'kn', label: 'ಕನ್ನಡ' },
-    { code: 'bn', label: 'বাংলা' },
-    { code: 'ml', label: 'മലയാളം' },
-    { code: 'pa', label: 'ਪੰਜਾਬੀ' }
-];
+
     return (
         <header
             className="navbar"
@@ -235,6 +225,7 @@ export default function DashboardHeader({ user, isMobile, onMobileMenuToggle }) 
                                     key={lang.code}
                                     onClick={() => {
                                         i18n.changeLanguage(lang.code);
+                                        localStorage.setItem('preferredLanguage', lang.code);
                                         setShowProfileMenu(false);
                                     }}
                                     style={{

--- a/frontend/nyaysetu-frontend/src/utils/languages.js
+++ b/frontend/nyaysetu-frontend/src/utils/languages.js
@@ -1,0 +1,12 @@
+export const languages = [
+    { code: 'en', label: 'English' },
+    { code: 'hi', label: 'हिंदी' },
+    { code: 'mr', label: 'मराठी' },
+    { code: 'ta', label: 'தமிழ்' },
+    { code: 'te', label: 'తెలుగు' },
+    { code: 'gu', label: 'ગુજરાતી' },
+    { code: 'kn', label: 'ಕನ್ನಡ' },
+    { code: 'bn', label: 'বাংলা' },
+    { code: 'ml', label: 'മലയാളം' },
+    { code: 'pa', label: 'ਪੰਜਾਬੀ' }
+];


### PR DESCRIPTION
## Title

feat: improve multilingual language support and language persistence

## Description

### Overview

This PR enhances the multilingual experience across the Nyay Setu frontend by improving language persistence, cleaning up language handling logic, and making the language selector architecture more reusable and maintainable.

### Changes Made

* Improved multilingual language persistence using `localStorage`
* Synced `i18next` language detection with saved user preference
* Added reusable `languages.js` utility for centralized language configuration
* Refactored dashboard language selector to use shared language config
* Removed duplicate `LanguageProvider` wrapper usage from `App.jsx`
* Improved compatibility between existing `LanguageContext` and `react-i18next`
* Preserved backward compatibility with existing components
* Enhanced maintainability and scalability for future language additions

### Languages Supported

* English
* Hindi
* Marathi
* Tamil
* Telugu
* Gujarati
* Kannada
* Bengali
* Malayalam
* Punjabi

### Impact

* Better multilingual UX
* Persistent language preference after refresh
* Cleaner architecture for future i18n enhancements
* Improved scalability for regional language support

### Related Issue

Closes #553
