### PR TITLE
fix: footer responsiveness on tablet and small screens

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
@@ -54,7 +54,7 @@ export default function Footer() {
     ];
 
     return (
-        <footer style={{
+        <footer className="landing-footer" style={{
             background: '#111827',
             borderTop: '1px solid rgba(255, 255, 255, 0.08)',
             padding: '4rem 0 2rem',
@@ -80,6 +80,7 @@ export default function Footer() {
             }}>
 
                 <motion.div
+                    className="footer-grid"
                     initial={{ opacity: 0, y: 30 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
@@ -91,7 +92,7 @@ export default function Footer() {
                     }}>
                     {/* Brand Section */}
                     <div>
-                        <div style={{
+                        <div className="footer-brand-row" style={{
                             display: 'flex',
                             alignItems: 'center',
                             gap: '0.75rem',
@@ -121,7 +122,7 @@ export default function Footer() {
                         }}>
                             {t('landing:footer.tagline')}
                         </p>
-                        <div style={{ display: 'flex', gap: '1rem' }}>
+                        <div className="footer-social-links" style={{ display: 'flex', gap: '1rem' }}>
                             {socialLinks.map((link) => (
                                 <motion.a
                                     key={link.label}
@@ -181,12 +182,13 @@ export default function Footer() {
                         }}>
                             {t('landing:footer.quickLinks')}
                         </h3>
-                        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                        <ul className="footer-link-list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                             {quickLinks.map((link) => (
                                 <li key={link.label} style={{ marginBottom: '0.75rem' }}>
                                     {link.action ? (
                                         <button
                                             type="button"
+                                            className="footer-nav-button"
                                             onClick={link.action}
                                             style={{
                                                 color: 'rgba(255, 255, 255, 0.7)',
@@ -247,6 +249,7 @@ export default function Footer() {
                                     ) : link.isRoute ? (
                                         <Link
                                             to={link.href}
+                                            className="footer-nav-link"
                                             style={{
                                                 color: 'rgba(255, 255, 255, 0.7)',
                                                 textDecoration: 'none',
@@ -300,6 +303,7 @@ export default function Footer() {
                                     ) : (
                                         <a
                                             href={link.href}
+                                            className="footer-nav-link"
                                             style={{
                                                 color: 'rgba(255, 255, 255, 0.7)',
                                                 textDecoration: 'none',
@@ -364,11 +368,12 @@ export default function Footer() {
                         }}>
                             {t('landing:footer.legal')}
                         </h3>
-                        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                        <ul className="footer-link-list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                             {legalLinks.map((link) => (
                                 <li key={link.label} style={{ marginBottom: '0.75rem' }}>
                                     <Link
                                         to={link.href}
+                                        className="footer-nav-link"
                                         style={{
                                             color: 'rgba(255, 255, 255, 0.7)',
                                             textDecoration: 'none',
@@ -430,16 +435,15 @@ export default function Footer() {
                         }}>
                             {t('landing:footer.getInTouch')}
                         </h3>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+                        <div className="footer-contact-list" style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
                             <a
                                 href="mailto:gadekarvidera4@gmail.com"
+                                className="footer-contact-link"
                                 style={{
                                     color: 'rgba(255, 255, 255, 0.7)',
                                     textDecoration: 'none',
                                     fontSize: '0.95rem',
                                     transition: 'all 0.3s ease',
-                                    display: 'inline-block',
-                                    position: 'relative',
                                     display: 'flex',
                                     alignItems: 'center',
                                     gap: '0.5rem'
@@ -477,13 +481,13 @@ export default function Footer() {
                                 href="https://github.com/viru0909-dev/nyay-setu-working"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                className="footer-contact-link"
                                 style={{
                                     color: 'rgba(255, 255, 255, 0.7)',
                                     textDecoration: 'none',
                                     fontSize: '0.95rem',
                                     display: 'flex',
                                     transition: 'all 0.3s ease',
-                                    position: 'relative',
                                     alignItems: 'center',
                                     gap: '0.5rem'
                                 }}
@@ -523,7 +527,7 @@ export default function Footer() {
                 </motion.div>
 
                 {/* Bottom Bar */}
-                <div style={{
+                <div className="footer-bottom-bar" style={{
                     borderTop: '1px solid rgba(255, 255, 255, 0.1)',
                     paddingTop: '2rem',
                     display: 'flex',

--- a/frontend/nyaysetu-frontend/src/styles/global.css
+++ b/frontend/nyaysetu-frontend/src/styles/global.css
@@ -350,6 +350,16 @@ a:hover { color: var(--color-primary); }
   .grid-cols-3,
   .grid-cols-4 { grid-template-columns: 1fr; }
   .container   { padding: 0 var(--spacing-lg); }
+
+  .fab {
+    right: 1rem;
+    width: 52px;
+    height: 52px;
+  }
+
+  .scroll-top-button {
+    --scroll-top-bottom: 6.5rem;
+  }
 }
 
 /* Floating action base (shared by assistant + scroll button) */

--- a/frontend/nyaysetu-frontend/src/styles/responsive.css
+++ b/frontend/nyaysetu-frontend/src/styles/responsive.css
@@ -266,7 +266,7 @@
     }
 
     /* Make buttons visible and touch-friendly */
-    button:not(.guest-continue-btn):not(.guest-btn-primary):not(.guest-btn-secondary):not(.guest-btn-ghost):not(.auth-full-width-btn),
+    button:not(.guest-continue-btn):not(.guest-btn-primary):not(.guest-btn-secondary):not(.guest-btn-ghost):not(.auth-full-width-btn):not(.footer-nav-button),
     .next-btn,
     .prev-btn,
     button[type="submit"]:not(.auth-full-width-btn),
@@ -369,6 +369,87 @@
         padding-top: 0.5rem !important;
         border-top: 1px solid var(--border-glass) !important;
 
+    }
+}
+
+/* Landing footer — tablet & small screens (≤1024px, incl. ~614px) */
+@media (max-width: 1024px) {
+    .landing-footer {
+        overflow: visible !important;
+        padding-bottom: 11rem !important;
+    }
+
+    .landing-footer > .container {
+        padding-left: 1.25rem !important;
+        padding-right: 1.25rem !important;
+    }
+
+    .landing-footer .footer-grid {
+        grid-template-columns: 1fr !important;
+        gap: 2.5rem !important;
+    }
+
+    .landing-footer .footer-brand-row {
+        flex-direction: row !important;
+        align-items: center !important;
+    }
+
+    .landing-footer .footer-social-links {
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
+        gap: 1rem !important;
+    }
+
+    .landing-footer .footer-social-links a {
+        min-height: 40px !important;
+        min-width: 40px !important;
+        width: 40px !important;
+        height: 40px !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    .landing-footer .footer-contact-list {
+        flex-direction: column !important;
+        gap: 0.75rem !important;
+    }
+
+    .landing-footer .footer-contact-link {
+        flex-direction: row !important;
+        align-items: flex-start !important;
+        flex-wrap: wrap !important;
+        min-height: auto !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        max-width: 100% !important;
+        word-break: break-word !important;
+        overflow-wrap: anywhere !important;
+    }
+
+    .landing-footer .footer-contact-link .contact-icon {
+        flex-shrink: 0 !important;
+    }
+
+    .landing-footer .footer-link-list li {
+        margin-bottom: 0.75rem !important;
+    }
+
+    .landing-footer .footer-nav-link,
+    .landing-footer .footer-nav-button {
+        padding: 0 !important;
+        margin: 0 !important;
+        min-height: auto !important;
+        font-size: 0.95rem !important;
+        text-align: left !important;
+        width: auto !important;
+        display: inline-block !important;
+        line-height: 1.5 !important;
+    }
+
+    .landing-footer .footer-bottom-bar {
+        flex-direction: column !important;
+        align-items: flex-start !important;
+        gap: 0.75rem !important;
     }
 }
 


### PR DESCRIPTION
## Description

Fixes footer layout on tablet and smaller viewports (e.g. **614px**), where sections were misaligned, social icons stacked vertically, Quick Links spacing was uneven, contact email was truncated, and floating action buttons overlapped footer content.

**Root cause:** The footer grid allowed two cramped columns at ~614px, and global mobile/tablet CSS (form/button/flex rules) unintentionally affected footer elements.

**Solution:**
- Added scoped CSS classes on `Footer.jsx` for targeted styling
- Single-column footer grid below **1024px**
- Restored horizontal social icon row and consistent link spacing
- Enabled email text wrapping in the contact section
- Added footer bottom padding and minor FAB adjustments to prevent overlap

**Files changed:**
- `frontend/nyaysetu-frontend/src/components/landing/Footer.jsx`
- `frontend/nyaysetu-frontend/src/styles/responsive.css`
- `frontend/nyaysetu-frontend/src/styles/global.css`

## Related Issue

Closes #998 

## Type of Change

- [x] Bug fix

## Screenshots
### Before
<img width="817" height="549" alt="image" src="https://github.com/user-attachments/assets/d26b15bf-9a2c-4c77-8aac-992ca1bffe5f" />


### After

<img width="608" height="416" alt="image" src="https://github.com/user-attachments/assets/745f081f-4e56-4093-9ebb-620bdfc8c73d" />


## Checklist

- [x] Code follows project guidelines
- [x] Tested locally at 614px and 428px
- [x] No unnecessary files included
- [x] Self-reviewed changes
- [ ] Documentation updated (not required for this UI fix)