### PR TITLE
fix: Duplicate Call-to-Action Buttons Leading to Same Action

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
@@ -464,7 +464,7 @@ export default function Header({ hideAuthButtons = false }) {
                                     onMouseEnter={e => { e.currentTarget.style.background = 'var(--color-primary-hover)'; e.currentTarget.style.transform = 'translateY(-1px)'; }}
                                     onMouseLeave={e => { e.currentTarget.style.background = 'var(--color-primary)'; e.currentTarget.style.transform = 'translateY(0)'; }}
                                 >
-                                    {t('header.cta.getStarted')}
+                                    {t('header.cta.signup')}
                                 </Link>
                             </>
                         )}
@@ -699,7 +699,7 @@ export default function Header({ hideAuthButtons = false }) {
                                             {t('header.cta.login')}
                                         </Link>
                                         <Link to="/signup" onClick={() => setIsMobileMenuOpen(false)} style={{ padding: '0.75rem', textAlign: 'center', background: 'var(--color-primary)', color: 'white', textDecoration: 'none', borderRadius: '10px', fontWeight: '600' }}>
-                                            {t('header.cta.getStarted')}
+                                            {t('header.cta.signup')}
                                         </Link>
                                     </>
                                 )}


### PR DESCRIPTION
Description
The landing page showed two CTA buttons with near-identical labels that both linked to /signup:

Hero section — "Get Started Free" (/signup)
Navbar — "Get Started" (/signup)
Because the navbar already has a separate "Login" button, the second navbar button reading "Get Started" duplicated the hero's primary CTA and made it unclear to users whether the two led anywhere different.

This PR repurposes the navbar button's label to "Sign Up" (reusing the already-existing, fully-translated header.cta.signup key). The navbar now reads "Login | Sign Up" — a clear, standard account-access pair — while the hero retains "Get Started Free" as the single emphasized primary marketing CTA. The buttons now communicate distinct purposes (persistent account access vs. primary conversion CTA) instead of appearing as two competing copies of the same action.

Both the desktop navbar and the mobile drawer button were updated for consistency. The /signup destination is intentionally unchanged, preserving the single primary conversion path.

Closes #1014