### PR TITLE
feat: cache node modules in github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'frontend/nyaysetu-frontend/package-lock.json'
 
       - name: Install Frontend Dependencies
         run: |


### PR DESCRIPTION
# Pull Request

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Added caching for Node.js modules in the GitHub Actions `deploy.yml` workflow using the `actions/setup-node` cache option. This significantly reduces the time spent installing frontend dependencies during CI runs.

Closes #858

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
