### PR TITLE
chore: improve PostgreSQL healthcheck readiness in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 10s
 
   # 2. Backend (Spring Boot)
   backend-spring:


### PR DESCRIPTION
### Fixes #855 

## Description

### Summary

This PR improves the PostgreSQL healthcheck configuration in `docker-compose.yml` by adding a `start_period` value to allow the database sufficient initialization time before healthcheck failures are counted.

### Changes Made

* Added `start_period: 10s` to the PostgreSQL healthcheck configuration.
* Retained the existing `pg_isready` readiness check.
* Kept the existing `depends_on` configuration using `condition: service_healthy`.

### Why

Although the database service already uses a healthcheck and the backend waits for a healthy database before starting, PostgreSQL may require a short initialization period before it can successfully respond to readiness checks. Adding a startup grace period helps avoid premature healthcheck failures during container startup.

### Testing

* Validated Docker Compose configuration using:

```bash
docker compose config
```

* Confirmed the healthcheck configuration is parsed correctly and included in the generated Compose configuration.

### Related Issue

Closes #855
