### PR TITLE
Fix header bounds 1139

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
@@ -163,6 +163,8 @@ export default function Header({ hideAuthButtons = false }) {
                 <div className="header-container" style={{
                     maxWidth: '1400px',
                     margin: '0 auto',
+                    width: '100%',
+                    boxSizing: 'border-box',
                 }}>
                     {/* Logo */}
                     <Link to="/" style={{
@@ -718,6 +720,8 @@ export default function Header({ hideAuthButtons = false }) {
                         flex-wrap: wrap !important;
                         gap: 1rem !important;
                         padding: 0.7rem 2rem;
+                        width: 100% !important;
+                        box-sizing: border-box !important;
                     }
 
                     @media (max-width: 900px) {

--- a/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
@@ -200,13 +200,13 @@ export default function Header({ hideAuthButtons = false }) {
                     {/* Desktop Nav */}
                     <nav
                         className="desktop-nav"
-                        style={{ display: 'flex', gap: '2rem', alignItems: 'center', flex: 1, justifyContent: 'center' }}
+                        style={{ display: 'flex', gap: 'clamp(0.5rem, 1.5vw, 2rem)', flexWrap: 'wrap', alignItems: 'center', flex: 1, justifyContent: 'center' }}
                     >
                         {navItems.map(renderNavItem)}
                     </nav>
 
                     {/* Right Controls */}
-                    <div className="desktop-cta" style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0 }}>
+                    <div className="desktop-cta" style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0, flexWrap: 'wrap' }}>
                         {/* Role Selector */}
                         <div id="role-selector" style={{ position: 'relative' }}>
                             <button
@@ -715,7 +715,7 @@ export default function Header({ hideAuthButtons = false }) {
                         flex-direction: row !important;
                         justify-content: space-between !important;
                         align-items: center !important;
-                        flex-wrap: nowrap !important;
+                        flex-wrap: wrap !important;
                         gap: 1rem !important;
                         padding: 0.7rem 2rem;
                     }


### PR DESCRIPTION
# Pull Request

## Description
This PR resolves the issue where the header extends slightly beyond the page boundary. I added `box-sizing: border-box` and `width: 100%` to the `.header-container` to ensure its internal padding does not increase its total width past the viewport.

Closes #1139

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
