### PR TITLE
Add RTL test for FileUnifiedPage stepper state preservation

### DIFF
--- a/frontend/nyaysetu-frontend/src/pages/litigant/FileUnifiedPage.test.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/FileUnifiedPage.test.jsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import FileUnifiedPage from './FileUnifiedPage';
+
+describe('FileUnifiedPage', () => {
+  it('preserves form state when navigating backwards', () => {
+    render(
+      <MemoryRouter>
+        <FileUnifiedPage />
+      </MemoryRouter>
+    );
+
+    // Step 1 - select case type
+    fireEvent.click(
+      screen.getByText('fileUnified.propertyDispute')
+    );
+
+    // Go to Step 2
+    fireEvent.click(
+      screen.getByText('fileUnified.next')
+    );
+
+    // Fill title field
+    const titleInput = screen.getAllByRole('textbox')[0];
+
+    fireEvent.change(titleInput, {
+      target: { value: 'Property Dispute Case' },
+    });
+
+    // Go back to Step 1
+    fireEvent.click(
+      screen.getByText('fileUnified.previous')
+    );
+
+    // Go forward again
+    fireEvent.click(
+      screen.getByText('fileUnified.next')
+    );
+
+    // Verify title is still there
+    expect(
+      screen.getAllByRole('textbox')[0]
+    ).toHaveValue('Property Dispute Case');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Added a React Testing Library (RTL) test for `FileUnifiedPage` to verify stepper navigation behavior.

The test ensures that:

* A case type can be selected in Step 1
* Navigation to Step 2 works correctly
* Form data entered in Step 2 is preserved after navigating back to Step 1
* Returning to Step 2 retains the previously entered data

Closes #739

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes

