### PR TITLE
fix: add authorization checks to getCaseById and deleteCase to preven…

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseManagementController.java
@@ -54,10 +54,11 @@ public class CaseManagementController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<CaseDTO> getCaseById(@PathVariable UUID id) {
-        CaseDTO caseDTO = caseManagementService.getCaseById(id);
-        return ResponseEntity.ok(caseDTO);
-    }
+        public ResponseEntity<?> getCaseById(@PathVariable UUID id, Authentication authentication) {
+            User user = authService.findByEmail(authentication.getName());
+            CaseDTO caseDTO = caseManagementService.getCaseById(id, user);
+            return ResponseEntity.ok(caseDTO);
+        }
 
     @PutMapping("/{id}")
     public ResponseEntity<CaseDTO> updateCase(
@@ -69,10 +70,11 @@ public class CaseManagementController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, String>> deleteCase(@PathVariable UUID id) {
-        caseManagementService.deleteCase(id);
-        return ResponseEntity.ok(Map.of("message", "Case deleted successfully"));
-    }
+        public ResponseEntity<?> deleteCase(@PathVariable UUID id, Authentication authentication) {
+            User user = authService.findByEmail(authentication.getName());
+            caseManagementService.deleteCase(id, user);
+            return ResponseEntity.ok(Map.of("message", "Case deleted successfully"));
+        }
 
     /**
      * Handover C: Lawyer submits draft

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/LawyerController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/LawyerController.java
@@ -45,7 +45,8 @@ public class LawyerController {
     ) {
         UUID caseId = UUID.fromString(request.get("caseId"));
         String template = request.get("template");
-        String draft = lawyerService.generateDraft(caseId, template);
+        User user = authService.findByEmail(authentication.getName());
+        String draft = lawyerService.generateDraft(caseId, template, user);
         return ResponseEntity.ok(Map.of("draft", draft));
     }
 

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
@@ -88,9 +88,21 @@ public class CaseManagementService {
                 .collect(Collectors.toList());
     }
 
-    public CaseDTO getCaseById(UUID id) {
+    public CaseDTO getCaseById(UUID id, User requestingUser) {
         CaseEntity caseEntity = caseRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Case not found"));
+
+        boolean isAdmin = requestingUser.getRole().name().equals("ADMIN");
+        boolean isOwner = caseEntity.getUserId().equals(requestingUser.getId());
+        boolean isJudge = requestingUser.getRole().name().equals("JUDGE") ||
+                        requestingUser.getRole().name().equals("SUPER_JUDGE");
+        boolean isLawyer = requestingUser.getRole().name().equals("LAWYER");
+
+        if (!isAdmin && !isOwner && !isJudge && !isLawyer) {
+            throw new org.springframework.security.access.AccessDeniedException(
+                "You do not have permission to view this case"
+            );
+        }
         return convertToDTO(caseEntity);
     }
 
@@ -122,9 +134,17 @@ public class CaseManagementService {
     }
 
     @Transactional
-    public void deleteCase(UUID id) {
-        if (!caseRepository.existsById(id)) {
-            throw new RuntimeException("Case not found");
+    public void deleteCase(UUID id, User requestingUser) {
+        CaseEntity caseEntity = caseRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Case not found"));
+
+        boolean isAdmin = requestingUser.getRole().name().equals("ADMIN");
+        boolean isOwner = caseEntity.getUserId().equals(requestingUser.getId());
+
+        if (!isAdmin && !isOwner) {
+            throw new org.springframework.security.access.AccessDeniedException(
+                "You do not have permission to delete this case"
+            );
         }
         caseRepository.deleteById(id);
     }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/LawyerService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/LawyerService.java
@@ -20,10 +20,10 @@ public class LawyerService {
     private final CaseRepository caseRepository;
     private final CaseManagementService caseManagementService;
 
-    public String generateDraft(UUID caseId, String templateType) {
+    public String generateDraft(UUID caseId, String templateType, User requestingUser) {
         log.info("Generating AI draft for case {} with template {}", caseId, templateType);
         
-        CaseDTO caseDetails = caseManagementService.getCaseById(caseId);
+        CaseDTO caseDetails = caseManagementService.getCaseById(caseId, requestingUser);
         
         String prompt = String.format(
             "You are an expert Indian legal drafter. Generate a formal legal document for the following case:\n\n" +


### PR DESCRIPTION
# Pull Request

## Description

`CaseManagementController` exposed `GET /api/v1/cases/{id}` and
`DELETE /api/v1/cases/{id}` with no ownership or role validation — any
authenticated user could read or delete any case by UUID (IDOR).

**Changes made:**
- `CaseManagementController.java` → passed `Authentication` into both endpoints
- `CaseManagementService.java` → added ownership/role check in `getCaseById`
  (owner, judge, lawyer, admin allowed) and `deleteCase` (owner or admin only).
  Unauthorized access now throws `AccessDeniedException` → 403 Forbidden.

Closes #931 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes