### PR TITLE
fix: resolve WebSocket connection failure for Nyay Saarthi (#465)

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/StompWebSocketConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/StompWebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.nyaysetu.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic", "/queue");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/api/ws/stomp")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+        registry.addEndpoint("/api/ws/stomp")
+                .setAllowedOriginPatterns("*");
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/WebSocketConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/WebSocketConfig.java
@@ -1,50 +1,22 @@
 package com.nyaysetu.backend.config;
 
+import com.nyaysetu.backend.handler.NotificationWebSocketHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
-import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-
-import com.nyaysetu.backend.handler.NotificationWebSocketHandler;
-
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSocket
-@EnableWebSocketMessageBroker
 @RequiredArgsConstructor
-public class WebSocketConfig implements WebSocketConfigurer, WebSocketMessageBrokerConfigurer {
+public class WebSocketConfig implements WebSocketConfigurer {
 
     private final NotificationWebSocketHandler notificationHandler;
 
-    // Raw WebSocket handler for notifications
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(notificationHandler, "/api/ws/notifications")
-                .setAllowedOrigins("*");  // Configure appropriately for production
-    }
-
-    // STOMP message broker for SimpMessagingTemplate
-    @Override
-    public void configureMessageBroker(MessageBrokerRegistry config) {
-        // Enable simple in-memory broker for topics
-        config.enableSimpleBroker("/topic", "/queue");
-        // Prefix for messages FROM client TO server
-        config.setApplicationDestinationPrefixes("/app");
-    }
-
-    @Override
-    public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // STOMP endpoint for SockJS fallback
-        registry.addEndpoint("/api/ws/stomp")
-                .setAllowedOrigins("*")
-                .withSockJS();
-        // Plain WebSocket STOMP endpoint
-        registry.addEndpoint("/api/ws/stomp")
-                .setAllowedOrigins("*");
+                .setAllowedOriginPatterns("*");
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/handler/NotificationWebSocketHandler.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/handler/NotificationWebSocketHandler.java
@@ -56,7 +56,7 @@ public class NotificationWebSocketHandler extends TextWebSocketHandler {
                     log.warn("Failed to close unauthenticated WebSocket session: {}", session.getId());
                 }
             }
-        }, 5, TimeUnit.SECONDS);
+        }, 15, TimeUnit.SECONDS);
 
         authTimeouts.put(session.getId(), timeout);
     }

--- a/frontend/nyaysetu-frontend/public/locales/en/litigant.json
+++ b/frontend/nyaysetu-frontend/public/locales/en/litigant.json
@@ -517,6 +517,7 @@
   "vakilFriend": {
     "welcome": "🙏 Namaste! I am Nyay Saarthi, your AI legal assistant. How can I help you today?",
     "offlineMessage": "🙏 Namaste! I am Nyay Saarthi (offline mode). The backend server is not responding. Please start the backend and refresh.",
+    "connectError": "Unable to connect to Nyay Saarthi. Please check your internet and try again.",
     "deepResearchError": "Deep research failed.",
     "speechNotSupported": "Your browser does not support speech recognition. Please use Chrome or Edge.",
     "noSession": "⚠️ No active session. Please refresh the page.",

--- a/frontend/nyaysetu-frontend/src/pages/litigant/VakilFriendPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/VakilFriendPage.jsx
@@ -199,7 +199,7 @@ export default function VakilFriendChat() {
             }]);
         } catch (err) {
             console.error('Failed to start session:', err);
-            setError('Failed to connect. Please make sure the backend is running.');
+            setError(t('vakilFriend.connectError'));
             setMessages([{
                 role: 'assistant',
                 content: t('vakilFriend.offlineMessage')

--- a/frontend/nyaysetu-frontend/src/services/NotificationService.js
+++ b/frontend/nyaysetu-frontend/src/services/NotificationService.js
@@ -6,7 +6,7 @@ class NotificationService {
         this.ws = null;
         this.listeners = [];
         this.reconnectAttempts = 0;
-        this.maxReconnectAttempts = 3;
+        this.maxReconnectAttempts = 10;
         this.API_BASE_URL = API_BASE_URL;
         this.isConnecting = false;
         this.connectionFailed = false;
@@ -16,11 +16,10 @@ class NotificationService {
      * Connects to the WebSocket for real-time notifications securely
      */
     connect(token) {
-        // Skip if already connected, connecting, or permanently failed
         if (this.ws && this.ws.readyState === WebSocket.OPEN) {
             return;
         }
-        if (this.isConnecting || this.connectionFailed) {
+        if (this.isConnecting) {
             return;
         }
         if (!token || token === 'null' || token === 'undefined') {
@@ -30,15 +29,13 @@ class NotificationService {
         const isProduction = !window.location.hostname.includes('localhost');
 
         try {
-            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-            const host = new URL(this.API_BASE_URL).host;
-            
-            // Secure URL without query parameters
-            const wsUrl = `${protocol}//${host}/api/ws/notifications`;
+            const parsedUrl = new URL(this.API_BASE_URL);
+            const protocol = parsedUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+            const wsUrl = `${protocol}//${parsedUrl.host}/api/ws/notifications`;
 
             this.isConnecting = true;
+            this.connectionFailed = false;
 
-            // Merged environment log routing rules - CONFLICT 1 RESOLVED
             if (!isProduction) {
                 if (import.meta.env.DEV) {
                     console.log('Connecting to WebSocket:', wsUrl);
@@ -47,7 +44,6 @@ class NotificationService {
 
             this.ws = new WebSocket(wsUrl);
 
-            // In-band Authentication frame payload dispatch - CONFLICT 2 RESOLVED
             this.ws.onopen = () => {
                 if (!isProduction) {
                     if (import.meta.env.DEV) {
@@ -56,8 +52,7 @@ class NotificationService {
                 }
                 this.reconnectAttempts = 0;
                 this.isConnecting = false;
-                
-                // Securely transmit token in the body frame immediately on open
+
                 this.ws.send(JSON.stringify({
                     type: 'AUTH',
                     token: token
@@ -109,20 +104,21 @@ class NotificationService {
             this.ws.onclose = (event) => {
                 this.isConnecting = false;
                 this.ws = null;
-                
-                // Code 1008 means server sandbox kicked the connection due to auth timeout/failure
+
                 if (event.code === 1008) {
                     this.connectionFailed = true;
                     return;
                 }
 
-                if (!this.connectionFailed) {
-                    this.attemptReconnect(token);
+                if (this.connectionFailed) {
+                    return;
                 }
+
+                this.attemptReconnect(token);
             };
         } catch (error) {
             this.isConnecting = false;
-            this.connectionFailed = true;
+            this.connectionFailed = false;
         }
     }
 
@@ -138,7 +134,10 @@ class NotificationService {
                 this.connect(token);
             }, delay);
         } else {
-            this.connectionFailed = true;
+            this.reconnectAttempts = 0;
+            setTimeout(() => {
+                this.connect(token);
+            }, 60000);
         }
     }
 
@@ -168,6 +167,10 @@ class NotificationService {
         this.reconnectAttempts = 0;
         this.isConnecting = false;
         this.connectionFailed = false;
+    }
+
+    resetConnection() {
+        this.disconnect();
     }
 
     // --- REST API Methods ---


### PR DESCRIPTION
﻿## Root Cause

The Nyay Saarthi WebSocket connection failure was caused by:

### 1. Conflicting WebSocket configuration (primary)
WebSocketConfig.java had both @EnableWebSocket AND @EnableWebSocketMessageBroker on the same class, causing the /api/ws/notifications handler to fail registration on production.

### 2. Aggressive auth timeout
NotificationWebSocketHandler.java had a 5-second auth timeout, too short for Render cold-starts.

### 3. Frontend permanent connection lock
NotificationService.js permanently blocked reconnection via connectionFailed flag, causing "stuck connecting" state.

### 4. Wrong WebSocket URL protocol
WS URL was built from window.location.protocol instead of the backend URL's protocol.

## Changes

Backend:
- Split WebSocket configs: separated raw @EnableWebSocket from @EnableWebSocketMessageBroker into two config classes
- Increased auth timeout from 5s to 15s
- Switched to setAllowedOriginPatterns("*") for better CORS compliance

Frontend:
- Fixed WebSocket URL to use backend protocol instead of frontend protocol
- Removed permanent connectionFailed lock; increased retries (3->10) with indefinite fallback
- Added resetConnection() method
- Improved error messages with i18n support
