### PR TITLE
fix: Fix extract_frames() ignoring frame_interval parameter

### DIFF
--- a/nlp-orchestrator/services/video_processor.py
+++ b/nlp-orchestrator/services/video_processor.py
@@ -45,12 +45,9 @@ async def extract_frames(video_path: str, job_id: str, frame_interval: int = 30)
     # Run OpenCV extraction in a thread to not block asyncio pool
     def _extract():
         cap = cv2.VideoCapture(video_path)
-        fps = int(cap.get(cv2.CAP_PROP_FPS))
-        if fps == 0:
-            fps = 30 # default assumed
-            
-        # extract 1 frame per second
-        interval = fps 
+
+        # extract every frame_interval frames
+        interval = max(1, frame_interval)
         
         count = 0
         success, image = cap.read()

--- a/nlp-orchestrator/tests/test_video_processor.py
+++ b/nlp-orchestrator/tests/test_video_processor.py
@@ -1,0 +1,43 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.modules.setdefault('cv2', Mock())
+sys.modules.setdefault('aiohttp', Mock())
+
+import services.video_processor as vp
+from services.video_processor import extract_frames
+
+
+class DummyCap:
+    def __init__(self, frame_count):
+        self.remaining = frame_count
+
+    def get(self, prop):
+        return 25
+
+    def read(self):
+        if self.remaining > 0:
+            self.remaining -= 1
+            return True, b'image'
+        return False, None
+
+    def release(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_extract_frames_frame_interval_controls_frequency(monkeypatch, tmp_path):
+    monkeypatch.setattr(vp, 'UPLOAD_DIR', str(tmp_path))
+    monkeypatch.setattr(vp.cv2, 'VideoCapture', lambda path: DummyCap(61))
+    monkeypatch.setattr(vp.cv2, 'resize', lambda image, size: image)
+    monkeypatch.setattr(vp.cv2, 'imwrite', lambda path, image: True)
+
+    results = [
+        len(await extract_frames('/tmp/fake.mp4', 'job', frame_interval=interval))
+        for interval in (1, 10, 30)
+    ]
+
+    assert results[0] > results[1] > results[2]
+    assert results == [50, 7, 3]


### PR DESCRIPTION
# Pull Request

## Description

Fixes an issue where `extract_frames()` ignored the provided `frame_interval` parameter and always sampled frames based on the video's FPS.

### Changes Made

* Updated frame extraction logic to use the supplied `frame_interval` value.
* Removed unused FPS-based interval calculation.
* Added a regression test to verify that different `frame_interval` values produce different extraction frequencies.
* Verified that the regression test passes with the fix and fails when the old behavior is restored.

### Testing

* Added `test_video_processor.py` covering the reported bug scenario.
* Confirmed the regression test passes successfully.
* Confirmed the regression test fails when the original FPS-based implementation is reintroduced.

Closes #1182

If this contribution meets the project requirements, kindly consider adding the following labels:

* `gssoc:approved`
* `level: `
* `quality: `

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
