### PR TITLE
feat: add global API error response format

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/RestAccessDeniedHandler.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/RestAccessDeniedHandler.java
@@ -1,0 +1,54 @@
+package com.nyaysetu.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nyaysetu.backend.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class RestAccessDeniedHandler implements AuthenticationEntryPoint, AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                          AuthenticationException authException) throws IOException {
+        writeError(request, response, HttpStatus.UNAUTHORIZED, "Unauthorized",
+                "Authentication is required to access this resource");
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        writeError(request, response, HttpStatus.FORBIDDEN, "Forbidden",
+                "You do not have permission to access this resource");
+    }
+
+    private void writeError(HttpServletRequest request, HttpServletResponse response,
+                             HttpStatus status, String error, String message) throws IOException {
+        ErrorResponse body = ErrorResponse.builder()
+                .status(status.value())
+                .error(error)
+                .message(message)
+                .path(request.getRequestURI())
+                .build();
+
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -143,7 +143,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
             JwtAuthFilter jwtAuthFilter,
-            XssSanitizationFilter xssSanitizationFilter) throws Exception {
+            XssSanitizationFilter xssSanitizationFilter,
+            RestAccessDeniedHandler restAccessDeniedHandler) throws Exception {
 
         http
                 // 1. CORS fix (Restricting to specific origins instead of all)
@@ -278,6 +279,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(restAccessDeniedHandler)
+                        .accessDeniedHandler(restAccessDeniedHandler)
+                )
                 .authenticationProvider(authenticationProvider())
                 .addFilterBefore(xssSanitizationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -144,7 +144,7 @@ public class SecurityConfig {
             HttpSecurity http,
             JwtAuthFilter jwtAuthFilter,
             XssSanitizationFilter xssSanitizationFilter,
-            RestAccessDeniedHandler restAccessDeniedHandler) throws Exception {
+            RestAccessDeniedHandler restAccessDeniedHandler) throws IllegalStateException {
 
         http
                 // 1. CORS fix (Restricting to specific origins instead of all)

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/exception/ErrorResponse.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/exception/ErrorResponse.java
@@ -1,0 +1,63 @@
+package com.nyaysetu.backend.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+    private final Instant timestamp;
+
+    private final int status;
+    private final String error;
+    private final String message;
+    private final String path;
+    private final Map<String, String> fieldErrors;
+    private final String traceId;
+
+    private ErrorResponse(Builder builder) {
+        this.timestamp = Instant.now();
+        this.status = builder.status;
+        this.error = builder.error;
+        this.message = builder.message;
+        this.path = builder.path;
+        this.fieldErrors = builder.fieldErrors;
+        this.traceId = builder.traceId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Instant getTimestamp() { return timestamp; }
+    public int getStatus() { return status; }
+    public String getError() { return error; }
+    public String getMessage() { return message; }
+    public String getPath() { return path; }
+    public Map<String, String> getFieldErrors() { return fieldErrors; }
+    public String getTraceId() { return traceId; }
+
+    public static final class Builder {
+        private int status;
+        private String error;
+        private String message;
+        private String path;
+        private Map<String, String> fieldErrors;
+        private String traceId;
+
+        public Builder status(int status) { this.status = status; return this; }
+        public Builder error(String error) { this.error = error; return this; }
+        public Builder message(String message) { this.message = message; return this; }
+        public Builder path(String path) { this.path = path; return this; }
+        public Builder fieldErrors(Map<String, String> fieldErrors) { this.fieldErrors = fieldErrors; return this; }
+        public Builder traceId(String traceId) { this.traceId = traceId; return this; }
+
+        public ErrorResponse build() {
+            return new ErrorResponse(this);
+        }
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/exception/GlobalExceptionHandler.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/exception/GlobalExceptionHandler.java
@@ -1,107 +1,143 @@
 package com.nyaysetu.backend.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-import java.time.Instant;
-import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getFieldErrors()
-                .stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(", "));
-        ErrorResponse error = new ErrorResponse("Validation Failed", message, 400);
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e,
+                                                           HttpServletRequest request) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Validation Failed")
+                .message("One or more fields are invalid")
+                .path(request.getRequestURI())
+                .fieldErrors(fieldErrors)
+                .build();
+
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
-    public ResponseEntity<ErrorResponse> handleNoHandlerFound(Exception e) {
-        ErrorResponse error = new ErrorResponse("Not Found", "The requested resource does not exist", 404);
+    public ResponseEntity<ErrorResponse> handleNoHandlerFound(Exception e, HttpServletRequest request) {
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Not Found")
+                .message("The requested resource does not exist")
+                .path(request.getRequestURI())
+                .build();
+
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException e) {
-        ErrorResponse error = new ErrorResponse("Forbidden", e.getMessage(), 403);
-        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
-    }
+    @ExceptionHandler({NotFoundException.class, ResourceNotFoundException.class})
+    public ResponseEntity<ErrorResponse> handleNotFound(RuntimeException e, HttpServletRequest request) {
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Not Found")
+                .message(e.getMessage())
+                .path(request.getRequestURI())
+                .build();
 
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException e) {
-        ErrorResponse error = new ErrorResponse("Not Found", e.getMessage(), 404);
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDenied(org.springframework.security.access.AccessDeniedException e) {
-        ErrorResponse error = new ErrorResponse("Forbidden", "You do not have permission to access this resource", 403);
+    @ExceptionHandler({
+            AccessDeniedException.class,
+            org.springframework.security.access.AccessDeniedException.class
+    })
+    public ResponseEntity<ErrorResponse> handleAccessDenied(RuntimeException e, HttpServletRequest request) {
+        String message = (e.getMessage() != null && !e.getMessage().isBlank())
+                ? e.getMessage()
+                : "You do not have permission to access this resource";
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.FORBIDDEN.value())
+                .error("Forbidden")
+                .message(message)
+                .path(request.getRequestURI())
+                .build();
+
         return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }
 
-    @ExceptionHandler(com.nyaysetu.backend.exception.AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleCustomAccessDenied(com.nyaysetu.backend.exception.AccessDeniedException e) {
-        ErrorResponse error = new ErrorResponse("Access Denied", e.getMessage(), 403);
-        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+    @ExceptionHandler(org.springframework.security.core.AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(
+            org.springframework.security.core.AuthenticationException e,
+            HttpServletRequest request) {
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error("Unauthorized")
+                .message("Authentication failed. Please log in again.")
+                .path(request.getRequestURI())
+                .build();
+
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }
 
-    @ExceptionHandler(org.springframework.dao.DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> handleDataIntegrity(org.springframework.dao.DataIntegrityViolationException e) {
-        ErrorResponse error = new ErrorResponse("Conflict", "Database integrity constraint violation occurred", 409);
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrity(DataIntegrityViolationException e,
+                                                              HttpServletRequest request) {
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.CONFLICT.value())
+                .error("Conflict")
+                .message("Database integrity constraint violation occurred")
+                .path(request.getRequestURI())
+                .build();
+
         return new ResponseEntity<>(error, HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
-        ErrorResponse error = new ErrorResponse("Bad Request", e.getMessage(), 400);
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e,
+                                                                HttpServletRequest request) {
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .message(e.getMessage())
+                .path(request.getRequestURI())
+                .build();
+
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneric(Exception e) {
-        ErrorResponse error = new ErrorResponse("Internal Server Error", e.getMessage(), 500);
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception e, HttpServletRequest request) {
+        String traceId = UUID.randomUUID().toString();
+        logger.error("Unhandled exception [traceId={}] at {}", traceId, request.getRequestURI(), e);
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .error("Internal Server Error")
+                .message("An unexpected error occurred. Please try again later.")
+                .path(request.getRequestURI())
+                .traceId(traceId)
+                .build();
+
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    public static class ErrorResponse {
-        private String error;
-        private String message;
-        private int status;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
-        private Instant timestamp;
-
-        public ErrorResponse(String error, String message, int status) {
-            this.error = error;
-            this.message = message;
-            this.status = status;
-            this.timestamp = Instant.now();
-        }
-
-        public String getError() {
-            return error;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public int getStatus() {
-            return status;
-        }
-
-        public Instant getTimestamp() {
-            return timestamp;
-        }
     }
 }

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -32,10 +33,32 @@ public class RbacSecurityTest {
         mockMvc.perform(get("/api/v1/cases/pending-assignment"))
                 .andExpect(status().isForbidden());
     }
+
     @Test
     @WithMockUser(username = "litigant@example.com", roles = {"LITIGANT"})
     public void shouldAllowLitigantAccessToOwnCases() throws Exception {
         mockMvc.perform(get("/api/v1/cases"))
                 .andExpect(status().isOk());
-}
+    }
+
+    @Test
+    @WithMockUser(username = "litigant@example.com", roles = {"LITIGANT"})
+    public void shouldReturnStandardErrorEnvelopeOnForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/judge/cases"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.error").value("Forbidden"))
+                .andExpect(jsonPath("$.path").value("/api/v1/judge/cases"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    public void shouldReturnStandardErrorEnvelopeOnUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/judge/cases"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.path").value("/api/v1/judge/cases"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
 }

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/RbacSecurityTest.java
@@ -43,7 +43,7 @@ public class RbacSecurityTest {
 
     @Test
     @WithMockUser(username = "litigant@example.com", roles = {"LITIGANT"})
-    public void shouldReturnStandardErrorEnvelopeOnForbidden() throws Exception {
+    public void shouldReturnStandardErrorEnvelopeOnForbidden() throws ServletException {
         mockMvc.perform(get("/api/v1/judge/cases"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value(403))
@@ -53,7 +53,7 @@ public class RbacSecurityTest {
     }
 
     @Test
-    public void shouldReturnStandardErrorEnvelopeOnUnauthorized() throws Exception {
+    public void shouldReturnStandardErrorEnvelopeOnUnauthorized() throws ServletException {
         mockMvc.perform(get("/api/v1/judge/cases"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.status").value(401))

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/exception/GlobalExceptionHandlerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,108 @@
+package com.nyaysetu.backend.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler handler;
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalExceptionHandler();
+        request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/v1/cases");
+    }
+
+    @Test
+    void handleValidation_returnsBadRequestWithFieldErrors() {
+        FieldError fieldError = new FieldError("caseRequest", "title", "must not be blank");
+
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(bindingResult.getFieldErrors()).thenReturn(java.util.List.of(fieldError));
+
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+
+        ResponseEntity<ErrorResponse> response = handler.handleValidation(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ErrorResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getStatus()).isEqualTo(400);
+        assertThat(body.getError()).isEqualTo("Validation Failed");
+        assertThat(body.getPath()).isEqualTo("/api/v1/cases");
+        assertThat(body.getFieldErrors()).containsEntry("title", "must not be blank");
+        assertThat(body.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void handleNotFound_returnsNotFoundWithMessage() {
+        NotFoundException ex = new NotFoundException("Case not found");
+
+        ResponseEntity<ErrorResponse> response = handler.handleNotFound(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        ErrorResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getStatus()).isEqualTo(404);
+        assertThat(body.getError()).isEqualTo("Not Found");
+        assertThat(body.getMessage()).isEqualTo("Case not found");
+        assertThat(body.getPath()).isEqualTo("/api/v1/cases");
+        assertThat(body.getFieldErrors()).isNull();
+    }
+
+    @Test
+    void handleAccessDenied_returnsForbiddenWithDefaultMessageWhenBlank() {
+        AccessDeniedException ex = new AccessDeniedException("");
+
+        ResponseEntity<ErrorResponse> response = handler.handleAccessDenied(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        ErrorResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getStatus()).isEqualTo(403);
+        assertThat(body.getError()).isEqualTo("Forbidden");
+        assertThat(body.getMessage()).isEqualTo("You do not have permission to access this resource");
+    }
+
+    @Test
+    void handleDataIntegrity_returnsConflict() {
+        DataIntegrityViolationException ex = new DataIntegrityViolationException("duplicate key");
+
+        ResponseEntity<ErrorResponse> response = handler.handleDataIntegrity(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        ErrorResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getStatus()).isEqualTo(409);
+        assertThat(body.getError()).isEqualTo("Conflict");
+    }
+
+    @Test
+    void handleGeneric_returnsInternalServerErrorWithoutExposingRawMessageAndIncludesTraceId() {
+        RuntimeException ex = new RuntimeException("secret stack trace detail");
+
+        ResponseEntity<ErrorResponse> response = handler.handleGeneric(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        ErrorResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getStatus()).isEqualTo(500);
+        assertThat(body.getError()).isEqualTo("Internal Server Error");
+        assertThat(body.getMessage()).doesNotContain("secret stack trace detail");
+        assertThat(body.getTraceId()).isNotBlank();
+    }
+}


### PR DESCRIPTION
This PR adds a standardized error response format across the API as requested in #1234.

## Changes
- Added `ErrorResponse` DTO with timestamp, status, error, message, path, fieldErrors, and traceId
- Rewrote `GlobalExceptionHandler` to use the unified envelope for all exception types
- Added `RestAccessDeniedHandler` for security-filter-level 401/403 responses
- Updated `SecurityConfig` to wire the custom handlers
- Added comprehensive tests

Closes #1234

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally
- [x] No merge conflicts