### PR TITLE
fix: resolve header overlapping issue for Tamil language (#1146)

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
@@ -200,13 +200,13 @@ export default function Header({ hideAuthButtons = false }) {
                     {/* Desktop Nav */}
                     <nav
                         className="desktop-nav"
-                        style={{ display: 'flex', gap: '2rem', alignItems: 'center', flex: 1, justifyContent: 'center' }}
+                        style={{ display: 'flex', gap: 'clamp(0.5rem, 1.5vw, 2rem)', flexWrap: 'wrap', alignItems: 'center', flex: 1, justifyContent: 'center' }}
                     >
                         {navItems.map(renderNavItem)}
                     </nav>
 
                     {/* Right Controls */}
-                    <div className="desktop-cta" style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0 }}>
+                    <div className="desktop-cta" style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0, flexWrap: 'wrap' }}>
                         {/* Role Selector */}
                         <div id="role-selector" style={{ position: 'relative' }}>
                             <button
@@ -715,7 +715,7 @@ export default function Header({ hideAuthButtons = false }) {
                         flex-direction: row !important;
                         justify-content: space-between !important;
                         align-items: center !important;
-                        flex-wrap: nowrap !important;
+                        flex-wrap: wrap !important;
                         gap: 1rem !important;
                         padding: 0.7rem 2rem;
                     }


### PR DESCRIPTION
# Pull Request

## Description
This PR resolves the overlapping elements issue in the header when selecting languages with longer words (specifically Tamil). I rearranged the layout using CSS flexbox properties. The header now dynamically adjusts its gap and gracefully wraps on smaller viewports to prevent cramped or overlapping navigation elements.

Closes #1146

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
