### PR TITLE
fix(frontend): enforce PWA auto-updates and out-dated cache cleanup

### DIFF
--- a/frontend/nyaysetu-frontend/src/main.jsx
+++ b/frontend/nyaysetu-frontend/src/main.jsx
@@ -8,44 +8,7 @@ import App from './App.jsx'
 import { useSessionMonitor } from './hooks/useSessionMonitor';
 import SessionWarningBanner from './components/SessionWarningBanner';
 import { Toaster } from "react-hot-toast";
-/**
- * Register service worker and handle updates
- * Only runs on production builds (preview/production), not on dev server
- */
-const registerServiceWorker = (callback) => {
-    // Skip service worker registration on dev server (port 5173)
-    // Only register on production builds (preview/production)
-    const isDev = import.meta.env.DEV;
-
-    if (isDev) {
-      //  console.log('🔧 Dev mode detected - Service Worker registration skipped');
-        return;
-    }
-
-    if ('serviceWorker' in navigator) {
-        window.addEventListener('load', async () => {
-            try {
-                const registration = await navigator.serviceWorker.register('/sw.js', {
-                    scope: '/',
-                });
-             //   console.log('✅ Service Worker registered successfully:', registration);
-
-                // Pass registration to callback
-                if (callback) {
-                    callback(registration);
-                }
-
-                // Check for updates periodically (every hour)
-                setInterval(() => {
-                    registration.update();
-                }, 60 * 60 * 1000);
-
-            } catch (error) {
-                console.error('❌ Service Worker registration failed:', error);
-            }
-        });
-    }
-};
+import { registerSW } from 'virtual:pwa-register';
 
 const Root = () => {
     const [swRegistration, setSwRegistration] = useState(null);
@@ -63,7 +26,17 @@ const Root = () => {
     };
 
     useEffect(() => {
-        registerServiceWorker(setSwRegistration);
+        if (!import.meta.env.DEV) {
+            const updateSW = registerSW({
+                onNeedRefresh() {
+                    console.log('🔄 New update found! Reloading to clear cache...');
+                    updateSW(true);
+                },
+                onOfflineReady() {
+                    console.log('✅ App is ready to work offline');
+                },
+            });
+        }
     }, []);
 
     return (

--- a/frontend/nyaysetu-frontend/src/styles/responsive.css
+++ b/frontend/nyaysetu-frontend/src/styles/responsive.css
@@ -260,7 +260,7 @@
     }
 
     /* Make buttons visible and touch-friendly */
-    button,
+    button:not(.guest-continue-btn):not(.guest-btn-primary):not(.guest-btn-secondary):not(.guest-btn-ghost),
     .next-btn,
     .prev-btn,
     button[type="submit"],
@@ -300,6 +300,7 @@
     /* Fix any overflowing elements */
     * {
         max-width: 100vw !important;
+    }
 
     /* Hearings Page */
     .hearings-header {

--- a/frontend/nyaysetu-frontend/vite.config.js
+++ b/frontend/nyaysetu-frontend/vite.config.js
@@ -33,6 +33,7 @@ export default defineConfig({
         ]
       },
       workbox: {
+        cleanupOutdatedCaches: true,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
         navigateFallback: '/offline.html',
         runtimeCaching: [


### PR DESCRIPTION
### What does this PR do?
This fixes a critical bug where UI updates (like the new `guest.css` styles for the "Explore as Guest" button) were not visible in the production Vercel deployment. 

The previous implementation used a manual `navigator.serviceWorker.register` in `main.jsx` and lacked the proper configuration to tell Workbox to clean out the old cached CSS and HTML files when a new app version was detected.

### Changes made:
1. **`vite.config.js`**: Added `cleanupOutdatedCaches: true` to the `workbox` config so the browser will actively purge old assets when a new Vercel deployment completes.
2. **`main.jsx`**: Replaced the manual Service Worker registration with Vite PWA's official `virtual:pwa-register` hook.
3. **Auto-reload Hook**: Configured the `onNeedRefresh()` lifecycle method within `main.jsx` to force the browser to reload `updateSW(true)` automatically when an update is available. 

### Why is this important?
End users will no longer need to open Chrome DevTools and manually click "Clear site data" to see new UI updates! 