### PR TITLE
test: add litigant access test for cases endpoint

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
@@ -32,4 +32,11 @@ public class RbacSecurityTest {
         mockMvc.perform(get("/api/v1/cases/pending-assignment"))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @WithMockUser(username = "litigant@example.com", roles = {"LITIGANT"})
+    void shouldAllowLitigantAccessOwnCasesEndpoint() throws Exception {
+        mockMvc.perform(get("/api/v1/litigant/cases"))
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
# Pull Request

## ## Description

Added a positive RBAC test to verify that a litigant can access their own `/api/v1/litigant/cases` endpoint.

## Changes Made

* Added a test for litigant access to `/api/v1/litigant/cases`
* Verified expected response status is `200 OK`
* Improved RBAC test coverage by including an allowed-access scenario

## Related Issue

Closes #1096 

