### PR TITLE
feat(auth): persist refreshToken and add refresh API support

### DIFF
--- a/frontend/nyaysetu-frontend/src/hooks/useSessionMonitor.jsx
+++ b/frontend/nyaysetu-frontend/src/hooks/useSessionMonitor.jsx
@@ -41,6 +41,8 @@ export const useSessionMonitor = (token) => {
     }, [token]);
     const handleLogout = () => {
         localStorage.removeItem('token');
+        // Also clear refresh token to avoid stale credentials
+        localStorage.removeItem('refreshToken');
         setShowWarning(false);
         // Redirects to login with a special parameter so we can show a nice message later
         window.location.href = '/login?reason=session_expired';

--- a/frontend/nyaysetu-frontend/src/pages/Login.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/Login.jsx
@@ -56,7 +56,7 @@ export default function Login() {
 
           //  console.log('Sending login request:', loginPayload);
             const response = await authAPI.login(loginPayload);
-            const { token, user } = response.data;
+            const { token, user, refreshToken } = response.data;
 
             if (selectedRole && user.role !== selectedRole) {
                 setError(`Invalid credentials for ${roles.find(r => r.value === selectedRole)?.label}`);
@@ -64,7 +64,7 @@ export default function Login() {
                 return;
             }
 
-            setAuth(user, token);
+            setAuth(user, token, refreshToken);
 
             navigate(resolvePostAuthPath(user.role, location.state));
         } catch (err) {

--- a/frontend/nyaysetu-frontend/src/services/api.js
+++ b/frontend/nyaysetu-frontend/src/services/api.js
@@ -102,8 +102,13 @@ export const authAPI = {
     logout: () => {
         localStorage.removeItem('token');
         localStorage.removeItem('user');
+        // Clear refresh token when logging out
+        localStorage.removeItem('refreshToken');
     },
 };
+
+// Refresh token endpoint helper
+authAPI.refresh = (refreshToken) => api.post('/api/v1/auth/refresh', { refreshToken });
 
 // Case API
 export const caseAPI = {

--- a/frontend/nyaysetu-frontend/src/store/authStore.js
+++ b/frontend/nyaysetu-frontend/src/store/authStore.js
@@ -66,9 +66,12 @@ export const useAuthStore = create((set, get) => ({
     isAuthenticated: false,
     isGuest: false,
 
-    setAuth: (user, token) => {
+    setAuth: (user, token, refreshToken = null) => {
         storage.setItem('token', token);
         storage.setItem('user', JSON.stringify(user));
+        if (refreshToken) {
+            storage.setItem('refreshToken', refreshToken);
+        }
         clearGuestStorage(storage);
         storage.removeItem(GUEST_INTENT_KEY);
         set({ user, token, isAuthenticated: true, isGuest: false });
@@ -87,6 +90,8 @@ export const useAuthStore = create((set, get) => ({
 
         storage.removeItem('token');
         storage.removeItem('user');
+        // Clear any persisted refresh token when creating a guest session
+        storage.removeItem('refreshToken');
         storage.setItem(GUEST_SESSION_ID_KEY, sessionId);
         storage.setItem(GUEST_USER_KEY, JSON.stringify(guestUser));
         storage.setItem(GUEST_CREATED_AT_KEY, new Date().toISOString());
@@ -107,6 +112,7 @@ export const useAuthStore = create((set, get) => ({
     logout: () => {
         storage.removeItem('token');
         storage.removeItem('user');
+        storage.removeItem('refreshToken');
         clearGuestStorage(storage);
         storage.removeItem(GUEST_INTENT_KEY);
         set({ user: null, token: null, isAuthenticated: false, isGuest: false });
@@ -161,6 +167,8 @@ export const useAuthStore = create((set, get) => ({
                 if (isTokenExpired(token)) {
                     storage.removeItem('token');
                     storage.removeItem('user');
+                    // Ensure refresh token is also cleared when access token expired
+                    storage.removeItem('refreshToken');
 
                     set({
                         token: null,

--- a/frontend/nyaysetu-frontend/src/store/authStore.test.js
+++ b/frontend/nyaysetu-frontend/src/store/authStore.test.js
@@ -34,8 +34,9 @@ describe('authStore', () => {
         it('should set authenticated state and persist user/token to localStorage', () => {
             const user = { id: 1, name: 'Kriti', email: 'kriti@example.com' };
             const token = 'valid-token';
+            const refreshToken = 'refresh-123';
 
-            useAuthStore.getState().setAuth(user, token);
+            useAuthStore.getState().setAuth(user, token, refreshToken);
 
             const state = useAuthStore.getState();
 
@@ -46,6 +47,7 @@ describe('authStore', () => {
 
             expect(ls.getItem('token')).toBe(token);
             expect(ls.getItem('user')).toBe(JSON.stringify(user));
+            expect(ls.getItem('refreshToken')).toBe(refreshToken);
         });
 
         it('should clear guest storage when logging in as authenticated user', () => {
@@ -54,7 +56,8 @@ describe('authStore', () => {
 
             const user = { id: 1, name: 'Kriti' };
             const token = 'valid-token';
-            useAuthStore.getState().setAuth(user, token);
+            const refreshToken = 'refresh-456';
+            useAuthStore.getState().setAuth(user, token, refreshToken);
 
             const state = useAuthStore.getState();
 
@@ -72,8 +75,9 @@ describe('authStore', () => {
         it('should clear all state and localStorage', () => {
             const user = { id: 1, name: 'Kriti' };
             const token = 'valid-token';
+            const refreshToken = 'refresh-789';
 
-            useAuthStore.getState().setAuth(user, token);
+            useAuthStore.getState().setAuth(user, token, refreshToken);
             useAuthStore.getState().logout();
 
             const state = useAuthStore.getState();
@@ -85,11 +89,32 @@ describe('authStore', () => {
 
             expect(ls.getItem('token')).toBeNull();
             expect(ls.getItem('user')).toBeNull();
+            expect(ls.getItem('refreshToken')).toBeNull();
         });
 
         it('should clear guest storage when logging out', () => {
+            // Simulate an authenticated user and refresh token, then switch to guest
+            const user = { id: 1, name: 'Kriti' };
+            const token = 'valid-token';
+            const refreshToken = 'refresh-guest-1';
+
+            ls.setItem('token', token);
+            ls.setItem('user', JSON.stringify(user));
+            ls.setItem('refreshToken', refreshToken);
+
             useAuthStore.getState().setGuest();
 
+            // Auth items should be cleared when a guest session is created
+            expect(ls.getItem('token')).toBeNull();
+            expect(ls.getItem('user')).toBeNull();
+            expect(ls.getItem('refreshToken')).toBeNull();
+
+            // Guest storage remains
+            expect(ls.getItem('guest_session_id')).not.toBeNull();
+            expect(ls.getItem('guest_user')).not.toBeNull();
+            expect(ls.getItem('guest_created_at')).not.toBeNull();
+
+            // Now call logout to ensure logout still clears guest storage
             ls.setItem('guest_modal_shown', 'true');
             ls.setItem('guest_post_auth_intent', JSON.stringify({ path: '/file-case' }));
 
@@ -143,8 +168,9 @@ describe('authStore', () => {
         it('should not mutate application state', () => {
             const user = { id: 1, name: 'Kriti' };
             const token = 'valid-token';
+            const refreshToken = 'refresh-000';
 
-            useAuthStore.getState().setAuth(user, token);
+            useAuthStore.getState().setAuth(user, token, refreshToken);
 
             const prevUser = useAuthStore.getState().user;
             const prevToken = useAuthStore.getState().token;


### PR DESCRIPTION
## Description

This PR adds frontend support for refresh token persistence and lifecycle management.

Changes included:

* Persist `refreshToken` after successful login when returned by the backend.
* Add `authAPI.refresh()` helper for the existing `/api/v1/auth/refresh` endpoint.
* Clear `refreshToken` during logout.
* Clear `refreshToken` during guest transitions.
* Clear `refreshToken` during token-expiry cleanup flows.
* Add/update tests covering refresh token persistence and cleanup behavior.

Closes #1320

## Type of change

* [x] New feature (non-breaking change which adds functionality)

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
