### PR TITLE
Fix: prevent DataLoader password overwrite for existing users

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/DataLoader.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/DataLoader.java
@@ -32,21 +32,27 @@ public class DataLoader implements CommandLineRunner {
 
     private void updateOrCreate(String email, String name, String pass, Role role) {
         var optionalUser = userRepository.findByEmail(email);
-        
+
         if (optionalUser.isPresent()) {
-            // User exists - UPDATE password
             User user = optionalUser.get();
-            user.setPassword(encoder.encode(pass));
-            userRepository.save(user);
-            log.debug("User already exists, password updated: {}", email);
+
+            // DO NOT overwrite password if already set
+            if (user.getPassword() == null || user.getPassword().isBlank()) {
+                user.setPassword(encoder.encode(pass));
+                userRepository.save(user);
+                log.debug("Password initialized for existing user: {}", email);
+            } else {
+                log.debug("User exists, not modifying password: {}", email);
+            }
+
         } else {
-            // User doesn't exist - CREATE
             User u = User.builder()
                     .email(email)
                     .name(name)
                     .password(encoder.encode(pass))
                     .role(role)
                     .build();
+
             userRepository.save(u);
             log.info("New user created: {}", email);
         }


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes a critical issue in the DataLoader where existing user passwords were being overwritten every time the application starts in non-production environments.

Previously, the CommandLineRunner updated passwords for all existing users regardless of whether they already had valid credentials. This caused unintended password resets during development/testing.

Fix implemented:

- Added a condition to update password only if it is null or blank
- Ensures existing user credentials are preserved
- New users are still created with encoded passwords as expected

Closes #989 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
