### PR TITLE
feat: enforce JWT RBAC validation on WebRTC signaling server

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -31,13 +31,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-<<<<<<< HEAD
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-=======
->>>>>>> origin/main
 
 @Configuration
 @EnableMethodSecurity
@@ -97,9 +91,6 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-<<<<<<< HEAD
-
-
         // SAFE DEFAULT (Localhost fallback)
         List<String> defaultOrigins = Arrays.asList(
                 "http://localhost:5173",
@@ -108,17 +99,11 @@ public class SecurityConfig {
         );
 
         if (allowedOrigins != null && !allowedOrigins.trim().isEmpty()) {
-=======
-        
-        // Use origins from application.properties / Env Var
-        if (allowedOrigins != null && !allowedOrigins.isEmpty()) {
->>>>>>> origin/main
             List<String> origins = Arrays.stream(allowedOrigins.split(","))
                     .map(String::trim)
                     .filter(s -> !s.isEmpty())
                     .collect(Collectors.toList());
 
-<<<<<<< HEAD
             if (origins.contains("*")) {
                 // SECURITY: Reject bare "*" when credentials are true
                 logger.warn("CORS_ALLOWED_ORIGINS contains bare '*'. This is unsafe with credentials. Falling back to localhost defaults.");
@@ -150,52 +135,6 @@ public class SecurityConfig {
                 "Origin",
                 "X-Requested-With"
         ));
-
-=======
-            if (origins.isEmpty()) {
-                // SAFE DEFAULT: Allow local development origins only
-                configuration.setAllowedOrigins(Arrays.asList(
-                    "http://localhost:5173",
-                    "http://localhost:3000",
-                    "http://localhost"
-                ));
-                configuration.setAllowCredentials(true);
-            } else {
-                // Security: reject bare "*" — it allows any origin to make credentialed requests
-                boolean hasBareWildcard = origins.stream().anyMatch(o -> o.trim().equals("*"));
-                if (hasBareWildcard) {
-                    logger.warn("CORS_ALLOWED_ORIGINS contains bare '*'. "
-                            + "This is unsafe with credentials. Falling back to localhost defaults.");
-                    configuration.setAllowedOrigins(Arrays.asList(
-                        "http://localhost:5173",
-                        "http://localhost:3000",
-                        "http://localhost"
-                    ));
-                } else {
-                    boolean hasPattern = origins.stream().anyMatch(o -> o.contains("*"));
-                    if (hasPattern) {
-                        // Specific patterns like https://*.example.com are safe with credentials
-                        configuration.setAllowedOriginPatterns(origins);
-                    } else {
-                        configuration.setAllowedOrigins(origins);
-                    }
-                }
-                configuration.setAllowCredentials(true);
-            }
-        } else {
-            // SAFE DEFAULT: Allow local development origins only
-            configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:5173", 
-                "http://localhost:3000", 
-                "http://localhost"
-            ));
-            configuration.setAllowCredentials(true);
-        }
-        
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        
->>>>>>> origin/main
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
@@ -234,18 +173,6 @@ public class SecurityConfig {
                                 ))
                 )
                 .authorizeHttpRequests(auth -> auth
-<<<<<<< HEAD
-                        // 2. Only strictly public endpoints allowed
-                        .requestMatchers("/api/auth/register", "/api/auth/login", "/api/auth/forgot-password").permitAll()
-                        .requestMatchers("/api/health/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                        .requestMatchers("/ws/**").permitAll()
-
-                        // 3. The exact fix for the bug: Everything else MUST be authenticated
-                        .anyRequest().authenticated()
-                )
-
-=======
                         // ── Public endpoints ──────────────────────────────────────────────
                         .requestMatchers(
                                 "/api/v1/auth/register",
@@ -257,7 +184,11 @@ public class SecurityConfig {
                                 "/api/v1/auth/ping",
                                 "/api/v1/auth/test",
                                 "/api/v1/health",
-                                "/api/v1/police/health"
+                                "/api/v1/police/health",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/actuator/**"
                         ).permitAll()
 
                         // ── WebSocket endpoints ───────────────────────────────────────────
@@ -346,7 +277,6 @@ public class SecurityConfig {
                         // ── Everything else requires authentication ────────────────────────
                         .anyRequest().authenticated()
                 )
->>>>>>> origin/main
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider())
                 .addFilterBefore(xssSanitizationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/StompWebSocketConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/StompWebSocketConfig.java
@@ -1,6 +1,8 @@
 package com.nyaysetu.backend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +10,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketSecurityInterceptor webSocketSecurityInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -23,5 +28,10 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .withSockJS();
         registry.addEndpoint("/api/ws/stomp")
                 .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketSecurityInterceptor);
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/WebSocketSecurityInterceptor.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/WebSocketSecurityInterceptor.java
@@ -1,0 +1,135 @@
+package com.nyaysetu.backend.config;
+
+import com.nyaysetu.backend.entity.Hearing;
+import com.nyaysetu.backend.entity.Role;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.repository.HearingParticipantRepository;
+import com.nyaysetu.backend.repository.HearingRepository;
+import com.nyaysetu.backend.repository.UserRepository;
+import com.nyaysetu.backend.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketSecurityInterceptor implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+    private final UserRepository userRepository;
+    private final HearingRepository hearingRepository;
+    private final HearingParticipantRepository hearingParticipantRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null) {
+            return message;
+        }
+
+        StompCommand command = accessor.getCommand();
+        if (StompCommand.CONNECT.equals(command)) {
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+            log.debug("STOMP CONNECT header received: {}", authHeader);
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String jwt = authHeader.substring(7);
+                try {
+                    String username = jwtService.extractUsername(jwt);
+                    if (username != null) {
+                        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                        if (jwtService.isTokenValid(jwt, userDetails)) {
+                            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                                    userDetails, null, userDetails.getAuthorities());
+                            accessor.setUser(authentication);
+                            log.info("STOMP connection authenticated for user: {}", username);
+                        } else {
+                            log.warn("STOMP connection failed: Invalid JWT token");
+                            throw new MessageDeliveryException("Invalid JWT token");
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("STOMP connection error: {}", e.getMessage());
+                    throw new MessageDeliveryException("Authentication failed: " + e.getMessage());
+                }
+            } else {
+                log.warn("STOMP connection rejected: Missing or invalid Authorization header");
+                throw new MessageDeliveryException("Missing or invalid Authorization header");
+            }
+        } else if (StompCommand.SUBSCRIBE.equals(command) || StompCommand.SEND.equals(command)) {
+            String destination = accessor.getDestination();
+            if (destination != null) {
+                log.debug("STOMP {} destination: {}", command, destination);
+                // Destination matches /topic/courtroom/{roomId} or /topic/hearing/{roomId}
+                if (destination.startsWith("/topic/courtroom/") || destination.startsWith("/topic/hearing/")) {
+                    Principal principal = accessor.getUser();
+                    if (principal == null) {
+                        log.warn("STOMP {} rejected: Unauthenticated user destination {}", command, destination);
+                        throw new MessageDeliveryException("Access denied: Unauthenticated");
+                    }
+
+                    String roomId = destination.substring(destination.lastIndexOf('/') + 1);
+                    String username = principal.getName();
+                    log.info("Checking {} authorization for user {} to room {}", command, username, roomId);
+
+                    // Fetch user from DB to verify role
+                    User user = userRepository.findByEmail(username)
+                            .orElseThrow(() -> new MessageDeliveryException("User not found: " + username));
+
+                    Role userRole = user.getRole();
+                    // Judge, lawyer, admins can access any courtroom/hearing signaling topic
+                    if (userRole == Role.JUDGE || userRole == Role.LAWYER || userRole == Role.ADMIN 
+                            || userRole == Role.SUPER_JUDGE || userRole == Role.TECH_ADMIN) {
+                        log.info("User {} with role {} authorized for destination {}", username, userRole, destination);
+                    } else {
+                        // For other roles (like LITIGANT), they must be assigned/invited to this specific hearing room
+                        Optional<Hearing> hearingOpt = findHearingByIdOrVideoRoomId(roomId);
+                        if (hearingOpt.isEmpty()) {
+                            log.warn("STOMP {} rejected: Hearing room {} not found", command, roomId);
+                            throw new MessageDeliveryException("Access denied: Hearing room not found");
+                        }
+
+                        Hearing hearing = hearingOpt.get();
+                        boolean isParticipant = hearingParticipantRepository.existsByHearingIdAndUserId(hearing.getId(), user.getId());
+                        if (!isParticipant) {
+                            log.warn("STOMP {} rejected: User {} is not assigned/invited to hearing {}", command, username, hearing.getId());
+                            throw new MessageDeliveryException("Access denied: Not a participant in this hearing");
+                        }
+                        log.info("User {} (LITIGANT) authorized for destination {}", username, destination);
+                    }
+                }
+            }
+        }
+
+        return message;
+    }
+
+    private Optional<Hearing> findHearingByIdOrVideoRoomId(String roomId) {
+        try {
+            // First check if it's a valid UUID
+            UUID uuid = UUID.fromString(roomId);
+            Optional<Hearing> hearing = hearingRepository.findById(uuid);
+            if (hearing.isPresent()) {
+                return hearing;
+            }
+        } catch (IllegalArgumentException e) {
+            // Not a valid UUID, so check by videoRoomId
+        }
+        return hearingRepository.findByVideoRoomId(roomId);
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/HearingRepository.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/HearingRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.Optional;
 
 @Repository
 public interface HearingRepository extends JpaRepository<Hearing, UUID> {
@@ -30,4 +31,6 @@ public interface HearingRepository extends JpaRepository<Hearing, UUID> {
     Hearing findTopByCaseEntityIdAndScheduledDateAfterOrderByScheduledDateAsc(UUID caseId, LocalDateTime date);
 
     List<Hearing> findByCaseEntityInAndScheduledDateBetween(List<CaseEntity> caseEntities, LocalDateTime start, LocalDateTime end);
+
+    Optional<Hearing> findByVideoRoomId(String videoRoomId);
 }

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -36,13 +36,8 @@ spring.jpa.properties.hibernate.format_sql=true
 # Flyway Migration - Production Ready
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
-<<<<<<< HEAD
 spring.flyway.validate-on-migrate=false
 spring.flyway.ignore-migration-patterns=*:missing
-=======
-spring.flyway.validate-on-migrate=true
-spring.flyway.ignore-missing-migrations=false
->>>>>>> origin/main
 # Use a separate connection for Flyway (Direct Connection) to avoid Transaction Pooler issues
 # Defaults to normal datasource if not specified (e.g. locally)
 # spring.flyway.url=${FLYWAY_URL:${spring.datasource.url}}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/config/WebSocketSecurityInterceptorTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/config/WebSocketSecurityInterceptorTest.java
@@ -1,0 +1,227 @@
+package com.nyaysetu.backend.config;
+
+import com.nyaysetu.backend.entity.Hearing;
+import com.nyaysetu.backend.entity.Role;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.repository.HearingParticipantRepository;
+import com.nyaysetu.backend.repository.HearingRepository;
+import com.nyaysetu.backend.repository.UserRepository;
+import com.nyaysetu.backend.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketSecurityInterceptorTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private HearingRepository hearingRepository;
+
+    @Mock
+    private HearingParticipantRepository hearingParticipantRepository;
+
+    @Mock
+    private MessageChannel messageChannel;
+
+    private WebSocketSecurityInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new WebSocketSecurityInterceptor(
+                jwtService,
+                userDetailsService,
+                userRepository,
+                hearingRepository,
+                hearingParticipantRepository
+        );
+    }
+
+    @Test
+    void connectWithValidJwtSucceeds() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.addNativeHeader("Authorization", "Bearer valid-token");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("test@example.com");
+        when(userDetails.getAuthorities()).thenReturn(null);
+
+        when(jwtService.extractUsername("valid-token")).thenReturn("test@example.com");
+        when(userDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
+        when(jwtService.isTokenValid("valid-token", userDetails)).thenReturn(true);
+
+        Message<?> result = interceptor.preSend(message, messageChannel);
+
+        assertNotNull(result);
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertNotNull(resultAccessor.getUser());
+        assertEquals("test@example.com", resultAccessor.getUser().getName());
+    }
+
+    @Test
+    void connectWithInvalidJwtThrowsException() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.addNativeHeader("Authorization", "Bearer invalid-token");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        UserDetails userDetails = mock(UserDetails.class);
+        when(jwtService.extractUsername("invalid-token")).thenReturn("test@example.com");
+        when(userDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
+        when(jwtService.isTokenValid("invalid-token", userDetails)).thenReturn(false);
+
+        assertThrows(MessageDeliveryException.class, () -> interceptor.preSend(message, messageChannel));
+    }
+
+    @Test
+    void connectWithMissingHeaderThrowsException() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        assertThrows(MessageDeliveryException.class, () -> interceptor.preSend(message, messageChannel));
+    }
+
+    @Test
+    void subscribeByJudgeSucceeds() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination("/topic/courtroom/room-123");
+        Principal principal = new UsernamePasswordAuthenticationToken("judge@example.com", null);
+        accessor.setUser(principal);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        User user = new User();
+        user.setEmail("judge@example.com");
+        user.setRole(Role.JUDGE);
+
+        when(userRepository.findByEmail("judge@example.com")).thenReturn(Optional.of(user));
+
+        Message<?> result = interceptor.preSend(message, messageChannel);
+        assertNotNull(result);
+    }
+
+    @Test
+    void subscribeByAssignedLitigantSucceeds() {
+        UUID hearingId = UUID.randomUUID();
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination("/topic/courtroom/" + hearingId);
+        Principal principal = new UsernamePasswordAuthenticationToken("litigant@example.com", null);
+        accessor.setUser(principal);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("litigant@example.com");
+        user.setRole(Role.LITIGANT);
+
+        Hearing hearing = new Hearing();
+        hearing.setId(hearingId);
+
+        when(userRepository.findByEmail("litigant@example.com")).thenReturn(Optional.of(user));
+        when(hearingRepository.findById(hearingId)).thenReturn(Optional.of(hearing));
+        when(hearingParticipantRepository.existsByHearingIdAndUserId(hearingId, 1L)).thenReturn(true);
+
+        Message<?> result = interceptor.preSend(message, messageChannel);
+        assertNotNull(result);
+    }
+
+    @Test
+    void subscribeByUnassignedLitigantThrowsException() {
+        UUID hearingId = UUID.randomUUID();
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination("/topic/courtroom/" + hearingId);
+        Principal principal = new UsernamePasswordAuthenticationToken("litigant@example.com", null);
+        accessor.setUser(principal);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("litigant@example.com");
+        user.setRole(Role.LITIGANT);
+
+        Hearing hearing = new Hearing();
+        hearing.setId(hearingId);
+
+        when(userRepository.findByEmail("litigant@example.com")).thenReturn(Optional.of(user));
+        when(hearingRepository.findById(hearingId)).thenReturn(Optional.of(hearing));
+        when(hearingParticipantRepository.existsByHearingIdAndUserId(hearingId, 1L)).thenReturn(false);
+
+        assertThrows(MessageDeliveryException.class, () -> interceptor.preSend(message, messageChannel));
+    }
+
+    @Test
+    void subscribeWithVideoRoomIdSucceeds() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination("/topic/courtroom/room-xyz");
+        Principal principal = new UsernamePasswordAuthenticationToken("litigant@example.com", null);
+        accessor.setUser(principal);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("litigant@example.com");
+        user.setRole(Role.LITIGANT);
+
+        UUID hearingId = UUID.randomUUID();
+        Hearing hearing = new Hearing();
+        hearing.setId(hearingId);
+        hearing.setVideoRoomId("room-xyz");
+
+        when(userRepository.findByEmail("litigant@example.com")).thenReturn(Optional.of(user));
+        when(hearingRepository.findByVideoRoomId("room-xyz")).thenReturn(Optional.of(hearing));
+        when(hearingParticipantRepository.existsByHearingIdAndUserId(hearingId, 1L)).thenReturn(true);
+
+        Message<?> result = interceptor.preSend(message, messageChannel);
+        assertNotNull(result);
+    }
+
+    @Test
+    void sendByAssignedLitigantSucceeds() {
+        UUID hearingId = UUID.randomUUID();
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+        accessor.setDestination("/topic/courtroom/" + hearingId);
+        Principal principal = new UsernamePasswordAuthenticationToken("litigant@example.com", null);
+        accessor.setUser(principal);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("litigant@example.com");
+        user.setRole(Role.LITIGANT);
+
+        Hearing hearing = new Hearing();
+        hearing.setId(hearingId);
+
+        when(userRepository.findByEmail("litigant@example.com")).thenReturn(Optional.of(user));
+        when(hearingRepository.findById(hearingId)).thenReturn(Optional.of(hearing));
+        when(hearingParticipantRepository.existsByHearingIdAndUserId(hearingId, 1L)).thenReturn(true);
+
+        Message<?> result = interceptor.preSend(message, messageChannel);
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Implements a custom `ChannelInterceptor` (`WebSocketSecurityInterceptor`) to enforce JWT signature validation and role-based access control (RBAC) on the WebRTC WebSocket signaling server. 

- On `CONNECT`: Extracts the Bearer JWT token from the STOMP `Authorization` header, validates its signature/expiration, and populates the authenticated `Principal`.
- On `SUBSCRIBE` / `SEND`: Restricts destinations starting with `/topic/courtroom/` and `/topic/hearing/` to authorized roles (`JUDGE`, `LAWYER`, `ADMIN`, `SUPER_JUDGE`, `TECH_ADMIN`) or assigned litigants present in the courtroom's participant list.

Closes #1323

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
