### PR TITLE
fix: complete session only after document transfer

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendService.java
@@ -474,14 +474,14 @@ public class VakilFriendService {
             }
         }
  
-        // Mark session as completed
+        transferDocumentsBeforeCompletion(sessionId, resultEntity);
+
+        // Mark session as completed only after document transfer succeeds.
         session.setStatus(ChatSessionStatus.COMPLETED);
         session.setUpdatedAt(LocalDateTime.now());
         chatSessionRepository.save(session);
-        // Link any uploaded documents to the new case/FIR
-        if (resultEntity instanceof CaseEntity) {
-             vakilFriendDocumentService.transferDocumentsToCase(sessionId, ((CaseEntity)resultEntity).getId());
-        } else if (resultEntity instanceof FirRecord) {
+
+        else if (resultEntity instanceof FirRecord) {
              // For FIRs, we might need a different logic or linked entity, currently linking to "caseId" which is UUID. 
              // But FirRecord uses String ID usually? No, let's see. 
              // FirRecord usually has a String firNumber. 
@@ -495,6 +495,36 @@ public class VakilFriendService {
  
         return resultEntity;
     }
+
+    /**
+ * Transfers uploaded Vakil-Friend documents before completing the session.
+ * If transfer fails, the transaction is rolled back and the session remains active.
+ */
+private void transferDocumentsBeforeCompletion(UUID sessionId, Object resultEntity) {
+    if (!(resultEntity instanceof CaseEntity)) {
+        log.debug(
+                "Skipping document transfer for non-case filing result: {}",
+                resultEntity.getClass().getSimpleName()
+        );
+        return;
+    }
+
+    CaseEntity caseEntity = (CaseEntity) resultEntity;
+
+    try {
+        vakilFriendDocumentService.transferDocumentsToCase(sessionId, caseEntity.getId());
+    } catch (Exception e) {
+        log.error(
+                "Failed to transfer Vakil-Friend documents before completing session: {}",
+                sessionId,
+                e
+        );
+        throw new RuntimeException(
+                "Failed to transfer uploaded documents. Session was not completed.",
+                e
+        );
+    }
+}
     
     /**
      * Auto-schedule the first hearing for a case

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendService.java
@@ -481,50 +481,49 @@ public class VakilFriendService {
         session.setUpdatedAt(LocalDateTime.now());
         chatSessionRepository.save(session);
 
-        else if (resultEntity instanceof FirRecord) {
-             // For FIRs, we might need a different logic or linked entity, currently linking to "caseId" which is UUID. 
-             // But FirRecord uses String ID usually? No, let's see. 
-             // FirRecord usually has a String firNumber. 
-             // DocumentEntity expects UUID caseId. 
-             // If FIR doesn't have UUID, we can't link easily unless we change DocumentEntity or FirRecord.
-             // Checking FirRecord: it likely has a UUID ID too?
-             // Assuming we skip FIR document linking for now or it's handled differently.
-             // Actually, let's check FirRecord definition if I can view it. I haven't viewed it.
-             // But for safer side, I'll only link for CaseEntity which has UUID.
+        if (resultEntity instanceof FirRecord) {
+            log.debug("Skipping case-document transfer for FIR filing result");
         }
- 
+
         return resultEntity;
     }
 
     /**
- * Transfers uploaded Vakil-Friend documents before completing the session.
- * If transfer fails, the transaction is rolled back and the session remains active.
- */
-private void transferDocumentsBeforeCompletion(UUID sessionId, Object resultEntity) {
-    if (!(resultEntity instanceof CaseEntity)) {
-        log.debug(
-                "Skipping document transfer for non-case filing result: {}",
-                resultEntity.getClass().getSimpleName()
-        );
-        return;
+     * Transfers uploaded Vakil-Friend documents before completing the session.
+     * If transfer fails, the transaction is rolled back and the session remains active.
+     */
+    private void transferDocumentsBeforeCompletion(
+            UUID sessionId,
+            Object resultEntity
+    ) {
+        if (!(resultEntity instanceof CaseEntity)) {
+            log.debug(
+                    "Skipping document transfer for non-case filing result: {}",
+                    resultEntity.getClass().getSimpleName()
+            );
+            return;
+        }
+
+        CaseEntity caseEntity = (CaseEntity) resultEntity;
+
+        try {
+            vakilFriendDocumentService.transferDocumentsToCase(
+                    sessionId,
+                    caseEntity.getId()
+            );
+        } catch (Exception e) {
+            log.error(
+                    "Failed to transfer Vakil-Friend documents before completing session: {}",
+                    sessionId,
+                    e
+            );
+            throw new RuntimeException(
+                    "Failed to transfer uploaded documents. Session was not completed.",
+                    e
+            );
+        }
     }
 
-    CaseEntity caseEntity = (CaseEntity) resultEntity;
-
-    try {
-        vakilFriendDocumentService.transferDocumentsToCase(sessionId, caseEntity.getId());
-    } catch (Exception e) {
-        log.error(
-                "Failed to transfer Vakil-Friend documents before completing session: {}",
-                sessionId,
-                e
-        );
-        throw new RuntimeException(
-                "Failed to transfer uploaded documents. Session was not completed.",
-                e
-        );
-    }
-}
     
     /**
      * Auto-schedule the first hearing for a case


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a data-loss risk in the Vakil-Friend `completeSession()` flow.

Previously, a session could be marked as `COMPLETED` before uploaded documents were transferred to the newly created case. If the transfer failed, the session could remain permanently completed while its evidence was not linked correctly.

The updated flow transfers documents before changing the session status. If document transfer fails, the method throws an exception before the session is finalized.

Closes #770

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] No breaking change introduced
- [x] Documentation update is not required for this backend-only fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented the document-transfer ordering where necessary
- [x] Documentation changes are not applicable for this backend-only fix
- [x] My changes generate no new whitespace warnings
- [x] I verified that document transfer occurs before the session is marked as `COMPLETED`
- [x] Document-transfer failure prevents the session from being finalized
- [x] Local Maven tests could not be run because Maven is not installed or configured on my system

## Testing

* [x] Ran `git diff --check` successfully
* [x] Verified `transferDocumentsBeforeCompletion(...)` executes before `ChatSessionStatus.COMPLETED`
* [x] Verified that document-transfer failure throws before the session status is updated
* [x] Confirmed that this PR changes only `VakilFriendService.java`

## Screenshots

Not applicable, backend-only change.
