### PR TITLE
fix: use versioned notification endpoints

### DIFF
--- a/frontend/nyaysetu-frontend/src/services/NotificationService.js
+++ b/frontend/nyaysetu-frontend/src/services/NotificationService.js
@@ -178,7 +178,7 @@ class NotificationService {
     async fetchNotifications(userId) {
         try {
             const token = localStorage.getItem('token');
-            const response = await axios.get(`${this.API_BASE_URL}/api/notifications/user/${userId}`, {
+            const response = await axios.get(`${this.API_BASE_URL}/api/v1/notifications/user/${userId}`, {
                 headers: { Authorization: `Bearer ${token}` }
             });
             return response.data;
@@ -190,7 +190,7 @@ class NotificationService {
     async markRead(id) {
         try {
             const token = localStorage.getItem('token');
-            await axios.post(`${this.API_BASE_URL}/api/notifications/${id}/read`, {}, {
+            await axios.post(`${this.API_BASE_URL}/api/v1/notifications/${id}/read`, {}, {
                 headers: { Authorization: `Bearer ${token}` }
             });
         } catch (error) {

--- a/frontend/nyaysetu-frontend/src/services/NotificationService.test.js
+++ b/frontend/nyaysetu-frontend/src/services/NotificationService.test.js
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import NotificationService from './NotificationService';
+import { API_BASE_URL } from '../config/apiConfig';
+
+vi.mock('axios', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn()
+    }
+}));
+
+describe('NotificationService REST endpoints', () => {
+    beforeEach(() => {
+        const storage = new Map();
+        vi.clearAllMocks();
+        vi.stubGlobal('localStorage', {
+            getItem: vi.fn((key) => storage.get(key) ?? null),
+            setItem: vi.fn((key, value) => storage.set(key, value)),
+            clear: vi.fn(() => storage.clear())
+        });
+        localStorage.setItem('token', 'test-token');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('uses versioned notification endpoints for fetch and mark-read calls', async () => {
+        axios.get.mockResolvedValue({ data: [{ id: 7 }] });
+        axios.post.mockResolvedValue({});
+
+        await NotificationService.fetchNotifications(42);
+        await NotificationService.markRead(7);
+
+        expect(axios.get).toHaveBeenCalledWith(
+            `${API_BASE_URL}/api/v1/notifications/user/42`,
+            { headers: { Authorization: 'Bearer test-token' } }
+        );
+        expect(axios.post).toHaveBeenCalledWith(
+            `${API_BASE_URL}/api/v1/notifications/7/read`,
+            {},
+            { headers: { Authorization: 'Bearer test-token' } }
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Updates notification REST calls to use the backend's `/api/v1/notifications` routes.
- Adds regression coverage for fetching notifications and marking a notification as read.

## Files Changed

- `frontend/nyaysetu-frontend/src/services/NotificationService.js`: corrected stale notification REST endpoint paths.
- `frontend/nyaysetu-frontend/src/services/NotificationService.test.js`: added focused endpoint and authorization-header coverage.

## Screenshot

No visual UI changes — this PR only updates API paths and navigation routes. The dashboard layout and styling remain unchanged.

## Testing Performed

- `npm ci`
- `npm test -- src/services/NotificationService.test.js --run`
- `npm run build`

## Type of Change

- Bug fix
- New feature
- Refactor
- Documentation

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have verified there are no new warnings or errors
- [x] My changes generate no new warnings in unrelated files
- [x] I have linked the issue this PR closes

## Known Limitations

- Build emits existing large chunk warnings; no bundle configuration was changed.

## GSSoC

Please add the appropriate GSSoC label if applicable.

## AI Assistance Disclosure

This PR was prepared with AI assistance and manually reviewed before submission.

Closes #1086
