### PR TITLE
fix: add keyboard focus-visible states to biometric buttons (#909)

### DIFF
--- a/frontend/nyaysetu-frontend/src/styles/Biometrics.css
+++ b/frontend/nyaysetu-frontend/src/styles/Biometrics.css
@@ -252,6 +252,22 @@
     border-color: var(--color-accent);
 }
 
+/* Keyboard focus states - Fix #909 */
+.btn-primary-bio:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
+.btn-secondary-bio:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
+.biometric-close-btn:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
 /* Typography & Layout */
 .biometric-body {
     padding: 2rem;


### PR DESCRIPTION
# Pull Request

## Description

Adds keyboard-accessible focus indicators to biometric interface controls using :`focus-visible`.

**Updated:**
- `.btn-primary-bio`
- `.btn-secondary-bio`
- `.biometric-close-btn`

This improves keyboard navigation accessibility by providing a clear visual indication of the currently focused element.
 
Closes #909

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
