### PR TITLE
docs: fix markdown formatting for Local Development Setup heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ This project is licensed under the **MIT License**. See the [LICENSE](./LICENSE)
   Built with purpose for a more accessible Indian Judiciary.<br/>
   <em>Nyay Setu — न्याय हर किसी का अधिकार है।</em>
 </p>
+
 ## Local Development Setup
 
 ### Prerequisites


### PR DESCRIPTION
Fixes a rendering issue in the README where '## Local Development Setup' was displayed as plain text because it lacked a preceding blank line after a closing HTML tag.