### PR TITLE
fix: replace ConcurrentHashMap with Caffeine cache in RateLimitFilter…

### DIFF
--- a/backend/nyaysetu-backend/pom.xml
+++ b/backend/nyaysetu-backend/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+
         <!-- Spring Boot Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/filter/RateLimitFilter.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/filter/RateLimitFilter.java
@@ -18,8 +18,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
 
 /**
  * RateLimitFilter
@@ -46,7 +47,10 @@ public class RateLimitFilter extends OncePerRequestFilter {
      * Stores token buckets for each client IP.
      * ConcurrentHashMap ensures thread safety.
      */
-    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+      private final Cache<String, Bucket> cache = Caffeine.newBuilder()
+        .maximumSize(100_000)
+        .expireAfterAccess(2, TimeUnit.MINUTES)
+        .build();
 
     /**
      * Maximum allowed requests per minute.
@@ -73,10 +77,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
             String clientIp = getClientIp(request);
 
             // Create bucket for new IP or reuse existing one
-            Bucket bucket = cache.computeIfAbsent(
-                    clientIp,
-                    ip -> createNewBucket()
-            );
+            Bucket bucket = cache.get(clientIp, ip -> createNewBucket());
 
             // Try consuming one token
             ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);


### PR DESCRIPTION
# Pull Request

## Description

Replaced the unbounded `ConcurrentHashMap<String, Bucket>` in `RateLimitFilter` with a
**Caffeine cache** that has a maximum size of 100,000 entries and a 2-minute
`expireAfterAccess` TTL. This prevents unlimited heap growth from unique/spoofed IPs
which could previously cause an `OutOfMemoryError` and crash the server.

**Changes made:**
- `pom.xml` → added `com.github.ben-manes.caffeine:caffeine:3.1.8` dependency
- `RateLimitFilter.java` → replaced `ConcurrentHashMap` with bounded Caffeine cache,
  replaced `computeIfAbsent` with `cache.get`

Closes #932 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes