### PR TITLE
test: add timestamp assertion to health endpoint test

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HealthControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HealthControllerTest.java
@@ -32,12 +32,13 @@ class HealthControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @Test
-    void healthEndpoint_shouldReturnExpectedFields() throws Exception {
-        mockMvc.perform(get("/api/v1/health"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("UP"))
-                .andExpect(jsonPath("$.service").value("nyaysetu-backend"))
-                .andExpect(jsonPath("$.uptime").exists());
+@Test
+void healthEndpoint_shouldReturnExpectedFields() throws Exception {
+    mockMvc.perform(get("/api/v1/health"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"))
+            .andExpect(jsonPath("$.service").value("nyaysetu-backend"))
+            .andExpect(jsonPath("$.uptime").exists())
+            .andExpect(jsonPath("$.timestamp").exists());
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

Added a test assertion to verify that the health endpoint response contains the `timestamp` field.

This improves response field coverage in `HealthControllerTest` by ensuring all expected fields are validated.

Closes #1098 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

