### PR TITLE
Fix #1001: Add apple-mobile-web-app-capable meta tag iOS/Safari PWA support

### DIFF
--- a/frontend/nyaysetu-frontend/index.html
+++ b/frontend/nyaysetu-frontend/index.html
@@ -35,6 +35,7 @@
 
   <!-- Apple-specific PWA Meta Tags -->
   <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="NyaySetu" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />


### PR DESCRIPTION
# Pull Request

## Description

Closes #1001

Added the missing `apple-mobile-web-app-capable` meta tag for iOS/Safari PWA support.

Previously, only `mobile-web-app-capable` was present. iOS Safari requires the Apple-specific meta tag to properly recognize and support Progressive Web App (PWA) behavior.

**File Changed**

- `frontend/nyaysetu-frontend/index.html`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
