### PR TITLE
fix(auth): handle axios timeout errors separately from network failures

### DIFF
--- a/frontend/nyaysetu-frontend/src/utils/errorHandler.js
+++ b/frontend/nyaysetu-frontend/src/utils/errorHandler.js
@@ -1,4 +1,10 @@
 export const getErrorMessage = (error) => {
+    // Axios timeout error
+    if (error.code === "ECONNABORTED") {
+        return "Request timed out. The server took too long to respond. Please try again.";
+    }
+
+    // Genuine network error
     if (!error.response) {
         return "Network error. Please check your internet connection.";
     }


### PR DESCRIPTION
# Pull Request

## Description

Fixes incorrect error messaging for Axios timeout failures.

Closes #894

When a request exceeds the configured Axios timeout (`ECONNABORTED`), the application previously displayed:

"Network error. Please check your internet connection."

This was misleading because the user's internet connection may be working correctly and the actual issue is that the server took too long to respond.

This change adds explicit handling for timeout errors and displays:

"Request timed out. The server took too long to respond. Please try again."

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
