### PR TITLE
test: add Mockito tests for notification events

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/notification/event/NotificationWebSocketEventListene
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/notification/event/NotificationWebSocketEventListene
@@ -1,0 +1,94 @@
+package com.nyaysetu.backend.notification.event;
+
+import com.nyaysetu.backend.handler.NotificationWebSocketHandler;
+import com.nyaysetu.backend.notification.entity.Notification;
+import com.nyaysetu.backend.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationWebSocketEventListenerTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationWebSocketHandler webSocketHandler;
+
+    @InjectMocks
+    private NotificationWebSocketEventListener listener;
+
+    @Test
+    void handleNotificationCreatedShouldSendWebSocketNotification() {
+        Notification notification = new Notification();
+        notification.setId(1L);
+        notification.setUserId(10L);
+        notification.setTitle("Case Update");
+        notification.setMessage("Your case has been updated");
+        notification.setCreatedAt(Instant.parse("2026-06-02T10:00:00Z"));
+        notification.setReadFlag(false);
+
+        when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
+
+        listener.handleNotificationCreated(new NotificationCreatedEvent(1L));
+
+        ArgumentCaptor<Map<String, Object>> payloadCaptor =
+                ArgumentCaptor.forClass(Map.class);
+
+        verify(webSocketHandler).sendNotification(eq(10L), payloadCaptor.capture());
+
+        Map<String, Object> payload = payloadCaptor.getValue();
+
+        assertEquals(1L, payload.get("id"));
+        assertEquals("Case Update", payload.get("title"));
+        assertEquals("Your case has been updated", payload.get("message"));
+        assertEquals("2026-06-02T10:00:00Z", payload.get("timestamp"));
+        assertEquals(false, payload.get("read"));
+    }
+
+    @Test
+    void handleNotificationCreatedShouldNotSendWhenEventIdIsNull() {
+        listener.handleNotificationCreated(new NotificationCreatedEvent(null));
+
+        verify(notificationRepository, never()).findById(anyLong());
+        verify(webSocketHandler, never()).sendNotification(anyLong(), anyMap());
+    }
+
+    @Test
+    void handleNotificationCreatedShouldNotSendWhenNotificationNotFound() {
+        when(notificationRepository.findById(1L)).thenReturn(Optional.empty());
+
+        listener.handleNotificationCreated(new NotificationCreatedEvent(1L));
+
+        verify(webSocketHandler, never()).sendNotification(anyLong(), anyMap());
+    }
+
+    @Test
+    void handleNotificationCreatedShouldNotSendWhenUserIdIsNull() {
+        Notification notification = new Notification();
+        notification.setId(1L);
+        notification.setUserId(null);
+
+        when(notificationRepository.findById(1L)).thenReturn(Optional.of(notification));
+
+        listener.handleNotificationCreated(new NotificationCreatedEvent(1L));
+
+        verify(webSocketHandler, never()).sendNotification(anyLong(), anyMap());
+    }
+}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/notification/service/NotificationServiceTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/notification/service/NotificationServiceTest.java
@@ -1,0 +1,49 @@
+package com.nyaysetu.backend.notification.service;
+
+import com.nyaysetu.backend.notification.entity.Notification;
+import com.nyaysetu.backend.notification.event.NotificationCreatedEvent;
+import com.nyaysetu.backend.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository repository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    void saveShouldPublishNotificationCreatedEvent() {
+        Notification notification = new Notification();
+        Notification savedNotification = new Notification();
+        savedNotification.setId(1L);
+
+        when(repository.save(notification)).thenReturn(savedNotification);
+
+        Notification result = notificationService.save(notification);
+
+        assertSame(savedNotification, result);
+
+        ArgumentCaptor<NotificationCreatedEvent> eventCaptor =
+                ArgumentCaptor.forClass(NotificationCreatedEvent.class);
+
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals(1L, eventCaptor.getValue().notificationId());
+    }
+}


### PR DESCRIPTION
## Description
Closes #740

Added Mockito unit tests for the notification flow.  
The tests verify that `NotificationService` publishes a `NotificationCreatedEvent` and that the WebSocket event listener dispatches the notification payload correctly.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
