### PR TITLE
fix(ui): resolve Explore as Guest alignment issue (#701)

### DIFF
--- a/frontend/nyaysetu-frontend/src/pages/Login.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/Login.jsx
@@ -437,6 +437,7 @@ export default function Login() {
                             {/* Sign In Button */}
                             <button
                                 type="submit"
+                                className="auth-full-width-btn"
                                 disabled={loading}
                                 style={{
                                     width: '100%',
@@ -461,6 +462,7 @@ export default function Login() {
                             {/* Face Login */}
                             <button
                                 type="button"
+                                className="auth-full-width-btn"
                                 onClick={() => setShowFaceLogin(true)}
                                 style={{
                                     width: '100%',

--- a/frontend/nyaysetu-frontend/src/pages/Signup.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/Signup.jsx
@@ -526,6 +526,7 @@ export default function Signup() {
                                     {/* Create Account Button */}
                                     <button
                                         type="submit"
+                                        className="auth-full-width-btn"
                                         disabled={loading}
                                         style={{
                                             width: '100%',

--- a/frontend/nyaysetu-frontend/src/styles/responsive.css
+++ b/frontend/nyaysetu-frontend/src/styles/responsive.css
@@ -260,10 +260,10 @@
     }
 
     /* Make buttons visible and touch-friendly */
-    button:not(.guest-continue-btn):not(.guest-btn-primary):not(.guest-btn-secondary):not(.guest-btn-ghost),
+    button:not(.guest-continue-btn):not(.guest-btn-primary):not(.guest-btn-secondary):not(.guest-btn-ghost):not(.auth-full-width-btn),
     .next-btn,
     .prev-btn,
-    button[type="submit"],
+    button[type="submit"]:not(.auth-full-width-btn),
     div[class*="button"] {
         min-height: 48px !important;
         padding: 12px 20px !important;


### PR DESCRIPTION
## Root Cause

The mobile responsive stylesheet had an overly broad rule in `responsive.css` that forced many buttons (including auth page submit/action buttons) to `width: auto !important`.

This overrode the intended full-width auth button styles on Login/Signup, making the action section visually inconsistent and misaligned around the "Explore as Guest" CTA.

## Changes Made

* Scoped the mobile button override to exclude explicitly full-width auth CTAs by updating:

  * `button:not(...):not(.auth-full-width-btn)`
  * `button[type="submit"]:not(.auth-full-width-btn)`
* Added `className="auth-full-width-btn"` to:

  * Login: Sign In button
  * Login: Login with Face button
  * Signup: Sign Up button
* Kept guest components/imports/styles intact and only changed files directly related to the misalignment regression.

## Testing Performed

* Ran app locally:

  * `npm run dev -- --host 127.0.0.1 --port 4173`
* Visual verification via Playwright screenshots:

  * Login mobile before/after
  * Signup mobile before/after
  * Login desktop regression check
  * Guest-session landing (desktop/mobile) with guest localStorage state
* Build verification:

  * `npm run build` ✅ successful

## Notes

* `npm run test -- --run` currently fails due existing test environment/localStorage setup in `authStore.test.js` (`localStorage.clear is not a function`), unrelated to this UI fix.

## Screenshots

* Before:

  * `/tmp/issue701/login-mobile.png`
  * `/tmp/issue701/signup-mobile.png`
* After:

  * `/tmp/issue701/login-mobile-fixed.png`
  * `/tmp/issue701/signup-mobile-fixed.png`
  * `/tmp/issue701/login-desktop-fixed.png`

Closes #701
