### PR TITLE
fix: restore API_BASE_URL fallback chain — production crash caused by PR #354

### DIFF
--- a/frontend/nyaysetu-frontend/src/services/api.js
+++ b/frontend/nyaysetu-frontend/src/services/api.js
@@ -7,13 +7,16 @@ import axios from 'axios';
 // In development: http://localhost:8080
 // In production: Replace with actual backend URL via environment variable
 // Check multiple variable names to be safe
-// Smart Base URL detection
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+// Smart Base URL detection with safe fallbacks
+const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+const PROD_BACKEND = 'https://nyaysetubackend.onrender.com';
 
-if (!API_BASE_URL) {
-  throw new Error(
-    "VITE_API_BASE_URL is missing. Please check your .env file."
-  );
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ||
+    import.meta.env.VITE_API_URL ||
+    (isLocalhost ? 'http://localhost:8080' : PROD_BACKEND);
+
+if (import.meta.env.DEV) {
+    console.log('[api.js] Using API_BASE_URL:', API_BASE_URL);
 }
 
 const api = axios.create({


### PR DESCRIPTION
## Critical Production Fix

The live site at `nyaysetu-lovat.vercel.app` is currently fully broken and showing "Oops! Something went wrong" on every page load.

### Root Cause

PR #354 (`fix/env-standardization` by @2024itb047samata) removed the smart fallback chain for `API_BASE_URL` in `frontend/nyaysetu-frontend/src/services/api.js` and replaced it with a hard `throw new Error()` that crashes the entire app if `VITE_API_BASE_URL` is not set as an environment variable.

Since our Vercel deployment does not have `VITE_API_BASE_URL` configured, the app throws a fatal error before any React component even renders.

### What changed in PR #354 (the breaking change)

```js
// BEFORE (worked in all environments):
const isLocalhost = window.location.hostname === 'localhost';
const PROD_BACKEND = 'https://nyaysetubackend.onrender.com';
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ||
    import.meta.env.VITE_API_URL ||
    (isLocalhost ? 'http://localhost:8080' : PROD_BACKEND);

// AFTER PR #354 (crashes when env var is missing):
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
if (!API_BASE_URL) {
  throw new Error("VITE_API_BASE_URL is missing.");
}