### PR TITLE
ci: add issue and PR automation workflows (#768)

### DIFF
--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -1,0 +1,41 @@
+name: Issue Automation
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Auto-label bugs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title.toLowerCase();
+            const body = context.payload.issue.body?.toLowerCase() || '';
+            const labels = [];
+
+            if (title.includes('bug') || body.includes('bug') || title.includes('fix')) {
+              labels.push('bug');
+            }
+            if (title.includes('feature') || title.includes('feat') || body.includes('feature request')) {
+              labels.push('enhancement');
+            }
+            if (title.includes('docs') || title.includes('documentation')) {
+              labels.push('documentation');
+            }
+            if (title.includes('test') || body.includes('test')) {
+              labels.push('testing');
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: labels
+              });
+            }

--- a/.github/workflows/pr-greeting.yml
+++ b/.github/workflows/pr-greeting.yml
@@ -1,0 +1,22 @@
+name: PR Automation
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  greet-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Greet contributor
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `👋 Thank you for opening this pull request, @${context.payload.pull_request.user.login}!\n\nPlease ensure:\n- [ ] Your PR references an existing issue (e.g., \`Closes #123\`)\n- [ ] You've signed your commits (\`git commit -s\`)\n- [ ] UI changes include screenshots\n- [ ] All CI checks pass\n\nA maintainer will review your PR shortly.`
+            });


### PR DESCRIPTION
## What
Adds GitHub Actions workflows for issue and PR automation.

## Root cause
No automated workflows existed for labeling new issues or welcoming PR contributors.

## Changes
- \.github/workflows/issue-label.yml\ — Auto-labels issues based on title/body keywords (bug, enhancement, docs, testing)
- \.github/workflows/pr-greeting.yml\ — Welcomes new PR contributors with a pre-merge checklist

## Verification
Workflows follow GitHub Actions syntax and existing patterns in the repo.

Closes #768