### PR TITLE
feat: centralize AI stream fault tolerance and recovery UI

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/AIAssistantModal.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/AIAssistantModal.jsx
@@ -4,12 +4,17 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { brainAPI } from '../../services/api';
+import StreamFallbackBanner from '../stream/StreamFallbackBanner';
+import {
+    downloadPartialStreamContent,
+    executeWithResilience,
+} from '../../utils/streamResilience';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 
 export default function AIAssistantModal({ isOpen, onClose }) {
-    
+
     const { t, i18n } = useTranslation('aiAssistant');
     const language = i18n.language;
     const [chatStarted, setChatStarted] = useState(false);
@@ -17,6 +22,13 @@ export default function AIAssistantModal({ isOpen, onClose }) {
     const [inputMessage, setInputMessage] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [sessionId, setSessionId] = useState(null);
+    const [assistantNetworkState, setAssistantNetworkState] = useState({
+    status: 'idle',
+    attempt: 0,
+    error: null,
+    lastRetryDelay: 0,
+    });
+    const lastPromptRef = useRef('');
     const messagesEndRef = useRef(null);
 
     const scrollToBottom = () => {
@@ -30,31 +42,93 @@ export default function AIAssistantModal({ isOpen, onClose }) {
             setMessages([]);
             setInputMessage('');
             setSessionId(null);
-        }
+            setAssistantNetworkState({
+                status: 'idle',
+                attempt: 0,
+                error: null,
+                lastRetryDelay: 0,
+            });
+            lastPromptRef.current = '';
+       }
     }, [isOpen]);
 
-    const sendMessage = async (text) => {
-        if (!text.trim()) return;
+    const savePartialAssistantChat = () => {
+    const content = messages
+        .map((msg) => `## ${msg.role === 'user' ? 'User' : 'AI Assistant'}\n\n${msg.content}`)
+        .join('\n\n---\n\n');
+
+    downloadPartialStreamContent('ai-assistant-partial-chat.md', content);
+};
+
+const sendMessage = async (text, { appendUserMessage = true } = {}) => {
+    if (!text.trim() || isLoading) return;
+
+    lastPromptRef.current = text;
+
+    if (appendUserMessage) {
         const userMessage = { role: 'user', content: text };
         setMessages(prev => [...prev, userMessage]);
         setInputMessage('');
-        setIsLoading(true);
-        try {
-            const response = await brainAPI.chat(text, sessionId);
-            const aiMessage = { role: 'ai', content: response.data.message };
-            setMessages(prev => [...prev, aiMessage]);
-            if (response.data.sessionId) setSessionId(response.data.sessionId);
-        } catch (error) {
-            console.error('AI Chat Error:', error);
-            const errorMessage = {
-                role: 'ai',
-                content: t('error')
-            };
-            setMessages(prev => [...prev, errorMessage]);
-        } finally {
-            setIsLoading(false);
-        }
-    };
+    }
+
+    setIsLoading(true);
+    setAssistantNetworkState({
+        status: 'connecting',
+        attempt: 0,
+        error: null,
+        lastRetryDelay: 0,
+    });
+
+    try {
+        const response = await executeWithResilience(
+            () => brainAPI.chat(text, sessionId),
+            {
+                breakerKey: 'landing-ai-assistant-chat',
+                maxRetries: 2,
+                baseDelayMs: 700,
+                maxDelayMs: 4000,
+                onRetry: ({ attempt, delay, error }) => {
+                    setAssistantNetworkState({
+                        status: 'reconnecting',
+                        attempt,
+                        error,
+                        lastRetryDelay: delay,
+                    });
+                },
+            }
+        );
+
+        const aiMessage = { role: 'ai', content: response.data.message };
+        setMessages(prev => [...prev, aiMessage]);
+
+        if (response.data.sessionId) setSessionId(response.data.sessionId);
+
+        setAssistantNetworkState({
+            status: 'completed',
+            attempt: 0,
+            error: null,
+            lastRetryDelay: 0,
+        });
+    } catch (error) {
+        console.error('AI Chat Error:', error);
+
+        setAssistantNetworkState({
+            status: 'failed',
+            attempt: 2,
+            error,
+            lastRetryDelay: 0,
+        });
+
+        const errorMessage = {
+            role: 'ai',
+            content: '⚠️ AI connection is currently unstable. Your chat is preserved. Please use Retry or Save partial.',
+        };
+
+        setMessages(prev => [...prev, errorMessage]);
+    } finally {
+        setIsLoading(false);
+    }
+};
 
     if (!isOpen) return null;
 
@@ -193,6 +267,18 @@ export default function AIAssistantModal({ isOpen, onClose }) {
                             flexDirection: 'column',
                             gap: '0'
                         }}>
+
+                        <StreamFallbackBanner
+    state={assistantNetworkState}
+    onRetry={() => {
+        if (lastPromptRef.current) {
+            sendMessage(lastPromptRef.current, { appendUserMessage: false });
+        }
+    }}
+    onSavePartial={savePartialAssistantChat}
+    hasPartialContent={messages.length > 0}
+/>
+
                             {/* Suggestions */}
                             {messages.length === 0 && (
                                 <div>

--- a/frontend/nyaysetu-frontend/src/components/stream/StreamFallbackBanner.jsx
+++ b/frontend/nyaysetu-frontend/src/components/stream/StreamFallbackBanner.jsx
@@ -1,0 +1,104 @@
+import { AlertTriangle, RotateCcw, Save } from 'lucide-react';
+
+export default function StreamFallbackBanner({
+    state,
+    onRetry,
+    onSavePartial,
+    hasPartialContent = false,
+}) {
+    if (!state || ['idle', 'streaming', 'completed'].includes(state.status)) {
+        return null;
+    }
+
+    const isFailed = state.status === 'failed';
+    const isReconnecting = state.status === 'reconnecting';
+
+    return (
+        <div
+            role="status"
+            style={{
+                marginBottom: '0.9rem',
+                padding: '0.85rem 1rem',
+                borderRadius: '0.85rem',
+                border: isFailed
+                    ? '1px solid rgba(239, 68, 68, 0.35)'
+                    : '1px solid rgba(245, 158, 11, 0.35)',
+                background: isFailed
+                    ? 'rgba(239, 68, 68, 0.08)'
+                    : 'rgba(245, 158, 11, 0.08)',
+                color: 'var(--text-main)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '0.75rem',
+                flexWrap: 'wrap',
+            }}
+        >
+            <div style={{ display: 'flex', gap: '0.65rem', alignItems: 'flex-start' }}>
+                <AlertTriangle
+                    size={18}
+                    color={isFailed ? '#ef4444' : '#f59e0b'}
+                    style={{ marginTop: '0.1rem', flexShrink: 0 }}
+                />
+
+                <div>
+                    <div style={{ fontWeight: 700, fontSize: '0.9rem' }}>
+                        {isFailed ? 'AI connection failed' : 'AI connection degraded'}
+                    </div>
+
+                    <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                        {isReconnecting
+                            ? `Retrying automatically. Attempt ${state.attempt}.`
+                            : 'Your current work is preserved. Retry or save partial content.'}
+                    </div>
+                </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                {hasPartialContent && (
+                    <button
+                        type="button"
+                        onClick={onSavePartial}
+                        style={{
+                            border: 'var(--border-glass)',
+                            background: 'var(--bg-glass)',
+                            color: 'var(--text-main)',
+                            borderRadius: '0.55rem',
+                            padding: '0.45rem 0.7rem',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.35rem',
+                            fontSize: '0.8rem',
+                        }}
+                    >
+                        <Save size={14} />
+                        Save partial
+                    </button>
+                )}
+
+                {isFailed && (
+                    <button
+                        type="button"
+                        onClick={onRetry}
+                        style={{
+                            border: 'none',
+                            background: 'var(--color-accent, var(--color-primary))',
+                            color: 'white',
+                            borderRadius: '0.55rem',
+                            padding: '0.45rem 0.7rem',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.35rem',
+                            fontSize: '0.8rem',
+                        }}
+                    >
+                        <RotateCcw size={14} />
+                        Retry
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/nyaysetu-frontend/src/hooks/useResilientStream.js
+++ b/frontend/nyaysetu-frontend/src/hooks/useResilientStream.js
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { consumeSSEStream, isAbortError } from '../utils/streamResilience';
+
+const initialState = {
+    status: 'idle',
+    attempt: 0,
+    error: null,
+    lastRetryDelay: 0,
+};
+
+const activeStatuses = new Set(['connecting', 'streaming', 'reconnecting']);
+
+export function useResilientStream({
+    breakerKey,
+    maxRetries = 3,
+} = {}) {
+    const abortRef = useRef(null);
+    const [streamState, setStreamState] = useState(initialState);
+
+    const cancel = useCallback(() => {
+        if (abortRef.current) {
+            abortRef.current.abort();
+            abortRef.current = null;
+        }
+
+        setStreamState((prev) =>
+            activeStatuses.has(prev.status) ? { ...prev, status: 'idle' } : prev
+        );
+    }, []);
+
+    const start = useCallback(
+        async ({ request, onEvent, onComplete, onFailure, onRetry }) => {
+            cancel();
+
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            setStreamState({
+                status: 'connecting',
+                attempt: 0,
+                error: null,
+                lastRetryDelay: 0,
+            });
+
+            try {
+                await consumeSSEStream({
+                    request,
+                    signal: controller.signal,
+                    breakerKey,
+                    maxRetries,
+                    onOpen: ({ attempt }) => {
+                        setStreamState({
+                            status: 'streaming',
+                            attempt,
+                            error: null,
+                            lastRetryDelay: 0,
+                        });
+                    },
+                    onRetry: ({ attempt, delay, error }) => {
+                        setStreamState({
+                            status: 'reconnecting',
+                            attempt,
+                            error,
+                            lastRetryDelay: delay,
+                        });
+
+                        onRetry?.({ attempt, delay, error });
+                    },
+                    onEvent,
+                    onComplete: () => {
+                        setStreamState({
+                            status: 'completed',
+                            attempt: 0,
+                            error: null,
+                            lastRetryDelay: 0,
+                        });
+
+                        onComplete?.();
+                    },
+                });
+            } catch (error) {
+                if (isAbortError(error)) {
+                    setStreamState({
+                        status: 'idle',
+                        attempt: 0,
+                        error: null,
+                        lastRetryDelay: 0,
+                    });
+                    return;
+                }
+
+                setStreamState({
+                    status: 'failed',
+                    attempt: maxRetries,
+                    error,
+                    lastRetryDelay: 0,
+                });
+
+                onFailure?.(error);
+            } finally {
+                abortRef.current = null;
+            }
+        },
+        [breakerKey, cancel, maxRetries]
+    );
+
+    useEffect(() => cancel, [cancel]);
+
+    return {
+        streamState,
+        start,
+        cancel,
+        isStreaming: activeStatuses.has(streamState.status),
+    };
+}

--- a/frontend/nyaysetu-frontend/src/pages/lawyer/AILegalAssistantPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/lawyer/AILegalAssistantPage.jsx
@@ -2,11 +2,9 @@ import { useState, useRef, useEffect } from "react";
 import {
   Brain,
   Sparkles,
-  Search,
   FileText,
   MessageSquare,
   History,
-  ChevronRight,
   Loader2,
   Send,
   Scaling,
@@ -17,6 +15,11 @@ import {
   Volume2,
 } from "lucide-react";
 import { brainAPI } from "../../services/api";
+import StreamFallbackBanner from "../../components/stream/StreamFallbackBanner";
+import {
+  downloadPartialStreamContent,
+  executeWithResilience,
+} from "../../utils/streamResilience";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -28,17 +31,26 @@ export default function AILegalAssistantPage() {
         '🙏 Greetings, Counselor. I am your Smart Legal Strategist.\n\nI have access to your **Active Case Portfolio** and **Hearing Schedule**. I can assist with:\n\n1. **Schedule Planning**: "What hearings do I have this week?"\n2. **Case Strategy**: "Draft a strategy for the Theft case."\n3. **Legal Research**: "Summarize BNS Section 302."\n\nHow can I help you today?',
     },
   ]);
+
   const [input, setInput] = useState("");
   const MAX_CHARACTERS = 1000;
   const characterCount = input.length;
   const isLimitExceeded = characterCount > MAX_CHARACTERS;
+
   const [loading, setLoading] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [speakingIndex, setSpeakingIndex] = useState(null);
+  const [assistantNetworkState, setAssistantNetworkState] = useState({
+    status: "idle",
+    attempt: 0,
+    error: null,
+    lastRetryDelay: 0,
+  });
+
+  const lastAssistantPromptRef = useRef("");
   const scrollRef = useRef(null);
   const mediaRecorderRef = useRef(null);
 
-  // Browser Native Speech Recognition
   const startRecording = () => {
     if (
       !("webkitSpeechRecognition" in window) &&
@@ -52,7 +64,7 @@ export default function AILegalAssistantPage() {
       window.SpeechRecognition || window.webkitSpeechRecognition;
     const recognition = new SpeechRecognition();
 
-    recognition.lang = "en-IN"; // Default to Indian English for Lawyers
+    recognition.lang = "en-IN";
     recognition.interimResults = false;
     recognition.maxAlternatives = 1;
 
@@ -79,7 +91,6 @@ export default function AILegalAssistantPage() {
     }
   };
 
-  // Text to Speech
   const speakText = (text, index) => {
     if (!("speechSynthesis" in window)) return;
 
@@ -106,27 +117,83 @@ export default function AILegalAssistantPage() {
     }
   }, [messages]);
 
-  const handleSend = async () => {
-    if (!input.trim() || loading || isLimitExceeded) return;
+  const saveAssistantChatSnapshot = () => {
+    const content = messages
+      .map(
+        (msg) =>
+          `## ${msg.role === "user" ? "User" : "AI Legal Assistant"}\n\n${msg.content}`,
+      )
+      .join("\n\n---\n\n");
 
-    const userMsg = input;
-    setInput("");
-    setMessages((prev) => [...prev, { role: "user", content: userMsg }]);
+    downloadPartialStreamContent("ai-legal-assistant-partial-chat.md", content);
+  };
+
+  const handleSend = async (
+    retryMessage = null,
+    { appendUserMessage = true } = {},
+  ) => {
+    const userMsg = typeof retryMessage === "string" ? retryMessage : input;
+
+    if (!userMsg.trim() || loading || isLimitExceeded) return;
+
+    lastAssistantPromptRef.current = userMsg;
+
+    if (appendUserMessage) {
+      setInput("");
+      setMessages((prev) => [...prev, { role: "user", content: userMsg }]);
+    }
+
     setLoading(true);
+    setAssistantNetworkState({
+      status: "connecting",
+      attempt: 0,
+      error: null,
+      lastRetryDelay: 0,
+    });
 
     try {
-      const response = await brainAPI.chat(userMsg);
+      const response = await executeWithResilience(() => brainAPI.chat(userMsg), {
+        breakerKey: "lawyer-ai-legal-assistant-chat",
+        maxRetries: 2,
+        baseDelayMs: 700,
+        maxDelayMs: 4000,
+        onRetry: ({ attempt, delay, error }) => {
+          setAssistantNetworkState({
+            status: "reconnecting",
+            attempt,
+            error,
+            lastRetryDelay: delay,
+          });
+        },
+      });
+
       setMessages((prev) => [
         ...prev,
         { role: "assistant", content: response.data.message },
       ]);
+
+      setAssistantNetworkState({
+        status: "completed",
+        attempt: 0,
+        error: null,
+        lastRetryDelay: 0,
+      });
     } catch (error) {
+      console.error("AI Legal Assistant error:", error);
+
+      setAssistantNetworkState({
+        status: "failed",
+        attempt: 2,
+        error,
+        lastRetryDelay: 0,
+      });
+
       setMessages((prev) => [
         ...prev,
         {
           role: "assistant",
           content:
-            "⚠️ Connection to AI Brain was interrupted. Please check your network.",
+            "⚠️ AI connection is currently unstable. Your chat is preserved. Please use Retry or Save partial.",
         },
       ]);
     } finally {
@@ -168,7 +235,6 @@ export default function AILegalAssistantPage() {
         flexDirection: "column",
       }}
     >
-      {/* Header */}
       <div style={{ marginBottom: "2rem", flexShrink: 0 }}>
         <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
           <div
@@ -219,7 +285,6 @@ export default function AILegalAssistantPage() {
           minHeight: 0,
         }}
       >
-        {/* Chat Column */}
         <div
           style={{
             ...glassStyle,
@@ -229,7 +294,6 @@ export default function AILegalAssistantPage() {
             overflow: "hidden",
           }}
         >
-          {/* Chat Messages */}
           <div
             ref={scrollRef}
             style={{
@@ -241,6 +305,19 @@ export default function AILegalAssistantPage() {
               gap: "1.25rem",
             }}
           >
+            <StreamFallbackBanner
+              state={assistantNetworkState}
+              onRetry={() => {
+                if (lastAssistantPromptRef.current) {
+                  handleSend(lastAssistantPromptRef.current, {
+                    appendUserMessage: false,
+                  });
+                }
+              }}
+              onSavePartial={saveAssistantChatSnapshot}
+              hasPartialContent={messages.length > 1}
+            />
+
             {messages.map((msg, i) => (
               <div
                 key={i}
@@ -268,6 +345,7 @@ export default function AILegalAssistantPage() {
                     <Sparkles size={20} color="var(--color-accent)" />
                   </div>
                 )}
+
                 <div
                   style={{
                     maxWidth: "80%",
@@ -296,6 +374,7 @@ export default function AILegalAssistantPage() {
                       {msg.content}
                     </ReactMarkdown>
                   </div>
+
                   {msg.role === "assistant" && (
                     <button
                       onClick={() => speakText(msg.content, i)}
@@ -327,6 +406,7 @@ export default function AILegalAssistantPage() {
                 </div>
               </div>
             ))}
+
             {loading && (
               <div style={{ display: "flex", gap: "1rem" }}>
                 <div
@@ -362,7 +442,6 @@ export default function AILegalAssistantPage() {
             )}
           </div>
 
-          {/* Chat Input */}
           <div
             style={{
               padding: "1.5rem",
@@ -398,7 +477,7 @@ export default function AILegalAssistantPage() {
                   justifyContent: "center",
                   transition: "all 0.2s",
                   flexShrink: 0,
-                  marginBottom: "2px", // Align with input
+                  marginBottom: "2px",
                   animation: isRecording ? "pulse 1.5s infinite" : "none",
                 }}
               >
@@ -409,7 +488,7 @@ export default function AILegalAssistantPage() {
                 <textarea
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
-                  onKeyPress={(e) =>
+                  onKeyDown={(e) =>
                     e.key === "Enter" &&
                     !e.shiftKey &&
                     (e.preventDefault(), handleSend())
@@ -418,23 +497,26 @@ export default function AILegalAssistantPage() {
                   style={{
                     width: "100%",
                     background: "var(--bg-glass)",
-                    border: "var(--border-glass)",
+                    border: isLimitExceeded
+                      ? "1px solid #ef4444"
+                      : "var(--border-glass)",
                     borderRadius: "1rem",
                     padding: "1rem 3.5rem 1rem 1.25rem",
                     color: "var(--text-main)",
                     outline: "none",
                     fontSize: "1rem",
                     resize: "none",
-                    height: "80px", // Fixed height match
+                    height: "80px",
                   }}
                 />
+
                 <button
-                  onClick={handleSend}
+                  onClick={() => handleSend()}
                   disabled={!input.trim() || loading || isLimitExceeded}
                   style={{
                     position: "absolute",
                     right: "1rem",
-                    bottom: "1rem",
+                    bottom: "2.25rem",
                     width: "36px",
                     height: "36px",
                     borderRadius: "8px",
@@ -445,51 +527,54 @@ export default function AILegalAssistantPage() {
                         : "var(--bg-glass-subtle)",
                     border: "none",
                     color: "white",
-                    cursor: input.trim() ? "pointer" : "not-allowed",
+                    cursor:
+                      input.trim() && !loading && !isLimitExceeded
+                        ? "pointer"
+                        : "not-allowed",
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
                     transition: "all 0.2s",
                   }}
                 >
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      marginTop: "0.5rem",
-                      fontSize: "0.85rem",
-                    }}
-                  >
-                    <span
-                      style={{
-                        color: isLimitExceeded
-                          ? "#ef4444"
-                          : "var(--text-secondary)",
-                        fontWeight: isLimitExceeded ? "600" : "400",
-                      }}
-                    >
-                      {isLimitExceeded ? "Character limit exceeded!" : ""}
-                    </span>
-
-                    <span
-                      style={{
-                        color: isLimitExceeded
-                          ? "#ef4444"
-                          : "var(--text-secondary)",
-                      }}
-                    >
-                      {characterCount}/{MAX_CHARACTERS}
-                    </span>
-                  </div>
                   <Send size={18} />
                 </button>
+
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    marginTop: "0.5rem",
+                    fontSize: "0.85rem",
+                  }}
+                >
+                  <span
+                    style={{
+                      color: isLimitExceeded
+                        ? "#ef4444"
+                        : "var(--text-secondary)",
+                      fontWeight: isLimitExceeded ? "600" : "400",
+                    }}
+                  >
+                    {isLimitExceeded ? "Character limit exceeded!" : ""}
+                  </span>
+
+                  <span
+                    style={{
+                      color: isLimitExceeded
+                        ? "#ef4444"
+                        : "var(--text-secondary)",
+                    }}
+                  >
+                    {characterCount}/{MAX_CHARACTERS}
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
 
-        {/* Sidebar Column */}
         <div
           style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
         >
@@ -617,18 +702,30 @@ export default function AILegalAssistantPage() {
           </div>
         </div>
       </div>
+
       <style>{`
-                @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-                @keyframes pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
-                .spin { animation: spin 1s linear infinite; }
-                
-                /* Markdown Styling */
-                .markdown-content p { margin-bottom: 0.5rem; }
-                .markdown-content ul, .markdown-content ol { padding-left: 1.2rem; margin-bottom: 0.5rem; }
-                .markdown-content li { margin-bottom: 0.2rem; }
-                .markdown-content strong { color: var(--color-accent); font-weight: 700; }
-                .markdown-content code { background: rgba(0,0,0,0.2); padding: 0.1rem 0.3rem; borderRadius: 4px; fontFamily: monospace; }
-            `}</style>
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @keyframes pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
+        .spin { animation: spin 1s linear infinite; }
+
+        .markdown-content p { margin-bottom: 0.5rem; }
+        .markdown-content ul,
+        .markdown-content ol {
+          padding-left: 1.2rem;
+          margin-bottom: 0.5rem;
+        }
+        .markdown-content li { margin-bottom: 0.2rem; }
+        .markdown-content strong {
+          color: var(--color-accent);
+          font-weight: 700;
+        }
+        .markdown-content code {
+          background: rgba(0,0,0,0.2);
+          padding: 0.1rem 0.3rem;
+          border-radius: 4px;
+          font-family: monospace;
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/nyaysetu-frontend/src/pages/litigant/VakilFriendPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/VakilFriendPage.jsx
@@ -1,5 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useResilientStream } from '../../hooks/useResilientStream';
+import StreamFallbackBanner from '../../components/stream/StreamFallbackBanner';
+import { downloadPartialStreamContent } from '../../utils/streamResilience';
 import { Send, Bot, User, CheckCircle, ArrowLeft, Loader2, History, Plus, MessageSquare, Paperclip, Scan, FileText, X, Mic, StopCircle, Volume2, Shield, AlertTriangle, CheckCircle2, Eye, UserCircle2 } from 'lucide-react';
 import { vakilFriendAPI } from '../../services/api';
 import axios from 'axios';
@@ -41,7 +44,16 @@ export default function VakilFriendChat() {
     const [reasoningStages, setReasoningStages] = useState({});
     const [reasoningText, setReasoningText] = useState('');
     const [kanoonResults, setKanoonResults] = useState([]);
-    const deepResearchAbortRef = useRef(null);
+    const lastDeepResearchQueryRef = useRef(null);
+
+const {
+    streamState: deepResearchStreamState,
+    start: startResilientDeepResearch,
+    cancel: cancelDeepResearchStream,
+} = useResilientStream({
+    breakerKey: 'vakil-friend-deep-research',
+    maxRetries: 3,
+});
 
     // Wake Word Buffers
     const commandBufferRef = useRef('');
@@ -319,62 +331,81 @@ export default function VakilFriendChat() {
     };
 
     // Deep Research SSE Connection
-    const startDeepResearch = async (query) => {
-        // Abort any previous deep research
-        if (deepResearchAbortRef.current) {
-            deepResearchAbortRef.current.abort();
-        }
+    const savePartialResearchSnapshot = () => {
+    const stageSummary = Object.entries(reasoningStages)
+        .map(([stage, details]) => `- ${stage}: ${details.status} — ${details.message || ''}`)
+        .join('\n');
 
-        const abortController = new AbortController();
-        deepResearchAbortRef.current = abortController;
+    const kanoonSummary = kanoonResults
+        .map((result) => `- ${result.title || 'Untitled'} ${result.doc_id ? `(Doc: ${result.doc_id})` : ''}`)
+        .join('\n');
 
-        // Reset state
-        setIsDeepResearching(true);
-        setReasoningStages({});
-        setReasoningText('');
-        setKanoonResults([]);
+    const content = [
+        '# Partial Deep Legal Research',
+        '',
+        `Query: ${lastDeepResearchQueryRef.current || 'Unknown'}`,
+        '',
+        '## Reasoning Stages',
+        stageSummary || 'No stages captured yet.',
+        '',
+        '## Reasoning Text',
+        reasoningText || 'No reasoning text captured yet.',
+        '',
+        '## Kanoon Results',
+        kanoonSummary || 'No Kanoon results captured yet.',
+    ].join('\n');
 
-        try {
-            const nlpBaseUrl = import.meta.env.VITE_NLP_BASE_URL || 'http://localhost:8001';
-            const response = await fetch(`${nlpBaseUrl}/research/deep`, {
+    downloadPartialStreamContent('partial-deep-legal-research.md', content);
+};
+
+// Deep Research SSE Connection
+const startDeepResearch = async (query) => {
+    lastDeepResearchQueryRef.current = query;
+
+    setIsDeepResearching(true);
+    setReasoningStages({});
+    setReasoningText('');
+    setKanoonResults([]);
+    setError(null);
+
+    const nlpBaseUrl = import.meta.env.VITE_NLP_BASE_URL || 'http://localhost:8001';
+
+    await startResilientDeepResearch({
+        request: ({ signal }) =>
+            fetch(`${nlpBaseUrl}/research/deep`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ query, language }),
-                signal: abortController.signal
-            });
+                signal,
+            }),
 
-            const reader = response.body.getReader();
-            const decoder = new TextDecoder();
-            let buffer = '';
+        onEvent: handleDeepResearchEvent,
 
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
+        onRetry: () => {
+            setError('AI research stream degraded. Reconnecting without clearing your current result...');
+        },
 
-                buffer += decoder.decode(value, { stream: true });
-                const lines = buffer.split('\n');
-                buffer = lines.pop(); // Keep incomplete line in buffer
-
-                for (const line of lines) {
-                    if (line.startsWith('data: ')) {
-                        try {
-                            const data = JSON.parse(line.slice(6));
-                            handleDeepResearchEvent(data);
-                        } catch (e) {
-                            // Ignore JSON parse errors for partial data
-                        }
-                    }
-                }
-            }
-        } catch (err) {
-            if (err.name !== 'AbortError') {
-                console.error('Deep research error:', err);
-                setError(t('vakilFriend.deepResearchError'));
-            }
-        } finally {
+        onComplete: () => {
             setIsDeepResearching(false);
-        }
-    };
+            setError(null);
+        },
+
+        onFailure: (err) => {
+            console.error('Deep research error:', err);
+            setIsDeepResearching(false);
+            setError(t('vakilFriend.deepResearchError'));
+
+            setMessages(prev => [
+                ...prev,
+                {
+                    role: 'assistant',
+                    content:
+                        '⚠️ Deep research stream was interrupted. Your partial reasoning is preserved. Please use Retry to reconnect or Save partial to download the current result.',
+                },
+            ]);
+        },
+    });
+};
 
     const handleDeepResearchEvent = (data) => {
         const { type, ...payload } = data;
@@ -1889,10 +1920,25 @@ export default function VakilFriendChat() {
                     flexDirection: 'column',
                     minHeight: '600px', // matches chat height roughly
                 }}>
+           <StreamFallbackBanner
+    state={deepResearchStreamState}
+    onRetry={() => {
+        if (lastDeepResearchQueryRef.current) {
+            startDeepResearch(lastDeepResearchQueryRef.current);
+        }
+    }}
+    onSavePartial={savePartialResearchSnapshot}
+    hasPartialContent={
+        Boolean(reasoningText) ||
+        kanoonResults.length > 0 ||
+        Object.keys(reasoningStages).length > 0
+    }
+/>
                     {/* Render Avatar Panel inline, removing its portal wrapper later or handling it specially */}
                     <AvatarPanel
                         state={avatarState}
                         onClose={() => {
+                            cancelDeepResearchStream();
                             setShowAvatar(false);
                             window.speechSynthesis.cancel();
 

--- a/frontend/nyaysetu-frontend/src/utils/streamResilience.js
+++ b/frontend/nyaysetu-frontend/src/utils/streamResilience.js
@@ -1,0 +1,259 @@
+const breakerRegistry = new Map();
+
+export const CIRCUIT_STATE = {
+    CLOSED: 'closed',
+    OPEN: 'open',
+    HALF_OPEN: 'half-open',
+};
+
+export class StreamResilienceError extends Error {
+    constructor(message, options = {}) {
+        super(message);
+        this.name = 'StreamResilienceError';
+        this.status = options.status;
+        this.cause = options.cause;
+        this.retryable = options.retryable ?? true;
+    }
+}
+
+export class CircuitBreaker {
+    constructor({ failureThreshold = 3, cooldownMs = 30000 } = {}) {
+        this.failureThreshold = failureThreshold;
+        this.cooldownMs = cooldownMs;
+        this.state = CIRCUIT_STATE.CLOSED;
+        this.failureCount = 0;
+        this.openedAt = null;
+    }
+
+    canRequest() {
+        if (this.state !== CIRCUIT_STATE.OPEN) return true;
+
+        const elapsed = Date.now() - this.openedAt;
+        if (elapsed >= this.cooldownMs) {
+            this.state = CIRCUIT_STATE.HALF_OPEN;
+            return true;
+        }
+
+        return false;
+    }
+
+    recordSuccess() {
+        this.state = CIRCUIT_STATE.CLOSED;
+        this.failureCount = 0;
+        this.openedAt = null;
+    }
+
+    recordFailure() {
+        this.failureCount += 1;
+
+        if (this.failureCount >= this.failureThreshold) {
+            this.state = CIRCUIT_STATE.OPEN;
+            this.openedAt = Date.now();
+        }
+    }
+}
+
+export const getCircuitBreaker = (key = 'default-stream', options = {}) => {
+    if (!breakerRegistry.has(key)) {
+        breakerRegistry.set(key, new CircuitBreaker(options));
+    }
+
+    return breakerRegistry.get(key);
+};
+
+export const resetCircuitBreaker = (key) => {
+    if (key) {
+        breakerRegistry.delete(key);
+        return;
+    }
+
+    breakerRegistry.clear();
+};
+
+export const sleep = (ms) =>
+    new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+
+export const getBackoffDelay = (
+    attempt,
+    { baseDelayMs = 800, maxDelayMs = 8000, jitter = true } = {}
+) => {
+    const exponentialDelay = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+    const jitterAmount = jitter ? Math.floor(Math.random() * 250) : 0;
+    return exponentialDelay + jitterAmount;
+};
+
+export const isAbortError = (error) => error?.name === 'AbortError';
+
+export const isRetryableError = (error) => {
+    if (!error || isAbortError(error)) return false;
+
+    const status = error.status || error.response?.status;
+
+    if (!status) return true;
+
+    return status === 408 || status === 429 || status >= 500;
+};
+
+export async function executeWithResilience(
+    operation,
+    {
+        breakerKey = 'default-operation',
+        breakerOptions,
+        maxRetries = 2,
+        baseDelayMs = 800,
+        maxDelayMs = 8000,
+        jitter = true,
+        onRetry,
+        onCircuitOpen,
+    } = {}
+) {
+    const breaker = getCircuitBreaker(breakerKey, breakerOptions);
+
+    if (!breaker.canRequest()) {
+        onCircuitOpen?.(breaker);
+
+        throw new StreamResilienceError(
+            'Circuit breaker is open. Please retry after a short cooldown.',
+            { retryable: true }
+        );
+    }
+
+    let lastError;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+        try {
+            const result = await operation({ attempt });
+            breaker.recordSuccess();
+            return result;
+        } catch (error) {
+            lastError = error;
+
+            if (!isRetryableError(error) || attempt === maxRetries) {
+                breaker.recordFailure();
+                throw error;
+            }
+
+            const delay = getBackoffDelay(attempt, {
+                baseDelayMs,
+                maxDelayMs,
+                jitter,
+            });
+
+            onRetry?.({ attempt: attempt + 1, delay, error });
+            await sleep(delay);
+        }
+    }
+
+    breaker.recordFailure();
+    throw lastError;
+}
+
+const parseSseLine = (line) => {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith(':')) return null;
+    if (!trimmed.startsWith('data:')) return null;
+
+    const payload = trimmed.replace(/^data:\s?/, '');
+
+    if (!payload || payload === '[DONE]') return null;
+
+    return JSON.parse(payload);
+};
+
+export async function consumeSSEStream({
+    request,
+    signal,
+    breakerKey = 'default-sse-stream',
+    maxRetries = 3,
+    onOpen,
+    onEvent,
+    onRawChunk,
+    onRetry,
+    onComplete,
+    onParseError,
+}) {
+    return executeWithResilience(
+        async ({ attempt }) => {
+            const response = await request({ signal, attempt });
+
+            if (!response.ok) {
+                throw new StreamResilienceError(
+                    `Stream request failed with status ${response.status}`,
+                    { status: response.status }
+                );
+            }
+
+            if (!response.body) {
+                throw new StreamResilienceError('Stream response body is empty');
+            }
+
+            onOpen?.({ attempt });
+
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+
+            while (true) {
+                if (signal?.aborted) {
+                    throw new DOMException('Stream aborted', 'AbortError');
+                }
+
+                const { done, value } = await reader.read();
+
+                if (done) break;
+
+                onRawChunk?.(value);
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split(/\r?\n/);
+                buffer = lines.pop() || '';
+
+                for (const line of lines) {
+                    try {
+                        const event = parseSseLine(line);
+                        if (event) onEvent?.(event);
+                    } catch (error) {
+                        onParseError?.({ line, error });
+                    }
+                }
+            }
+
+            if (buffer.trim()) {
+                try {
+                    const event = parseSseLine(buffer);
+                    if (event) onEvent?.(event);
+                } catch (error) {
+                    onParseError?.({ line: buffer, error });
+                }
+            }
+
+            onComplete?.();
+            return true;
+        },
+        {
+            breakerKey,
+            maxRetries,
+            onRetry,
+        }
+    );
+}
+
+export const downloadPartialStreamContent = (
+    filename,
+    content,
+    mimeType = 'text/markdown'
+) => {
+    const blob = new Blob([content || 'No partial content available.'], {
+        type: mimeType,
+    });
+
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+
+    URL.revokeObjectURL(url);
+};

--- a/frontend/nyaysetu-frontend/src/utils/streamResilience.test.js
+++ b/frontend/nyaysetu-frontend/src/utils/streamResilience.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    CircuitBreaker,
+    CIRCUIT_STATE,
+    executeWithResilience,
+    getBackoffDelay,
+    isRetryableError,
+    resetCircuitBreaker,
+} from './streamResilience';
+
+describe('streamResilience utilities', () => {
+    beforeEach(() => {
+        resetCircuitBreaker();
+        vi.restoreAllMocks();
+    });
+
+    it('calculates exponential backoff with max delay', () => {
+        expect(
+            getBackoffDelay(0, {
+                baseDelayMs: 1000,
+                maxDelayMs: 10000,
+                jitter: false,
+            })
+        ).toBe(1000);
+
+        expect(
+            getBackoffDelay(2, {
+                baseDelayMs: 1000,
+                maxDelayMs: 10000,
+                jitter: false,
+            })
+        ).toBe(4000);
+
+        expect(
+            getBackoffDelay(5, {
+                baseDelayMs: 1000,
+                maxDelayMs: 8000,
+                jitter: false,
+            })
+        ).toBe(8000);
+    });
+
+    it('marks network and server errors as retryable', () => {
+        expect(isRetryableError(new Error('Network failed'))).toBe(true);
+        expect(isRetryableError({ status: 429 })).toBe(true);
+        expect(isRetryableError({ status: 503 })).toBe(true);
+        expect(isRetryableError({ status: 400 })).toBe(false);
+        expect(isRetryableError({ name: 'AbortError' })).toBe(false);
+    });
+
+    it('opens the circuit after repeated failures', () => {
+        const breaker = new CircuitBreaker({
+            failureThreshold: 2,
+            cooldownMs: 30000,
+        });
+
+        expect(breaker.canRequest()).toBe(true);
+
+        breaker.recordFailure();
+        expect(breaker.state).toBe(CIRCUIT_STATE.CLOSED);
+
+        breaker.recordFailure();
+        expect(breaker.state).toBe(CIRCUIT_STATE.OPEN);
+        expect(breaker.canRequest()).toBe(false);
+    });
+
+    it('retries retryable operations before succeeding', async () => {
+        const operation = vi
+            .fn()
+            .mockRejectedValueOnce({ status: 503 })
+            .mockResolvedValueOnce('ok');
+
+        await expect(
+            executeWithResilience(operation, {
+                breakerKey: 'retry-test',
+                maxRetries: 1,
+                baseDelayMs: 0,
+                maxDelayMs: 0,
+                jitter: false,
+            })
+        ).resolves.toBe('ok');
+
+        expect(operation).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry non-retryable client errors', async () => {
+        const operation = vi.fn().mockRejectedValue({ status: 400 });
+
+        await expect(
+            executeWithResilience(operation, {
+                breakerKey: 'client-error-test',
+                maxRetries: 2,
+                baseDelayMs: 0,
+                maxDelayMs: 0,
+                jitter: false,
+            })
+        ).rejects.toEqual({ status: 400 });
+
+        expect(operation).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description
Implemented centralized AI stream/network fault tolerance and recovery handling for AI assistant flows.

This PR adds a reusable resilience layer with exponential backoff retry, retryable error detection, circuit breaker handling, reusable SSE stream consumption, and partial content download support. It also adds a shared fallback UI so users can retry failed AI requests or save partial chat/research content instead of losing progress.

Integrated the resilience flow into:
- Landing `AIAssistantModal`
- Lawyer `AILegalAssistantPage`
- Litigant `VakilFriendPage` deep research SSE flow

Closes #997 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
**Before:**
- Generic AI failure message only
- No retry action
- No save-partial option
- No centralized fallback UI
<img width="1919" height="951" alt="image" src="https://github.com/user-attachments/assets/3aef8f90-7fb9-4e09-a6bb-eed7758b73e3" />
<br></br>
<img width="1919" height="951" alt="image" src="https://github.com/user-attachments/assets/00102889-cd4e-42d3-ab64-417ce73c8295" />
<br></br>


**After:**
- AI connection failure banner
<img width="1917" height="945" alt="image" src="https://github.com/user-attachments/assets/3e2827e5-eef0-451b-a4b3-35fb57765e2f" />
<br></br>

- Retry button
<img width="1918" height="943" alt="image" src="https://github.com/user-attachments/assets/1f54c1d1-c4c5-4015-a463-899441125211" />
<br></br>

- Save partial button
<img width="1896" height="926" alt="image" src="https://github.com/user-attachments/assets/c42ad3bb-7ff8-4b80-875d-f701a9f8482d" />
<br></br>

- Downloaded markdown preserves partial chat content
<img width="1772" height="883" alt="image" src="https://github.com/user-attachments/assets/382bcd50-afe4-44ac-82cc-0d6dedd61f84" />
<br></br>

## Testing
- [x] `npm run build`
- [x] `npx vitest run src/pages/lawyer/AILegalAssistantPage.test.jsx --pool=threads --reporter=verbose`
- [x] `npx vitest run src/utils/streamResilience.test.js --pool=threads --reporter=verbose`
- [x] Manually simulated unavailable/blocked AI backend
- [x] Verified fallback banner appears
- [x] Verified Retry action
- [x] Verified Save partial markdown download

Note: Existing Vite chunk-size warnings may appear during build, but no new build/test failures were introduced by this PR.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Documentation update not required for this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes