### PR TITLE
test(backend): add unit tests for JwtAuthFilter and JwtService functionality (#738)

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/filter/JwtAuthFilterTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/filter/JwtAuthFilterTest.java
@@ -1,0 +1,75 @@
+package com.nyaysetu.backend.filter;
+
+import com.nyaysetu.backend.service.JwtService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Key;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtAuthFilterTest {
+
+    private JwtService jwtService;
+    private JwtAuthFilter filter;
+    private final String secret = "0123456789ABCDEF0123456789ABCDEF";
+
+    @BeforeEach
+    void setup() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "secretKey", secret);
+        UserDetailsService uds = Mockito.mock(UserDetailsService.class);
+        filter = new JwtAuthFilter(jwtService, uds);
+    }
+
+    @Test
+    void malformedToken_shouldReturn401WithJsonMessage() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/protected");
+        req.addHeader("Authorization", "Bearer this.is.not.valid");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        String body = resp.getContentAsString();
+        assertTrue(body.contains("Unauthorized"));
+        assertTrue(body.contains("Access token is expired or invalid"));
+    }
+
+    @Test
+    void expiredToken_shouldReturn401WithJsonMessage() throws Exception {
+        // create expired token signed with the same secret
+        Key key = Keys.hmacShaKeyFor(secret.getBytes());
+        String expired = Jwts.builder()
+                .setSubject("user@example.com")
+                .setIssuedAt(new Date(System.currentTimeMillis() - 10_000))
+                .setExpiration(new Date(System.currentTimeMillis() - 1_000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setServletPath("/api/v1/protected");
+        req.addHeader("Authorization", "Bearer " + expired);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        String body = resp.getContentAsString();
+        assertTrue(body.contains("Unauthorized"));
+        assertTrue(body.contains("Access token is expired or invalid"));
+    }
+}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/JwtServiceTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/JwtServiceTest.java
@@ -1,0 +1,60 @@
+package com.nyaysetu.backend.service;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+    private final String secret = "0123456789ABCDEF0123456789ABCDEF"; // 32 chars -> 256 bits
+
+    @BeforeEach
+    void setup() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "secretKey", secret);
+    }
+
+    @Test
+    void generateToken_shouldBeSignedAndValid() {
+        UserDetails user = User.withUsername("alice@example.com").password("pw").roles("USER").build();
+        String token = jwtService.generateToken(Map.of(), user);
+
+        assertNotNull(token);
+        assertEquals("alice@example.com", jwtService.extractUsername(token));
+        assertTrue(jwtService.isTokenValid(token, user));
+    }
+
+    @Test
+    void expiredToken_shouldThrowExpiredException_whenParsing() {
+        // create an already-expired token
+        Key key = Keys.hmacShaKeyFor(secret.getBytes());
+        String expired = Jwts.builder()
+                .setSubject("bob@example.com")
+                .setIssuedAt(new Date(System.currentTimeMillis() - 10000))
+                .setExpiration(new Date(System.currentTimeMillis() - 1000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThrows(ExpiredJwtException.class, () -> jwtService.extractUsername(expired));
+    }
+
+    @Test
+    void malformedToken_shouldBeRejected() {
+        String bad = "this.is.not.a.valid.jwt";
+        assertThrows(Exception.class, () -> jwtService.extractUsername(bad));
+    }
+}

--- a/frontend/nyaysetu-frontend/src/pages/litigant/FileUnifiedPage.test.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/FileUnifiedPage.test.jsx
@@ -1,0 +1,129 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import FileUnifiedPage from "./FileUnifiedPage";
+
+describe("FileUnifiedPage stepper navigation", () => {
+  const renderPage = () =>
+    render(
+      <MemoryRouter>
+        <FileUnifiedPage />
+      </MemoryRouter>,
+    );
+
+  it("navigates back using Previous button and preserves form state", async () => {
+    const { container } = renderPage();
+
+    // Select first case type card so we can proceed to step 2
+    const firstCaseButton = container.querySelector(
+      ".horizontal-scroll-cards button",
+    );
+    expect(firstCaseButton).toBeTruthy();
+    fireEvent.click(firstCaseButton);
+
+    // Proceed to Step 2
+    fireEvent.click(screen.getByRole("button", { name: /fileUnified.next/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /fileUnified.caseDetails/i }),
+      ).toBeInTheDocument(),
+    );
+
+    // Fill some fields in Step 2 (use placeholders rendered as i18n keys)
+    const titleInput = screen.getByPlaceholderText(
+      /fileUnified.caseTitlePlaceholder/i,
+    );
+    const petitionerInput = screen.getByPlaceholderText(
+      /fileUnified.petitionerPlaceholder/i,
+    );
+    const respondentInput = screen.getByPlaceholderText(
+      /fileUnified.respondentPlaceholder/i,
+    );
+    const descriptionInput = screen.getByPlaceholderText(
+      /fileUnified.caseDescriptionPlaceholder/i,
+    );
+
+    fireEvent.change(titleInput, { target: { value: "Test Case Title" } });
+    fireEvent.change(petitionerInput, { target: { value: "Alice" } });
+    fireEvent.change(respondentInput, { target: { value: "Bob" } });
+    fireEvent.change(descriptionInput, { target: { value: "Some facts" } });
+
+    // Go to Step 3
+    fireEvent.click(screen.getByRole("button", { name: /fileUnified.next/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/fileUnified.clickUploadFiles/i),
+      ).toBeInTheDocument(),
+    );
+
+    // Click Previous to go back to Step 2
+    fireEvent.click(
+      screen.getByRole("button", { name: /fileUnified.previous/i }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /fileUnified.caseDetails/i }),
+      ).toBeInTheDocument(),
+    );
+
+    // Ensure the previously entered values are preserved
+    expect(titleInput.value).toBe("Test Case Title");
+    expect(petitionerInput.value).toBe("Alice");
+    expect(respondentInput.value).toBe("Bob");
+  });
+
+  it("allows clicking a completed step indicator to navigate back and preserves state", async () => {
+    const { container } = renderPage();
+
+    // Select a case type and move to step 2
+    const firstCaseButton = container.querySelector(
+      ".horizontal-scroll-cards button",
+    );
+    fireEvent.click(firstCaseButton);
+    fireEvent.click(screen.getByRole("button", { name: /fileUnified.next/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /fileUnified.caseDetails/i }),
+      ).toBeInTheDocument(),
+    );
+
+    // Fill required fields
+    const titleInput2 = screen.getByPlaceholderText(
+      /fileUnified.caseTitlePlaceholder/i,
+    );
+    const descriptionInput2 = screen.getByPlaceholderText(
+      /fileUnified.caseDescriptionPlaceholder/i,
+    );
+    const petitionerInput2 = screen.getByPlaceholderText(
+      /fileUnified.petitionerPlaceholder/i,
+    );
+    const respondentInput2 = screen.getByPlaceholderText(
+      /fileUnified.respondentPlaceholder/i,
+    );
+    fireEvent.change(titleInput2, { target: { value: "Preserve Title" } });
+    fireEvent.change(descriptionInput2, { target: { value: "Some facts" } });
+    fireEvent.change(petitionerInput2, { target: { value: "Alice" } });
+    fireEvent.change(respondentInput2, { target: { value: "Bob" } });
+
+    // Move forward to Step 3
+    fireEvent.click(screen.getByRole("button", { name: /fileUnified.next/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/fileUnified.clickUploadFiles/i),
+      ).toBeInTheDocument(),
+    );
+
+    // Click the stepper label for "Case Details" (completed) to go back
+    const stepLabel = screen.getAllByText(/fileUnified.caseDetails/i)[0];
+    fireEvent.click(stepLabel);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /fileUnified.caseDetails/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(titleInput2.value).toBe("Preserve Title");
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
- JwtService tests: `JwtServiceTest.java`— validates token signing/extraction, expired token behavior, malformed token rejection.
- Filter tests: `JwtAuthFilterTest.java` — asserts `JwtAuthFilter` returns 401 JSON for malformed and expired tokens.

## Closes #738 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
