### PR TITLE
fix: sanitize uploaded video filenames in forensics service

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/forensics/service/ForensicsService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/forensics/service/ForensicsService.java
@@ -17,6 +17,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -60,7 +61,9 @@ public class ForensicsService {
             }
             
             for (MultipartFile video : videos) {
-                String filename = UUID.randomUUID() + "_" + video.getOriginalFilename();
+                String rawName = video.getOriginalFilename() != null ? video.getOriginalFilename() : "video";
+                String safeName = new File(rawName).getName(); // strips all path separators
+                String filename = UUID.randomUUID() + "_" + safeName;
                 Path filePath = uploadPath.resolve(filename);
                 Files.copy(video.getInputStream(), filePath);
                 // For local fastAPI to access, we can give absolute paths

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/forensics/service/ForensicsServicePathTraversalTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/forensics/service/ForensicsServicePathTraversalTest.java
@@ -1,0 +1,119 @@
+package com.nyaysetu.backend.forensics.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.forensics.entity.AccidentCase;
+import com.nyaysetu.backend.forensics.repository.AccidentCaseRepository;
+import com.nyaysetu.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ForensicsServicePathTraversalTest {
+
+    @Mock
+    private AccidentCaseRepository accidentCaseRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private ForensicsService forensicsService;
+
+    @TempDir
+    private Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        forensicsService = new ForensicsService(
+                accidentCaseRepository,
+                userRepository,
+                objectMapper
+        );
+        ReflectionTestUtils.setField(forensicsService, "UPLOAD_DIR", tempDir.toString() + "/forensics/");
+    }
+
+    @Test
+    void testNormalFilenameUploadSucceeds() throws IOException {
+        String username = "test@example.com";
+        User mockUser = User.builder().id(1L).email(username).build();
+        AccidentCase savedCase = AccidentCase.builder().id(UUID.randomUUID()).build();
+
+        when(userRepository.findByEmail(username)).thenReturn(Optional.of(mockUser));
+        when(accidentCaseRepository.save(any(AccidentCase.class))).thenReturn(savedCase);
+
+        byte[] content = "test video content".getBytes();
+        MultipartFile videoFile = createMockMultipartFile("evidence.mp4", content);
+
+        UUID jobId = forensicsService.initializeAnalysis(List.of(videoFile), "Test description", username);
+
+        assertNotNull(jobId);
+        File[] files = tempDir.resolve("forensics").toFile().listFiles();
+        assertNotNull(files);
+        assertEquals(1, files.length);
+
+        File savedFile = files[0];
+        assertEquals(tempDir.resolve("forensics").toRealPath(), savedFile.getParentFile().toPath().toRealPath());
+        assertFalse(savedFile.getName().contains("../"));
+        assertTrue(savedFile.getName().endsWith("evidence.mp4"));
+    }
+
+    @Test
+    void testTraversalFilenamesAreSanitized() throws IOException {
+        String username = "test@example.com";
+        User mockUser = User.builder().id(1L).email(username).build();
+        AccidentCase savedCase = AccidentCase.builder().id(UUID.randomUUID()).build();
+
+        when(userRepository.findByEmail(username)).thenReturn(Optional.of(mockUser));
+        when(accidentCaseRepository.save(any(AccidentCase.class))).thenReturn(savedCase);
+
+        List<String> originals = List.of("../../../tmp/evil.mp4", "a/../../../tmp/evil.mp4", "..\\..\\tmp\\evil.mp4");
+        byte[] content = "malicious video".getBytes();
+
+        for (String originalFilename : originals) {
+            MultipartFile videoFile = createMockMultipartFile(originalFilename, content);
+            UUID jobId = forensicsService.initializeAnalysis(List.of(videoFile), "Test", username);
+            assertNotNull(jobId, "Upload should succeed for " + originalFilename);
+        }
+
+        File[] files = tempDir.resolve("forensics").toFile().listFiles();
+        assertNotNull(files);
+        assertEquals(originals.size(), files.length);
+
+        for (File savedFile : files) {
+            assertEquals(tempDir.resolve("forensics").toRealPath(), savedFile.getParentFile().toPath().toRealPath());
+            assertFalse(savedFile.getName().contains(".."), "Stored filename must not contain path traversal");
+            assertFalse(savedFile.getName().contains("/"));
+            assertFalse(savedFile.getName().contains("\\"));
+            assertTrue(savedFile.getName().endsWith("evil.mp4"));
+        }
+    }
+
+    private MultipartFile createMockMultipartFile(String originalFilename, byte[] content) throws IOException {
+        MultipartFile mock = mock(MultipartFile.class);
+        when(mock.getOriginalFilename()).thenReturn(originalFilename);
+        when(mock.getInputStream()).thenReturn(new ByteArrayInputStream(content));
+        return mock;
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes a path traversal vulnerability in the forensic video upload flow by sanitizing user-controlled filenames before generating the destination file path.

Previously, `ForensicsService` used `MultipartFile.getOriginalFilename()` directly when constructing upload paths. Since uploaded filenames originate from user input, crafted filenames containing path traversal sequences or directory separators could influence the resolved filesystem location.

### Changes Made

* Sanitized uploaded filenames before path construction.
* Ensured uploaded files remain within the intended upload directory.
* Added regression test coverage for malicious filename inputs.
* Preserved existing behavior for valid uploads.

### Test Coverage

Added tests covering:

* Standard video uploads
* Unix-style path traversal attempts (`../`)
* Nested traversal sequences
* Windows-style path traversal attempts (`..\`)
* Filename sanitization behavior

Closes #1295

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes

## Security Impact

This change prevents user-supplied filenames from influencing the final filesystem path used for uploaded forensic videos. Uploaded files are now constrained to the intended upload directory, mitigating path traversal risks while maintaining existing upload functionality.
