### PR TITLE
ci: add Dependabot config for automated dependency scanning (#760)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/backend/nyaysetu-backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend/nyaysetu-frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "ci"
+      - "dependencies"


### PR DESCRIPTION
## What
Adds Dependabot configuration for automated vulnerability scanning.

## Root cause
No automated dependency scanning existed for pom.xml or package.json, leaving outdated libraries with known CVEs undetected.

## Changes
- \.github/dependabot.yml\ — New config with weekly scans for Maven, npm, and GitHub Actions ecosystems

## Verification
Config syntax validated against Dependabot specification.

Closes #760