### PR TITLE
docs: fix branding inconsistency in root README (#777)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 <hr/>
 
-## Why Nyay Saarthi?
+## Why Nyay Setu?
 
 The Indian judiciary faces a systemic crisis that affects hundreds of millions of citizens:
 


### PR DESCRIPTION
## What
Fixes branding inconsistency where the root README used 'Nyay Saarthi' instead of 'NyaySetu'.

## Root cause
The section heading on line 49 had an outdated project name that wasn't updated during rebranding.

## Changes
- \README.md\ — Changed \## Why Nyay Saarthi?\ to \## Why Nyay Setu?\

## Verification
\grep\ confirms no remaining 'Nyay Saarthi' instances in root README.

Closes #777