### PR TITLE
feat(nlp): tuning prompt for regional language translation

### DIFF
--- a/nlp-orchestrator/avatar_speech.py
+++ b/nlp-orchestrator/avatar_speech.py
@@ -4,7 +4,6 @@ Layer 5: Avatar Speech Layer
 2. Converts the final answer to Hinglish spoken dialogue for the 3D avatar
 """
 
-import asyncio
 import random
 from groq import AsyncGroq
 from config import GROQ_API_KEY, GROQ_MODEL_FAST
@@ -99,17 +98,52 @@ def get_interim_messages(query: str, count: int = 3) -> list[str]:
     return result
 
 
-HINGLISH_CONVERSION_PROMPT = """You are converting a formal English legal answer into a friendly, 
+HINGLISH_CONVERSION_PROMPT = """You are converting a formal English legal answer into a friendly,
 conversational Hinglish dialogue spoken by an AI legal assistant avatar named "Nyay Saarthi".
 
-Rules:
-- Mix Hindi and English naturally, as a bilingual Indian would speak
-- Shorten to 4-6 sentences maximum for spoken delivery
-- Be warm, reassuring and professional
-- Mention key section numbers and laws but explain them simply
-- End with an encouraging statement
-- Use "aap" (respectful) instead of "tum"
-- Do NOT use markdown formatting. Plain text only, suitable for text-to-speech.
+TONE & REGISTER (most important):
+Speak the way an educated, bilingual Indian would explain things to a friend over chai —
+warm, simple and everyday. Do NOT sound like a government notice, a news anchor, or a
+court order. Use the EASY, COLLOQUIAL word, not the heavy "shuddh"/Sanskritised one.
+
+Use the common ENGLISH word whenever a normal Indian speaker would naturally say it in
+English. Keep these in English: court, judge, police, FIR, bail, case, lawyer, advocate,
+rights, complaint, refund, insurance, accident, property, rent, contract, notice, appeal,
+compensation, hearing, evidence. Forcing a formal Hindi translation for these makes the
+speech harder to understand, not easier.
+
+AVOID these overly formal / Sanskritised words → USE the everyday word instead:
+- "nyayalaya" → "court"
+- "vidhik" / "vaidhanik" → "kanooni" or just "legal"
+- "adhiniyam" → "Act" or "kanoon"
+- "praavdhaan" → "niyam" or "rule"
+- "prakriya" → "process"
+- "kshatipoorti" → "compensation" or "muaavza"
+- "abhiyukt" → "accused"
+- "yachika" / "aavedan" → "application" or "petition"
+- "vivaran" → "details"
+- "upalabdh" → "available" or "mil sakta hai"
+- "sambandhit" → "related" or "se juda hua"
+- "tatpashchaat" → "uske baad"
+- "kripya" → "please"
+- "pradaan karna" → "dena", "prapt karna" → "lena/milna"
+When in doubt, pick the word your auto-rickshaw driver would understand.
+
+OTHER RULES:
+- Mix Hindi and English naturally, the way bilingual Indians actually talk.
+- Keep it to 4-6 short sentences for spoken delivery.
+- Be warm, reassuring and professional — but never stiff or bookish.
+- Mention key section numbers and law names accurately (e.g. "Section 138", "Motor
+  Vehicles Act"), but explain what they mean in plain words.
+- Use "aap" (respectful), never "tum".
+- End with one short, encouraging line.
+- Plain text only, no markdown, no bullet points — it will be read aloud by text-to-speech.
+
+STYLE EXAMPLE (match this register, do not copy the content):
+"Dekhiye, aapke case mein Motor Vehicles Act ka Section 166 lagta hai — iska matlab hai
+ki aap accident ke liye compensation claim kar sakte hain. Pehle ek police complaint aur
+FIR ki copy le lijiye, phir insurance company ko notice bhejna padega. Ghabraaiye mat,
+process thoda lamba hai par kanoon aapke saath hai. Main aapko har step samjha dunga."
 
 Original English Answer:
 {markdown_answer}

--- a/nlp-orchestrator/compare_hinglish_prompts.py
+++ b/nlp-orchestrator/compare_hinglish_prompts.py
@@ -1,0 +1,163 @@
+"""
+Manual verification harness for Issue #849 — colloquial Hinglish prompt.
+
+Calls Groq with the OLD prompt and the NEW prompt on the same sample legal
+answers, prints both outputs side by side, and counts formal/Sanskritised words
+in each so you can SEE the register actually improved (not just that the prompt
+text changed).
+
+This is the layer that proves the fix. Unit tests guard the prompt contract;
+this exercises the real model.
+
+Usage (from nlp-orchestrator/, with your real key in the environment):
+    export GROQ_API_KEY=sk-...
+    python compare_hinglish_prompts.py            # real A/B against Groq
+    python compare_hinglish_prompts.py --dry-run  # offline: just the word scan
+
+The NEW prompt is imported from avatar_speech.py so this always tests what you
+actually shipped. The OLD prompt is pinned below for comparison.
+"""
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+
+# ─── The OLD prompt (pre-#849), pinned here purely for A/B comparison ─────────
+OLD_PROMPT = """You are converting a formal English legal answer into a friendly, \
+conversational Hinglish dialogue spoken by an AI legal assistant avatar named "Nyay Saarthi".
+
+Rules:
+- Mix Hindi and English naturally, as a bilingual Indian would speak
+- Shorten to 4-6 sentences maximum for spoken delivery
+- Be warm, reassuring and professional
+- Mention key section numbers and laws but explain them simply
+- End with an encouraging statement
+- Use "aap" (respectful) instead of "tum"
+- Do NOT use markdown formatting. Plain text only, suitable for text-to-speech.
+
+Original English Answer:
+{markdown_answer}
+
+Convert to Hinglish dialogue:"""
+
+# Formal / Sanskritised words the issue is about. Lower-case, romanised.
+FORMAL_WORDS = [
+    "nyayalaya", "vidhik", "vaidhanik", "adhiniyam", "praavdhaan", "pravdhaan",
+    "prakriya", "kshatipoorti", "abhiyukt", "yachika", "aavedan", "vivaran",
+    "upalabdh", "sambandhit", "tatpashchaat", "kripya", "pradaan", "prapt",
+    "anurodh", "shighra", "sandarbh", "vidhaan",
+]
+
+# Representative synthesized answers (one per legal domain).
+SAMPLES = {
+    "accident": (
+        "Under Section 166 of the Motor Vehicles Act, 1988, a victim of a road "
+        "accident may file a claim for compensation before the Motor Accident "
+        "Claims Tribunal. The claimant should obtain a copy of the FIR and the "
+        "insurance details of the offending vehicle. Negligence on the part of "
+        "the driver must be established to succeed in the claim."
+    ),
+    "criminal": (
+        "If you wish to report a cognizable offence, you may file an FIR under "
+        "Section 173 of the Bharatiya Nagarik Suraksha Sanhita, 2023. The police "
+        "are obligated to register the FIR. If they refuse, you may approach the "
+        "Superintendent of Police or file a complaint before the Magistrate."
+    ),
+    "consumer": (
+        "Under the Consumer Protection Act, 2019, a consumer aggrieved by a "
+        "defective product or deficient service may file a complaint before the "
+        "District Consumer Disputes Redressal Commission. The complaint must be "
+        "filed within two years of the cause of action and may seek a refund or "
+        "compensation."
+    ),
+}
+
+
+def count_formal_words(text: str) -> list[str]:
+    """Return the formal words found in the text (word-boundary, case-insensitive)."""
+    lowered = text.lower()
+    hits = []
+    for w in FORMAL_WORDS:
+        if re.search(rf"\b{re.escape(w)}", lowered):
+            hits.append(w)
+    return hits
+
+
+async def run_prompt(client, model: str, prompt_template: str, answer: str) -> str:
+    resp = await client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt_template.format(markdown_answer=answer)}],
+        temperature=0.6,
+        max_tokens=512,
+    )
+    return resp.choices[0].message.content.strip()
+
+
+async def main_async(new_prompt: str, model: str) -> int:
+    from groq import AsyncGroq  # imported here so --dry-run needs no groq install
+
+    client = AsyncGroq(api_key=os.environ["GROQ_API_KEY"])
+    old_total, new_total = 0, 0
+
+    for domain, answer in SAMPLES.items():
+        old_out = await run_prompt(client, model, OLD_PROMPT, answer)
+        new_out = await run_prompt(client, model, new_prompt, answer)
+        old_hits = count_formal_words(old_out)
+        new_hits = count_formal_words(new_out)
+        old_total += len(old_hits)
+        new_total += len(new_hits)
+
+        print("=" * 72)
+        print(f"DOMAIN: {domain}")
+        print("-" * 72)
+        print(f"[OLD]  formal words: {old_hits or 'none'}")
+        print(old_out)
+        print("-" * 72)
+        print(f"[NEW]  formal words: {new_hits or 'none'}")
+        print(new_out)
+        print()
+
+    print("=" * 72)
+    print(f"TOTAL formal-word hits  ->  OLD: {old_total}   NEW: {new_total}")
+    print("Expected: NEW <= OLD (fewer formal words). Also eyeball readability.")
+    print("=" * 72)
+    # Non-zero exit if the new prompt did not improve, so this can gate CI later.
+    return 0 if new_total <= old_total else 1
+
+
+def dry_run() -> int:
+    """Offline sanity check: no network, no key, no groq install needed."""
+    sample = (
+        "Aapke case mein nyayalaya jaana padega. Vidhik prakriya ke anusaar "
+        "kshatipoorti ke liye aavedan karein."
+    )
+    print("Dry run — scanning a sample formal sentence:")
+    print(f"  text : {sample}")
+    print(f"  hits : {count_formal_words(sample)}")
+    print("\nNew prompt avoid-list mentions found in shipped prompt:")
+    from avatar_speech import HINGLISH_CONVERSION_PROMPT
+    present = [w for w in FORMAL_WORDS if w in HINGLISH_CONVERSION_PROMPT.lower()]
+    print(f"  {present}")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="offline word-scan only")
+    parser.add_argument("--model", default="llama-3.3-70b-versatile")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        sys.exit(dry_run())
+
+    if not os.environ.get("GROQ_API_KEY"):
+        print("ERROR: set GROQ_API_KEY in your environment first.", file=sys.stderr)
+        sys.exit(2)
+
+    # Import the SHIPPED prompt so we always A/B against what's in the PR.
+    os.environ.setdefault("GROQ_API_KEY", "x")  # let config.py import cleanly
+    from avatar_speech import HINGLISH_CONVERSION_PROMPT
+
+    sys.exit(asyncio.run(main_async(HINGLISH_CONVERSION_PROMPT, args.model)))

--- a/nlp-orchestrator/tests/test_avatar_speech.py
+++ b/nlp-orchestrator/tests/test_avatar_speech.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for avatar_speech Hinglish conversion (Issue #849).
+
+Covers the prompt-tuning fix for "[NLP] Tune prompt for regional language
+translation": the system prompt must steer the model toward colloquial,
+understandable Hinglish instead of overly formal / Sanskritised Hindi.
+
+These tests guard the *prompt contract* (so the register cannot silently
+regress) and verify the surrounding conversion logic still behaves correctly
+without making any real network call to Groq.
+
+Run with: python -m pytest tests/test_avatar_speech.py -v
+Or directly: python tests/test_avatar_speech.py
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Allow direct execution from the project root.
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+# Mock GROQ_API_KEY before importing avatar_speech so config.py does not
+# exit in CI environments without a .env file.
+with patch.dict(os.environ, {"GROQ_API_KEY": "test-key-for-ci"}):
+    import avatar_speech
+    from avatar_speech import (
+        HINGLISH_CONVERSION_PROMPT,
+        convert_to_hinglish,
+        detect_domain,
+        get_interim_messages,
+    )
+
+
+# ── Prompt contract: register-tuning regression guards ───────────────────────
+
+class TestHinglishPromptRegister:
+    """The tuned prompt must actively steer away from formal Hindi (Issue #849)."""
+
+    def test_prompt_still_accepts_the_answer_placeholder(self):
+        # The prompt must keep exactly one format placeholder, so .format() works.
+        assert "{markdown_answer}" in HINGLISH_CONVERSION_PROMPT
+        assert HINGLISH_CONVERSION_PROMPT.count("{") == 1
+        assert HINGLISH_CONVERSION_PROMPT.count("}") == 1
+
+    def test_prompt_formats_without_keyerror(self):
+        rendered = HINGLISH_CONVERSION_PROMPT.format(markdown_answer="SAMPLE ANSWER")
+        assert "SAMPLE ANSWER" in rendered
+        assert "{markdown_answer}" not in rendered
+
+    def test_prompt_demands_colloquial_register(self):
+        lowered = HINGLISH_CONVERSION_PROMPT.lower()
+        # At least one explicit colloquial-register cue must be present.
+        assert "colloquial" in lowered
+        assert "shuddh" in lowered or "sanskrit" in lowered
+
+    @pytest.mark.parametrize(
+        "formal_word",
+        ["nyayalaya", "adhiniyam", "praavdhaan", "kshatipoorti", "vidhik"],
+    )
+    def test_prompt_names_formal_words_to_avoid(self, formal_word):
+        # The avoid-list anchors the model away from these specific formal terms.
+        assert formal_word in HINGLISH_CONVERSION_PROMPT.lower()
+
+    @pytest.mark.parametrize(
+        "english_keep",
+        ["court", "police", "fir", "bail", "compensation", "insurance"],
+    )
+    def test_prompt_whitelists_common_english_terms(self, english_keep):
+        assert english_keep in HINGLISH_CONVERSION_PROMPT.lower()
+
+    def test_prompt_preserves_original_constraints(self):
+        lowered = HINGLISH_CONVERSION_PROMPT.lower()
+        # Existing behavioural rules must survive the tuning.
+        assert "aap" in lowered                 # respectful pronoun
+        assert "tum" in lowered                 # explicitly disallowed
+        assert "markdown" in lowered            # plain-text / TTS rule
+        assert "4-6" in HINGLISH_CONVERSION_PROMPT  # length guidance
+        assert "nyay saarthi" in lowered        # avatar persona retained
+
+    def test_prompt_keeps_legal_accuracy_requirement(self):
+        lowered = HINGLISH_CONVERSION_PROMPT.lower()
+        assert "section" in lowered  # section numbers / law names stay accurate
+
+
+# ── convert_to_hinglish: behaviour with a mocked Groq client ─────────────────
+
+class TestConvertToHinglish:
+    @pytest.mark.asyncio
+    async def test_returns_stripped_model_output(self):
+        fake_message = MagicMock()
+        fake_message.content = "  Dekhiye, aapka case strong hai.  "
+        fake_choice = MagicMock(message=fake_message)
+        fake_response = MagicMock(choices=[fake_choice])
+
+        with patch.object(
+            avatar_speech.client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=fake_response),
+        ) as mock_create:
+            result = await convert_to_hinglish("The petitioner may claim compensation.")
+
+        assert result == "Dekhiye, aapka case strong hai."
+        # The tuned prompt (with the user's answer) must be what we send.
+        sent = mock_create.call_args.kwargs["messages"][0]["content"]
+        assert "The petitioner may claim compensation." in sent
+        assert "colloquial" in sent.lower()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_first_sentences_on_error(self):
+        long_answer = (
+            "First sentence here. Second sentence here. "
+            "Third sentence here. Fourth sentence here."
+        )
+        with patch.object(
+            avatar_speech.client.chat.completions,
+            "create",
+            new=AsyncMock(side_effect=RuntimeError("groq down")),
+        ):
+            result = await convert_to_hinglish(long_answer)
+
+        # Fallback keeps the first three sentences and stays non-empty.
+        assert result.startswith("First sentence here")
+        assert "Third sentence here" in result
+        assert "Fourth sentence here" not in result
+        assert result.endswith(".")
+
+
+# ── Unchanged helpers: light coverage so the module stays green ──────────────
+
+class TestDomainHelpers:
+    def test_detect_domain_matches_keywords(self):
+        assert detect_domain("My car had an accident on the road") == "accident"
+        assert detect_domain("I need to file an FIR with the police") == "criminal"
+        assert detect_domain("question about my rented flat possession") == "property"
+
+    def test_detect_domain_defaults_to_general(self):
+        assert detect_domain("hello there, random question") == "general"
+
+    def test_get_interim_messages_respects_count_and_dedupes(self):
+        msgs = get_interim_messages("car accident claim", count=3)
+        assert len(msgs) == 3
+        assert len(set(msgs)) == 3  # no duplicates
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# Pull Request: Tune prompt for regional language translation
 
## Summary
 
The Hinglish dialogue spoken by the **Nyay Saarthi** avatar sometimes came out in a very formal, Sanskritised "shuddh" Hindi (words like *nyayalaya*, *adhiniyam*, *praavdhaan*, *kshatipoorti*), which is harder for everyday users to understand than the plain, mixed Hinglish they actually speak. This PR tunes the `HINGLISH_CONVERSION_PROMPT` system prompt in `nlp-orchestrator/avatar_speech.py` so the model produces colloquial, easy-to-understand Hinglish, and adds tests to lock the new register in.

## Closes #849
 
## What's in this PR
 
`nlp-orchestrator/avatar_speech.py`: rewrote the system prompt used by `convert_to_hinglish()` to steer register without touching any conversion logic, the model, generation params, or the `{markdown_answer}` placeholder contract:
 
- **Register guidance up top**: instructs the model to talk like an educated bilingual Indian explaining things to a friend, *not* like a government notice, news anchor, or court order, and to prefer the easy word over the heavy "shuddh"/Sanskritised one.
- **Keep-in-English whitelist**: common terms users already know in English (court, police, FIR, bail, case, lawyer, compensation, insurance, etc.) are explicitly kept in English rather than force-translated into formal Hindi.
- **Avoid-list with substitutions**: an explicit "use this, not that" mapping (eg: *nyayalaya -> court*, *adhiniyam -> Act/kanoon*, *kshatipoorti -> compensation/muaavza*) to anchor the model away from the specific formal words that triggered the issue.
- **One-shot style example**: a short sample line in the target register so the model matches tone and not just rules.
- **Preserved all original constraints**: 4 to 6 sentence spoken length, warm tone, accurate section numbers / law names, `aap` (not `tum`), and plain text only (no markdown) for text-to-speech.
`nlp-orchestrator/tests/test_avatar_speech.py`: new test module (there was none for this file before):
 
- Prompt-contract regression guards: the placeholder is intact and `.format()` still works; the colloquial-register cue is present; the formal words to avoid and the English terms to keep are named; the original constraints (length, `aap`/`tum`, plain-text, persona, section accuracy) all survive.
- `convert_to_hinglish()` behaviour with a **mocked** Groq client (no network): output is stripped and built from the tuned prompt; the error path falls back to the first three sentences.
- Light coverage of the untouched `detect_domain` / `get_interim_messages` helpers.

### Why prompt-only (no logic change)
 
The only LLM-driven translation path is this system prompt; `report_generator`'s avatar script uses fixed templates that are already colloquial. Keeping the change to the prompt string makes it low-risk, reviewable, and easy to iterate on.
 
## Type of change
 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing
 
```bash
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> python -m pytest tests/test_avatar_speech.py -v
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-4.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 21 items

tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_still_accepts_the_answer_placeholder PASSED [  4%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_formats_without_keyerror PASSED             [  9%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_demands_colloquial_register PASSED          [ 14%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_names_formal_words_to_avoid[nyayalaya] PASSED [ 19%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_names_formal_words_to_avoid[adhiniyam] PASSED [ 23%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_names_formal_words_to_avoid[praavdhaan] PASSED [ 28%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_names_formal_words_to_avoid[kshatipoorti] PASSED [ 33%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_names_formal_words_to_avoid[vidhik] PASSED  [ 38%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_whitelists_common_english_terms[court] PASSED [ 42%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_whitelists_common_english_terms[police] PASSED [ 47%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_whitelists_common_english_terms[fir] PASSED [ 52%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_whitelists_common_english_terms[bail] PASSED [ 57%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_whitelists_common_english_terms[compensation] PASSED [ 61%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_whitelists_common_english_terms[insurance] PASSED [ 66%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_preserves_original_constraints PASSED       [ 71%]
tests/test_avatar_speech.py::TestHinglishPromptRegister::test_prompt_keeps_legal_accuracy_requirement PASSED     [ 76%]
tests/test_avatar_speech.py::TestConvertToHinglish::test_returns_stripped_model_output PASSED                    [ 80%]
tests/test_avatar_speech.py::TestConvertToHinglish::test_falls_back_to_first_sentences_on_error PASSED           [ 85%]
tests/test_avatar_speech.py::TestDomainHelpers::test_detect_domain_matches_keywords PASSED                       [ 90%]
tests/test_avatar_speech.py::TestDomainHelpers::test_detect_domain_defaults_to_general PASSED                    [ 95%]
tests/test_avatar_speech.py::TestDomainHelpers::test_get_interim_messages_respects_count_and_dedupes PASSED      [100%]Running teardown with pytest sessionfinish...


================================================= 21 passed in 1.00s ==================================================
```

### Manual testing

**Before-and-after harness**:
```bash
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> python compare_hinglish_prompts.py --dry-run
Dry run — scanning a sample formal sentence:
  text : Aapke case mein nyayalaya jaana padega. Vidhik prakriya ke anusaar kshatipoorti ke liye aavedan karein.
  hits : ['nyayalaya', 'vidhik', 'prakriya', 'kshatipoorti', 'aavedan']

New prompt avoid-list mentions found in shipped prompt:
  ['nyayalaya', 'vidhik', 'vaidhanik', 'adhiniyam', 'praavdhaan', 'prakriya', 'kshatipoorti', 'abhiyukt', 'yachika', 'aavedan', 'vivaran', 'upalabdh', 'sambandhit', 'tatpashchaat', 'kripya', 'pradaan', 'prapt']
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> python compare_hinglish_prompts.py
========================================================================
DOMAIN: accident
------------------------------------------------------------------------
[OLD]  formal words: none
Aapko pata hona chahiye ki Motor Vehicles Act, 1988 ki Section 166 ke tahat, aap road accident ke baad Motor Accident Claims Tribunal me compensation ke liye claim file kar sakte hain. Aapko FIR ki copy aur offending vehicle ke insurance details lena hoga. Driver ki lado par negligence prove karna zaroori hai, tabhi aapka claim succeed hoga. Aap chinta na karein, hum aapki madad karenge, bas humein apni puri jaankari dein. Aapko nyay milne ki poori ummeed hai, aage badhte hain.
------------------------------------------------------------------------
[NEW]  formal words: none
Dekhiye, aapke case mein Motor Vehicles Act ka Section 166 lagta hai — iska matlab hai ki aap accident ke liye compensation claim kar sakte hain. Pehle ek police complaint aur FIR ki copy le lijiye, aur offending vehicle ki insurance details bhi milayein. Driver ki ladoochhedi ko prove karna hoga, tabhi aapka claim successful hoga. Ghabraaiye mat, main aapko har step samjha dunga, aapko apne haq ka claim milne mein madad karunga.

========================================================================
DOMAIN: criminal
------------------------------------------------------------------------
[OLD]  formal words: none
Aap agar koi cognizable offence report karna chahte hain, to aap Section 173 ke tahat Bharatiya Nagarik Suraksha Sanhita, 2023 ke under FIR darj kara sakte hain. Police ko yeh FIR register karna zaroori hai, lekin agar ve mana karte hain, to aap Superintendent of Police se sampark kar sakte hain ya Magistrate ke saamne complaint file kar sakte hain. Aapko chinta nahin karni chahiye, aapka adhikar hai aur hum aapke saath hain. Aapko nyay milega, aap himmat mat haariye.
------------------------------------------------------------------------
[NEW]  formal words: none
Dekhiye, aap koi cognizable offence report karna chahte hain, to aap Section 173 ke tahat FIR darj kara sakte hain. Police ko yeh FIR register karna zaroori hai, lekin agar ve mana karte hain, to aap Superintendent of Police ke paas ja sakte hain ya Magistrate ke saamne complaint file kar sakte hain. Yeh process thoda lamba hai, lekin aapko apne rights ke liye ladna padta hai. Main aapko madad karunga, ghabraaiye mat, kanoon aapke saath hai. Aap apni complaint lekar aaiye, hum saath mein court mein jaenge.

========================================================================
DOMAIN: consumer
------------------------------------------------------------------------
[OLD]  formal words: none
Aapko Consumer Protection Act, 2019 ke tehet, agar aapko koi defective product ya deficient service mila hai, to aap District Consumer Disputes Redressal Commission mein complaint file kar sakte hain. Section 2 ke hisaab se, aapko do saal ke andar complaint file karni hogi. Aap refund ya compensation bhi maang sakte hain, jo aapke nuksan ke hisaab se decide kiya jayega. Aapko chinta nahi karni chahiye, Nyay Saarthi aapke saath hai, aap apna haq le sakte hain.
------------------------------------------------------------------------
[NEW]  formal words: none
Dekhiye, aapko Consumer Protection Act, 2019 ke tahat complaint file karni hai, agar aapko koi defective product mila hai ya service thik nahin mili. Aapko District Consumer Disputes Redressal Commission mein complaint deni hogi, aur wo bhi do saal ke andar, jab se aapko nuksan hua hai. Aap refund ya compensation manga sakte hain, jo bhi aapko sahi lage. Ghabraaiye mat, main aapko har step samjha dunga, aapko apne haq milenge.

========================================================================
TOTAL formal-word hits  ->  OLD: 0   NEW: 0
Expected: NEW <= OLD (fewer formal words). Also eyeball readability.
========================================================================
```

**Testing the actual function**:
```bash
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> python -c "import asyncio; from avatar_speech import convert_to_hinglish; print(asyncio.run(convert_to_hinglish('Under Section 138 of the Negotiable Instruments Act, a dishonoured cheque is a criminal offence.')))"
Dekhiye, aapke case mein Negotiable Instruments Act ka Section 138 lagta hai — iska matlab hai ki agar koi cheque dishonour ho jata hai, to yeh ek criminal offence hai. Aapko court mein case file karna padega aur judge ke saamne apni baat rakhni hogi. Police ko bhi FIR darj karwani hogi, aur phir aapko lawyer ki madad leni hogi. Ghabraaiye mat, main aapko har step samjha dunga. Aapke rights ki protection ke liye kanoon aapke saath hai, chinta mat kijiye.
```

**Running the service**:
NOTE: this is after running ```uvicorn main:app --port 8001 --reload``` on a separate terminal.

```bash
PS C:\Users\madhu> $body = @{ query = "My bike was hit by a car, what can I claim?"; language = "hinglish" } | ConvertTo-Json
PS C:\Users\madhu> Invoke-RestMethod -Uri "http://localhost:8001/api/legal/analyze" -Method Post -ContentType "application/json" -Body $body | ConvertTo-Json -Depth 10
{
    "query":  "My bike was hit by a car, what can I claim?",
    "sub_questions":  [
                          "What are the provisions under the Motor Vehicles Act (MVA) for claiming compensation in a road accident?",
                          "What is the process for filing a claim under the MVA?",
                          "What are the documents required to support a claim for damages under the MVA?"
                      ],
    "research":  [
                     {
                         "question":  "What are the provisions under the Motor Vehicles Act (MVA) for claiming compensation in a road accident?",
                         "answer":  "The retrieved context does not cover the provisions under the Motor Vehicles Act (MVA) for claiming compensation in a road accident directly. However, it mentions Section 166 and Section 168 of the Act, which relate to claims for compensation and the inquiry to determine compensation, respectively. \n\nAccording to the context, under Section 166 of the Motor Vehicles Act, a petition can be filed seeking compensation for the death of a person in a road traffic accident. The Claims Tribunal is required to hold an inquiry to determine compensation which must appear to it to be just, as per Section 168 of the Act. \n\nIt also mentions that strict rules of evidence are not applicable in an inquiry conducted by the Claims Tribunal, and the term \"rashness and negligence\" has to be construed lightly while making a decision on a petition for claim, as the chapter in the Motor Vehicle Act dealing with compensation is a benevolent legislation and not a penal one.\n\nHowever, the specific provisions and procedures for claiming compensation under the MVA are not explicitly stated in the provided context. Therefore, I cannot verify the exact provisions and procedures.",
                         "source":  "groq",
                         "grounded":  true,
                         "error":  null
                     },
                     {
                         "question":  "What is the process for filing a claim under the MVA?",
                         "answer":  "The retrieved context does not cover the process for filing a claim under the Motor Vehicles Act (MVA) directly. However, it mentions that a petition can be filed under Section 166 of the Act, seeking compensation for the death of a person in a road traffic accident. \n\nAs per the context, the petitioners filed a petition under Section 166 of the Motor Vehicles Act, 1989, seeking compensation of Rs.50,00,000/- for the death of Sri.Gangadhara A. S/o. Ashwathappa, in a road traffic accident. \n\nTo provide more information, Section 166 of the Motor Vehicles Act, 1988, allows a claimant to file a petition before a Motor Accident Claims Tribunal for compensation in case of an accident. However, the exact process and requirements for filing a claim are not specified in the provided context. \n\nTherefore, I cannot verify the exact process for filing a claim under the MVA based on the given context.",
                         "source":  "groq",
                         "grounded":  true,
                         "error":  null
                     },
                     {
                         "question":  "What are the documents required to support a claim for damages under the MVA?",
                         "answer":  "The retrieved context does not cover this directly, but based on the information provided in the excerpts, it can be inferred that the documents required to support a claim for damages under the Motor Vehicles Act (MVA) may include:\n\n1. A certified copy of the report under Section 173 Cr.P.C. (as mentioned in Smt. Gayathri N vs Reliance General Insurance Co on 19 February, 2021)\n2. Mechanical inspection reports of the vehicles (as mentioned in State vs . : Kallu on 25 November, 2019 and Smt. Gayathri N vs Reliance General Insurance Co on 19 February, 2021)\n3. Photographs of the vehicles (as mentioned in State vs . : Kallu on 25 November, 2019)\n4. Post-mortem examination report (as mentioned in Smt. Gayathri N vs Reliance General Insurance Co on 19 February, 2021)\n5. Proof of expenses incurred for the last rites and obsequies (as mentioned in Smt. Gayathri N vs Reliance General Insurance Co on 19 February, 2021)\n\nHowever, it is essential to note that the specific documents required may vary depending on the circumstances of the case and the jurisdiction. Therefore, it is recommended to consult the relevant provisions of the Motor Vehicles Act and seek advice from a qualified legal professional to determine the exact documents required to support a claim for damages.",
                         "source":  "groq",
                         "grounded":  true,
                         "error":  null
                     }
                 ],
    "final_answer":  {
                         "markdown":  "## Introduction to Claiming Compensation\nIf your bike was hit by a car, you can claim compensation under the Motor Vehicles Act (MVA). The amount of compensation you can claim depends on the severity of the accident, the damage to your bike, and the injuries you sustained. You can file a petition under Section 166 of the MVA to seek compensation.\n\n## Key Legal Provisions\nThe MVA provides provisions for claiming compensation in cases of road accidents. The key sections to note are:\n- Section 166 of the MVA, which allows a claimant to file a petition before a Motor Accident Claims Tribunal for compensation in case of an accident.\n- Section 168 of the MVA, which requires the Claims Tribunal to hold an inquiry to determine compensation that must appear to it to be just.\n\n## Practical Steps to Take\nTo claim compensation, you can take the following steps:\n- File a police report and obtain a copy of the report under Section 173 Cr.P.C.\n- Collect documents such as mechanical inspection reports of the vehicles, photographs of the vehicles, post-mortem examination report (if applicable), and proof of expenses incurred for medical treatment or last rites.\n- Gather evidence of the accident, including witness statements and any available video footage.\n- Consult a lawyer to help you prepare and file a petition under Section 166 of the MVA.\n\n## Important Deadlines and Limitations\nIt is essential to note that there are time limits for filing a claim under the MVA. Although the exact time limit is not specified in the provided context, it is generally recommended to file a claim as soon as possible after the accident. You should also be aware that the Claims Tribunal may have specific requirements and deadlines for filing documents and appearing for hearings.\n\n## Disclaimer\nThis response provides general information and is not a substitute for professional legal advice. The specific documents required and the process for filing a claim may vary depending on the circumstances of the case and the jurisdiction. It is recommended that you consult a qualified lawyer to determine the exact requirements and procedures for claiming compensation under the MVA.",
                         "hinglish":  "Dekhiye, aapke bike ko car ne hit kiya hai, to aap Motor Vehicles Act ke tehet compensation claim kar sakte hain, khaskar Section 166 ke under. Pehle ek police complaint aur FIR ki copy le lijiye, phir insurance company ko notice bhejna padega. Aapko apne case ke details collect karne honge, jaise ki mechanical inspection reports, photographs, aur medical expenses ka proof. Ghabraaiye mat, main aapko har step samjha dunga.",
                         "citation_validation":  [

                                                 ]
                     }
}
```