### PR TITLE
fix: restore user object in login response payload (fixes frontend crash caused by #301)

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -104,6 +104,12 @@ public class AuthController {
             response.put("token", token);
             response.put("accessToken", token);
             response.put("refreshToken", refreshToken);
+            response.put("user", Map.of(
+                "id", user.getId(),
+                "name", user.getName(),
+                "email", user.getEmail(),
+                "role", user.getRole().name()
+            ));
 
             return ResponseEntity.ok(response);
         }


### PR DESCRIPTION
## Critical Bug Fix

The login functionality is currently broken in production and local environments, showing an "Invalid email or password" UI state due to an underlying frontend crash.

### Root Cause
PR #301 (`feature/jwt-refresh-token` by @diyajn) introduced refresh tokens to the `/auth/login` backend endpoint. However, during that implementation, the `user` object was accidentally removed from the JSON response payload. 

Meanwhile, the frontend (`Login.jsx`) has a strict validation check that expects `response.data.user` to be returned so it can verify the user's role against their selected login tab. Because it was missing, the frontend crashed with a fatal TypeError:
`TypeError: Cannot read properties of undefined (reading 'role')`

### What this fix does
This PR simply restores the `user` object in the response map of `AuthController.java` so that the frontend can successfully parse the user details and role.

```java
// Added back to AuthController.java login response:
response.put("user", Map.of(
    "id", user.getId(),
    "name", user.getName(),
    "email", user.getEmail(),
    "role", user.getRole().name()
));