### PR TITLE
fix: replace console error logging in CaseManagementService

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseManagementService.java
@@ -181,10 +181,10 @@ public class CaseManagementService {
             // BUT, to satisfy "dedicated storage", we really should create a document record.
             // Let's inject DocumentRepository and create a record pointing to a placeholder.
             
-        } catch (Exception e) {
-           // log error but don't fail transaction
-           System.err.println("Failed to auto-generate draft document: " + e.getMessage());
-        }
+          } catch (Exception e) {
+              // log error but don't fail transaction
+              log.error("Failed to auto-generate draft document", e);
+          }
 
         // Notify Client
         if (caseEntity.getClient() != null) {

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/CaseManagementServiceTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/CaseManagementServiceTest.java
@@ -1,0 +1,64 @@
+package com.nyaysetu.backend.service;
+
+import com.nyaysetu.backend.entity.CaseEntity;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.repository.CaseRepository;
+import com.nyaysetu.backend.repository.HearingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CaseManagementServiceTest {
+
+    @Mock
+    private CaseRepository caseRepository;
+
+    @Mock
+    private HearingRepository hearingRepository;
+
+    @Mock
+    private com.nyaysetu.backend.notification.service.NotificationService notificationService;
+
+    @Mock
+    private com.nyaysetu.backend.service.CaseTimelineService timelineService;
+
+    private CaseManagementService service;
+
+    @BeforeEach
+    public void setup() {
+        service = new CaseManagementService(caseRepository, hearingRepository, notificationService, timelineService);
+    }
+
+    @Test
+    public void sendDraftForApproval_swallowsException_whenDraftContentIsNull() {
+        UUID caseId = UUID.randomUUID();
+
+        User client = User.builder().id(1L).email("client@example.com").name("Client").build();
+
+        CaseEntity caseEntity = CaseEntity.builder()
+                .id(caseId)
+                .client(client)
+                .build();
+
+        when(caseRepository.findById(caseId)).thenReturn(Optional.of(caseEntity));
+        when(caseRepository.save(ArgumentMatchers.any(CaseEntity.class))).thenAnswer(i -> i.getArgument(0));
+
+        // Passing null draftContent should cause a NPE inside the try block, which must be swallowed
+        assertDoesNotThrow(() -> service.sendDraftForApproval(caseId, null));
+
+        // Verify that the case was saved (status update) and timeline updated
+        verify(caseRepository, atLeastOnce()).save(ArgumentMatchers.any(CaseEntity.class));
+        verify(timelineService).addEvent(eq(caseId), eq("DRAFT_SUBMITTED"), anyString());
+    }
+}


### PR DESCRIPTION
## Description

Closes #1273 

### Summary

This PR replaces direct console error output in `CaseManagementService` with structured SLF4J logging.

Previously, exceptions occurring during auto-generated draft document creation were logged using `System.err.println(...)`, which bypasses the application's configured logging framework and prevents proper error monitoring in production environments.

### Changes Made

* Replaced `System.err.println(...)` with `log.error(...)` in `CaseManagementService`.
* Preserved existing behavior (exceptions are still caught and do not interrupt the transaction flow).
* Added unit test coverage for the exception handling path to ensure the method continues operating correctly when draft generation fails.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes

### Test Results

```text
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
