### PR TITLE
fix: update default guest button styling to match website styling

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Header.jsx
@@ -103,8 +103,6 @@ export default function Header({ hideAuthButtons = false }) {
     });
 
     const renderNavItem = (item) => {
-        const baseStyle = navLinkStyle(item.href);
-
         const displayLabel =
             t(item.labelKey) === item.labelKey
                 ? item.labelKey
@@ -134,7 +132,6 @@ export default function Header({ hideAuthButtons = false }) {
         );
 
         const sharedProps = {
-            style: baseStyle,
             onMouseEnter: e => {
                 e.currentTarget.style.color = 'var(--color-primary)';
                 const underline =
@@ -176,10 +173,6 @@ export default function Header({ hideAuthButtons = false }) {
         // -------------------------------------------------------------
 
         const baseStyle = navLinkStyle(isActive);
-        // Fallback to labelKey directly if translation returns the exact key
-
-        const displayLabel = t(item.labelKey) === item.labelKey ? item.labelKey : t(item.labelKey);
-
         if (item.action) {
             return (
                 <button

--- a/frontend/nyaysetu-frontend/src/styles/guest.css
+++ b/frontend/nyaysetu-frontend/src/styles/guest.css
@@ -506,25 +506,24 @@
 .guest-continue-btn {
     width: 100%;
     margin-top: 1rem;
-    padding: 0.95rem 1rem;
-    border-radius: 0.85rem;
-    border: 1px dashed var(--border-medium);
-    background: var(--bg-surface);
-    color: var(--text-main);
-    font-weight: 700;
-    font-size: 0.9rem;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(30, 42, 68, 0.2);
+    background: rgba(30, 42, 68, 0.08);
+    color: var(--color-primary);
+    font-weight: 600;
+    font-size: 0.95rem;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+    gap: 0.75rem;
+    transition: all 0.3s;
 }
 
 .guest-continue-btn:hover:not(:disabled) {
-    border-color: var(--color-primary);
-    background: color-mix(in srgb, var(--color-accent) 4%, transparent);
-    box-shadow: 0 4px 16px color-mix(in srgb, var(--color-accent) 10%, transparent);
+    background: rgba(30, 42, 68, 0.15);
+    border-color: rgba(30, 42, 68, 0.3);
 }
 
 .guest-continue-btn:disabled {


### PR DESCRIPTION
# Pull Request

## Description
Updates the styling of the "Explore as Guest" button (`.guest-continue-btn`) to visually match the "Login with Face" button and the overall aesthetic of the authentication pages. This fixes the issue where the guest button was rendering with default, unstyled browser attributes, ensuring a consistent and modern UI.

Closes #1371 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional
Before
<img width="600" height="167" alt="Screenshot 2026-06-14 211224" src="https://github.com/user-attachments/assets/37b28fbe-8987-43ff-9bd5-d0ce883df4a7" />

After
1. Dark
<img width="607" height="137" alt="Screenshot 2026-06-14 224036" src="https://github.com/user-attachments/assets/1a107f69-ffb7-48b2-b907-ec6cd004cf94" />

2.Light
<img width="623" height="138" alt="Screenshot 2026-06-14 224458" src="https://github.com/user-attachments/assets/c34426cc-f0d5-4bd5-94b1-ed6ddf63a037" />

Note to maintainer:
I removed the duplicate nav item declarations in `Header.jsx` that were causing the frontend build to fail. The `baseStyle` and `displayLabel` variables were each declared twice inside `renderNavItem`, and I cleaned that up so the component compiles correctly again.
