### PR TITLE
fix: prevent role escalation on public registration

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
                     req.getEmail(),
                     req.getName(),
                     req.getPassword(),
-                    req.getRole() != null ? req.getRole() : Role.LITIGANT // default to LITIGANT
+                    Role.LITIGANT // public registration always creates LITIGANT — role is not caller-controlled
             );
             
             // Auto-login after registration

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/RegisterRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/RegisterRequest.java
@@ -1,22 +1,31 @@
 package com.nyaysetu.backend.dto;
 
-import com.nyaysetu.backend.entity.Role;
 import lombok.Data;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+/**
+ * DTO for the public self-registration endpoint.
+ *
+ * NOTE: There is intentionally NO `role` field here.
+ * Public registration always creates a LITIGANT account.
+ * Elevated roles (JUDGE, POLICE, LAWYER, ADMIN, etc.) are
+ * provisioned only by an admin through a separate secured endpoint.
+ * Accepting a caller-supplied role here would allow any anonymous
+ * user to self-escalate to JUDGE or ADMIN privileges.
+ */
 @Data
 public class RegisterRequest {
 
-    @NotBlank(message="Email is required")
-    @Email(message="Invalid email format")
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
     private String email;
+
     @NotBlank(message = "Name is required")
     private String name;
 
     @NotBlank(message = "Password is required")
     @Size(min = 8, message = "Password must be at least 8 characters")
     private String password;
-    private Role role; // very important
 }


### PR DESCRIPTION
## Description
Removes the `role` field from `RegisterRequest.java` and hardcodes `Role.LITIGANT`
in `AuthController.java`. Previously, any unauthenticated caller could POST
`"role": "JUDGE"` or `"role": "ADMIN"` during registration and receive a fully
privileged JWT. Elevated roles must be provisioned through a separate admin-only
endpoint.

Closes Closes #1141

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes