### PR TITLE
Fix: Correct heading from 'Why Nyay Saarthi?' to 'Why Nyay Setu?' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@
 - [License](#license)
 
 <hr/>
-
-## Why Nyay Saarthi?
+<!-- Fix: Corrected heading from 'Why Nyay Saarthi?' to 'Why Nyay Setu?' to match project name and fix broken TOC link -->
+## Why Nyay Setu?
 
 The Indian judiciary faces a systemic crisis that affects hundreds of millions of citizens:
 


### PR DESCRIPTION
## Description
Fixed a wrong project name in README.md.

The section heading "Why Nyay Saarthi?" was incorrectly 
using "Nyay Saarthi" which is a different project name. 
The correct project name is "Nyay Setu".

This also caused the Table of Contents link 
[Why Nyay Setu?](#why-nyay-setu) to be broken since it 
was pointing to a heading that didn't exist.

Fixed by correcting the heading to "Why Nyay Setu?" which 
also fixes the broken TOC link automatically.

Closes #

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings