### PR TITLE
fix: replace printStackTrace with structured logging

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
@@ -261,7 +261,7 @@ public class DocumentManagementController {
                             "attachment; filename=\"Certificate_" + id + ".pdf\"")
                     .body(pdfBytes);
         } catch (Exception e) {
-            e.printStackTrace(); // Log stack trace to console
+            log.error("Certificate generation failed for document {}", id, e);
             return ResponseEntity.status(500).body(Map.of("error", "Certificate generation failed: " + e.getMessage()));
         }
     }

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/DocumentManagementControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/DocumentManagementControllerTest.java
@@ -1,0 +1,90 @@
+package com.nyaysetu.backend.controller;
+
+import com.nyaysetu.backend.entity.Role;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.service.AuthService;
+import com.nyaysetu.backend.service.CaseManagementService;
+import com.nyaysetu.backend.service.DocumentAnalysisService;
+import com.nyaysetu.backend.service.DocumentManagementService;
+import com.nyaysetu.backend.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentManagementControllerTest {
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private DocumentManagementService documentManagementService;
+
+    @Mock
+    private CaseManagementService caseManagementService;
+
+    @Mock
+    private com.nyaysetu.backend.service.CaseAccessService caseAccessService;
+
+    @Mock
+    private DocumentAnalysisService documentAnalysisService;
+
+    @Mock
+    private com.nyaysetu.backend.service.CertificateService certificateService;
+
+    private DocumentManagementController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new DocumentManagementController(
+                documentManagementService,
+                caseManagementService,
+                authService,
+                caseAccessService,
+                documentAnalysisService,
+                certificateService
+        );
+    }
+
+    @Test
+    void downloadCertificate_shouldReturn500WhenCertificateGenerationFails() throws Exception {
+        UUID documentId = UUID.randomUUID();
+
+        User user = User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .name("Test User")
+                .role(Role.LAWYER)
+                .build();
+
+        when(authService.findByEmail("user@example.com")).thenReturn(user);
+        doNothing().when(documentManagementService).ensureDocumentAccess(documentId, 1L, "LAWYER");
+        when(certificateService.generateDocumentCertificate(documentId))
+                .thenThrow(new RuntimeException("Generator failure"));
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("user@example.com", null);
+
+        ResponseEntity<?> response = controller.downloadCertificate(documentId, auth);
+
+        assertEquals(500, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertEquals("Certificate generation failed: Generator failure", body.get("error"));
+    }
+}


### PR DESCRIPTION
## Description

Closes #1275

### Summary

This PR replaces direct console stack trace output in `DocumentManagementController` with structured SLF4J logging.

Previously, certificate generation failures were handled using `printStackTrace()`, which bypasses the application's configured logging framework and makes monitoring and troubleshooting more difficult in production environments.

### Changes Made

* Replaced `e.printStackTrace()` with structured `log.error(...)` logging.
* Preserved existing endpoint behavior and HTTP responses.
* Added focused unit test coverage for the certificate generation failure path.
* Verified that the endpoint continues returning HTTP 500 with the expected error response when certificate generation fails.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes

## Test Results

```text
DocumentManagementControllerTest: PASSED
Backend test suite: PASSED

Tests run: 18
Failures: 0
Errors: 0
Skipped: 0
BUILD SUCCESS
```
