### PR TITLE
fix: enable Flyway validation and fail fast on missing migrations

### DIFF
--- a/backend/nyaysetu-backend/src/main/resources/application-prod.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application-prod.properties
@@ -17,7 +17,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # Flyway
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
-spring.flyway.validate-on-migrate=false
+spring.flyway.validate-on-migrate=true
 spring.flyway.ignore-missing-migrations=false
 
 # CORS - Strict origin from Env Var

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -37,8 +37,8 @@ spring.jpa.properties.hibernate.format_sql=true
 # Flyway Migration - Production Ready
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
-spring.flyway.validate-on-migrate=false
-spring.flyway.ignore-missing-migrations=true
+spring.flyway.validate-on-migrate=true
+spring.flyway.ignore-missing-migrations=false
 # Use a separate connection for Flyway (Direct Connection) to avoid Transaction Pooler issues
 # Defaults to normal datasource if not specified (e.g. locally)
 # spring.flyway.url=${FLYWAY_URL:${spring.datasource.url}}


### PR DESCRIPTION
## Description

Enables `validate-on-migrate` and disables `ignore-missing-migrations` so that schema drift is caught at startup rather than silently ignored. This ensures the migration history always matches the source tree across all environments.

Closes #732

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes