### PR TITLE
test(sec): verify RBAC on API endpoints (#761)

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
@@ -1,0 +1,35 @@
+package com.nyaysetu.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class RbacSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "litigant@example.com", roles = {"LITIGANT"})
+    public void shouldDenyLitigantAccessToJudgeEndpoint() throws Exception {
+        mockMvc.perform(get("/api/v1/judge/cases"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "litigant@example.com", roles = {"LITIGANT"})
+    public void shouldDenyLitigantAccessToAdminEndpoint() throws Exception {
+        mockMvc.perform(get("/api/v1/cases/pending-assignment"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
This PR implements backend integration tests validating Role-Based Access Control (RBAC) boundaries. Using `@SpringBootTest`, `@AutoConfigureMockMvc`, and `@WithMockUser(roles = "LITIGANT")`, the tests verify that a user authenticated with a `LITIGANT` token receives a `403 Forbidden` response when attempting to access judge-only and admin-only endpoints.

Specifically, the following endpoints are verified:
- `GET /api/v1/judge/cases` (Judge only, restricted to: `JUDGE`, `SUPER_JUDGE`, `ADMIN`)
- `GET /api/v1/cases/pending-assignment` (Admin only, restricted to: `ADMIN`, `SUPER_JUDGE`, `TECH_ADMIN`)

Closes #761

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
