### PR TITLE
fix: validate JWT secret independently of profile naming

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -41,17 +41,15 @@ public class SecurityConfig {
 
     @PostConstruct
     public void validateJwtSecretConfiguration() {
-        boolean isProd = java.util.Arrays.stream(environment.getActiveProfiles())
-                .anyMatch("prod"::equalsIgnoreCase);
         boolean isDev = java.util.Arrays.stream(environment.getActiveProfiles())
-                .anyMatch("dev"::equalsIgnoreCase);
+                .anyMatch(profile -> profile.equalsIgnoreCase("dev") || profile.equalsIgnoreCase("test"));
         String jwtSecretEnv = System.getenv("JWT_SECRET");
         boolean isJwtSecretEnvMissing = jwtSecretEnv == null || jwtSecretEnv.trim().isEmpty();
         boolean isUsingDefaultSecret = DEFAULT_JWT_SECRET.equals(jwtSecret);
 
-        if (isProd && (isJwtSecretEnvMissing || isUsingDefaultSecret)) {
+        if (!isDev && (isJwtSecretEnvMissing || isUsingDefaultSecret)) {
             throw new IllegalStateException(
-                    "Security configuration error: JWT_SECRET environment variable is required in production. "
+                    "Security configuration error: JWT_SECRET environment variable is required in non-development deployments. "
                             + "Application startup is blocked to prevent using an insecure default JWT signing key.");
         }
 


### PR DESCRIPTION
## Description

Removes profile-name-dependent production detection in favor of directly checking whether the JWT secret is the insecure default. Startup now fails whenever the fallback signing key is used outside of dev/test profiles, regardless of the active profile name.

Closes #730

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes