### PR TITLE
Fix: Add missing Home and Upcoming Features links to footer Quick Links

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
@@ -41,7 +41,9 @@ export default function Footer() {
     ];
 
     const quickLinks = [
+        { label: t('common:header.nav.home'), href: '/', isRoute: true },
         { label: t('common:header.nav.features'), href: '/#features' },
+        { label: t('common:header.nav.upcomingFeatures'), href: '/upcoming-features', isRoute: true },
         { label: t('common:header.nav.constitution'), href: '/constitution', isRoute: true },
         { label: t('common:header.nav.aiAssistant'), action: () => setShowAIModal(true) },
         { label: t('common:header.nav.about'), href: '/about', isRoute: true }


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes the inconsistency between the main navbar and the footer Quick Links.  
Previously, the footer only showed 4 links (Features, Constitution, AI Assistant, About).  
Now, it includes all 6 links by adding **Home** and **Upcoming Features**.

Closes #983 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
