### PR TITLE
fix(security): Mitigate SSRF vulnerability in video download service

### DIFF
--- a/nlp-orchestrator/services/video_processor.py
+++ b/nlp-orchestrator/services/video_processor.py
@@ -1,3 +1,33 @@
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+def validate_url_for_ssrf(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Disallowed scheme: {parsed.scheme}")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("No hostname found in URL.")
+    try:
+        resolved_ip = socket.getaddrinfo(hostname, None)[0][4][0]
+    except socket.gaierror:
+        raise ValueError(f"Cannot resolve hostname: {hostname}")
+    ip_obj = ipaddress.ip_address(resolved_ip)
+    for blocked in BLOCKED_NETWORKS:
+        if ip_obj in blocked:
+            raise ValueError(f"URL resolves to blocked IP: {resolved_ip}")
+
 import cv2
 import os
 import aiohttp
@@ -8,6 +38,11 @@ UPLOAD_DIR = "/tmp/nyaysetu_forensics"
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 async def download_video(url: str, job_id: str) -> str:
+    try:
+        validate_url_for_ssrf(url)
+    except ValueError as e:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=400, detail=f"Unsafe URL rejected: {e}")
     """Download video from URL (which will be a MinIO/Spring Boot endpoint) to a local temp file."""
     # If the URL is already a local path (for testing), just return it
     if url.startswith("/") and os.path.exists(url):


### PR DESCRIPTION
## Summary
Fixes #1129

## Problem
The `download_video()` function in `video_processor.py` fetched any 
user-provided URL without validation, allowing SSRF attacks targeting 
internal services and cloud metadata endpoints like `169.254.169.254`.

## Fix
Added `validate_url_for_ssrf()` that:
- ✅ Whitelists only `http`/`https` schemes
- ✅ Resolves hostname to IP before making any request
- ✅ Blocks all private/internal IP ranges (127.x, 10.x, 172.16.x, 192.168.x, 169.254.x)
- ✅ Returns HTTP 400 for any rejected URL

## Tested
- `http://127.0.0.1:8080` → 400 Bad Request ✅
- `http://169.254.169.254/latest/meta-data/` → 400 Bad Request ✅
- Valid public video URL → proceeds normally ✅