### PR TITLE
fix: use actual case count instead of hardcoded 0 for lawyer casesHandled (#1297)

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseAssignmentService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseAssignmentService.java
@@ -109,7 +109,7 @@ public class CaseAssignmentService {
                         .name(lawyer.getName())
                         .email(lawyer.getEmail())
                         .specialization("General Practice") // TODO: Add specialization field
-                        .casesHandled(0) // TODO: Count from cases
+                        .casesHandled((int) caseRepository.countByLawyer(lawyer))
                         .rating(4.5) // TODO: Add rating system
                         .build())
                 .collect(Collectors.toList());


### PR DESCRIPTION
Fixes #1297

The getAvailableLawyers endpoint returns casesHandled=0 for every lawyer due to a hardcoded placeholder. CaseRepository already has countByLawyer() method; use it to populate the actual case count.