### PR TITLE
fix(security): disable stack traces in production API responses

### DIFF
--- a/backend/nyaysetu-backend/src/main/resources/application-prod.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application-prod.properties
@@ -32,3 +32,7 @@ jwt.expiration=${JWT_EXPIRATION_MS:36000000}
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=200MB
 spring.servlet.multipart.max-request-size=200MB
+# Security: prevent leaking internal error details in production
+server.error.include-message=never
+server.error.include-stacktrace=never
+server.error.include-binding-errors=never


### PR DESCRIPTION
# Pull Request

## Summary
This PR prevents leaking internal error details in production API responses.

## Changes
- Added Spring Boot production error configuration:
  - server.error.include-message=never
  - server.error.include-stacktrace=never
  - server.error.include-binding-errors=never

## Why
Stack traces and internal error messages can expose sensitive implementation details in production environments.

## Type
Security fix / configuration improvement