### PR TITLE
fix(frontend): add explicit aria-label to modal close buttons (#820)

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/auth/FaceLoginModal.jsx
+++ b/frontend/nyaysetu-frontend/src/components/auth/FaceLoginModal.jsx
@@ -101,7 +101,7 @@ export default function FaceLoginModal({ isOpen, onClose, onSuccess }) {
                 >
                     <div className="biometric-header-decor"></div>
 
-                    <button onClick={onClose} className="biometric-close-btn">
+                    <button onClick={onClose} aria-label="Close" className="biometric-close-btn">
                         <X size={20} />
                     </button>
 

--- a/frontend/nyaysetu-frontend/src/components/auth/ForgotPasswordModal.jsx
+++ b/frontend/nyaysetu-frontend/src/components/auth/ForgotPasswordModal.jsx
@@ -63,7 +63,7 @@ export default function ForgotPasswordModal({ isOpen, onClose }) {
                 >
                     <div className="biometric-header-decor"></div>
 
-                    <button onClick={onClose} className="biometric-close-btn">
+                    <button onClick={onClose} aria-label="Close" className="biometric-close-btn">
                         <X size={20} />
                     </button>
 
@@ -135,6 +135,7 @@ export default function ForgotPasswordModal({ isOpen, onClose }) {
                                 </p>
                                 <button
                                     onClick={onClose}
+                                    aria-label="Close"
                                     className="biometric-btn btn-secondary-bio"
                                     style={{ margin: '0 auto' }}
                                 >

--- a/frontend/nyaysetu-frontend/src/components/avatar/AvatarPanel.jsx
+++ b/frontend/nyaysetu-frontend/src/components/avatar/AvatarPanel.jsx
@@ -124,6 +124,7 @@ export default function AvatarPanel({
 
                 <button
                     onClick={onClose}
+                    aria-label="Close"
                     style={{
                         background: 'rgba(255,255,255,0.06)',
                         border: '1px solid rgba(255,255,255,0.1)',

--- a/frontend/nyaysetu-frontend/src/components/common/KeyboardShortcutsModal.jsx
+++ b/frontend/nyaysetu-frontend/src/components/common/KeyboardShortcutsModal.jsx
@@ -90,6 +90,7 @@ export default function KeyboardShortcutsModal({
 
           <button
             onClick={onClose}
+            aria-label="Close"
             style={{
               background: "transparent",
               border: "none",

--- a/frontend/nyaysetu-frontend/src/components/landing/AIAssistantModal.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/AIAssistantModal.jsx
@@ -155,6 +155,7 @@ export default function AIAssistantModal({ isOpen, onClose }) {
                                 whileTap={{ scale: 0.92 }}
                                 transition={{ type: 'spring', stiffness: 350 }}
                                 onClick={onClose}
+                                aria-label="Close"
                                 style={{
                                     background: 'var(--bg-hover)',
                                     border: '1px solid var(--border-medium)',

--- a/frontend/nyaysetu-frontend/src/pages/litigant/CaseDetailPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/CaseDetailPage.jsx
@@ -1652,6 +1652,7 @@ function PrepKitModal({ isOpen, onClose, stage }) {
 
                 <button
                     onClick={onClose}
+                    aria-label="Close"
                     style={{ width: '100%', padding: '1rem', background: 'var(--color-accent)', color: 'white', border: 'none', borderRadius: '0.75rem', fontWeight: '700', fontSize: '1rem', cursor: 'pointer' }}>
                     {t('caseDetail.aiPrepKit.gotIt')}
                 </button>
@@ -1680,7 +1681,7 @@ function BSA634GeneratorModal({ isOpen, onClose }) {
     return (
         <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1100, backdropFilter: 'blur(8px)' }} onClick={onClose}>
             <div style={{ background: '#0f172a', border: '1px solid #334155', borderRadius: '1.5rem', width: '90%', maxWidth: '500px', padding: '2.5rem', boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)', position: 'relative' }} onClick={e => e.stopPropagation()}>
-                <button onClick={onClose} style={{ position: 'absolute', top: '1rem', right: '1rem', background: 'none', border: 'none', color: '#64748b', cursor: 'pointer' }}><X size={24} /></button>
+                <button onClick={onClose} aria-label="Close" style={{ position: 'absolute', top: '1rem', right: '1rem', background: 'none', border: 'none', color: '#64748b', cursor: 'pointer' }}><X size={24} /></button>
 
                 <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
                     <Shield size={48} color={step === 'DONE' ? '#10b981' : '#3b82f6'} style={{ marginBottom: '1rem' }} />


### PR DESCRIPTION
# Pull Request

## Description
Closes #820

Added explicit `aria-label="Close"` attributes to modal close buttons across the frontend application. Screen readers previously announced these interactable icons simply as 'button'; they now correctly describe their specific functionality ("Close").

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes