### PR TITLE
feat: added unit tests for decomposer.py

### DIFF
--- a/nlp-orchestrator/tests/test_decomposer.py
+++ b/nlp-orchestrator/tests/test_decomposer.py
@@ -1,77 +1,142 @@
-import pytest
-from unittest.mock import AsyncMock, patch
+"""Unit tests for ``decomposer.decompose_query``.
 
-from decomposer import decompose_query
+These tests exercise the Layer-1 query decomposition logic in complete
+isolation from the Groq LPU by mocking the async chat-completion call.
+They cover the happy path, the 5-sub-question cap, the domain guardrail
+(empty array), and every fallback branch (malformed JSON, wrong JSON
+shape, and transport-level exceptions), as well as verifying that the
+request is built with the expected model and sampling parameters.
+
+Resolves #852.
+"""
+
+import os
+
+# decomposer.py imports config.py, which calls sys.exit(1) when GROQ_API_KEY
+# is unset. Provide a dummy key BEFORE importing so the suite is runnable
+# standalone (no real credentials, no network — every call is mocked).
+os.environ.setdefault("GROQ_API_KEY", "test-key-decomposer")
+
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+
+from config import GROQ_MODEL_FAST  # noqa: E402
+from decomposer import DECOMPOSE_PROMPT, decompose_query  # noqa: E402
+
+PATCH_TARGET = "decomposer.client.chat.completions.create"
+
+
+def _mock_completion(content):
+    """Build a fake Groq chat-completion whose first choice carries ``content``.
+
+    Mirrors the real shape consumed by the decomposer:
+    ``response.choices[0].message.content``.
+    """
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_returns_parsed_sub_questions(mock_create):
+    mock_create.return_value = _mock_completion(
+        '["What does Section 304A IPC say?", "What is the penalty?"]'
+    )
+
+    result = await decompose_query("Explain rash and negligent driving")
+
+    assert result == [
+        "What does Section 304A IPC say?",
+        "What is the penalty?",
+    ]
 
 
 @pytest.mark.asyncio
-@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
-async def test_returns_list_of_strings(mock_create):
-    mock_create.return_value.choices = [
-        type(
-            "obj",
-            (),
-            {
-                "message": type(
-                    "obj",
-                    (),
-                    {
-                        "content": '["What is IPC?", "What is BNS?"]'
-                    }
-                )()
-            }
-        )
-    ]
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_result_is_list_of_strings(mock_create):
+    mock_create.return_value = _mock_completion('["What is IPC?", "What is BNS?"]')
 
     result = await decompose_query("Explain IPC and BNS")
 
     assert isinstance(result, list)
-    assert all(isinstance(q, str) for q in result)
+    assert result and all(isinstance(q, str) for q in result)
 
 
 @pytest.mark.asyncio
-@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
-async def test_maximum_five_subquestions(mock_create):
-    mock_create.return_value.choices = [
-        type(
-            "obj",
-            (),
-            {
-                "message": type(
-                    "obj",
-                    (),
-                    {
-                        "content": '["Q1", "Q2", "Q3", "Q4", "Q5", "Q6"]'
-                    }
-                )()
-            }
-        )
-    ]
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_single_sub_question_preserved(mock_create):
+    mock_create.return_value = _mock_completion('["Only one focused question?"]')
 
-    result = await decompose_query("Complex legal query")
+    result = await decompose_query("A narrow question")
+
+    assert result == ["Only one focused question?"]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_surrounding_whitespace_is_stripped(mock_create):
+    mock_create.return_value = _mock_completion('\n\n  ["Q1", "Q2"]  \n')
+
+    result = await decompose_query("Query with whitespace in response")
+
+    assert result == ["Q1", "Q2"]
+
+
+# --------------------------------------------------------------------------- #
+# Cap at five
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_caps_at_five_sub_questions(mock_create):
+    mock_create.return_value = _mock_completion(
+        '["Q1", "Q2", "Q3", "Q4", "Q5", "Q6", "Q7"]'
+    )
+
+    result = await decompose_query("A very broad legal query")
+
+    assert result == ["Q1", "Q2", "Q3", "Q4", "Q5"]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_exactly_five_sub_questions_unchanged(mock_create):
+    mock_create.return_value = _mock_completion('["Q1", "Q2", "Q3", "Q4", "Q5"]')
+
+    result = await decompose_query("Query yielding exactly five")
 
     assert len(result) == 5
 
 
+# --------------------------------------------------------------------------- #
+# Domain guardrail: non-legal queries -> empty array
+# --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
-@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
-async def test_json_parsing_failure_returns_original_query(mock_create):
-    mock_create.return_value.choices = [
-        type(
-            "obj",
-            (),
-            {
-                "message": type(
-                    "obj",
-                    (),
-                    {
-                        "content": "INVALID JSON"
-                    }
-                )()
-            }
-        )
-    ]
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_non_legal_query_returns_empty_list(mock_create):
+    # Per the prompt's guardrail the model returns [] for off-domain queries.
+    mock_create.return_value = _mock_completion("[]")
 
+    result = await decompose_query("What is the boiling point of water?")
+
+    assert result == []
+
+
+# --------------------------------------------------------------------------- #
+# Fallback: malformed / wrong-shape JSON -> [query]
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_invalid_json_falls_back_to_original_query(mock_create):
+    mock_create.return_value = _mock_completion("this is not json at all")
     query = "What happens in a road accident case?"
 
     result = await decompose_query(query)
@@ -80,13 +145,134 @@ async def test_json_parsing_failure_returns_original_query(mock_create):
 
 
 @pytest.mark.asyncio
-@patch("decomposer.client.chat.completions.create", new_callable=AsyncMock)
-async def test_api_failure_returns_original_query(mock_create):
-    mock_create.side_effect = Exception("API failure")
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_markdown_fenced_json_falls_back(mock_create):
+    # The decomposer does not strip ``` fences, so fenced output is not
+    # valid JSON and must fall back to the original query.
+    mock_create.return_value = _mock_completion('```json\n["Q1", "Q2"]\n```')
+    query = "Explain bail provisions under BNSS"
 
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_json_object_instead_of_list_falls_back(mock_create):
+    mock_create.return_value = _mock_completion('{"question": "What is IPC?"}')
+    query = "Explain the Indian Penal Code"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_json_scalar_string_falls_back(mock_create):
+    mock_create.return_value = _mock_completion('"just a single string"')
+    query = "Define mens rea"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_list_with_non_string_items_falls_back(mock_create):
+    mock_create.return_value = _mock_completion("[1, 2, 3]")
+    query = "List the fundamental rights"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_list_with_mixed_types_falls_back(mock_create):
+    mock_create.return_value = _mock_completion('["valid question?", 42]')
+    query = "Explain Article 21"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+# --------------------------------------------------------------------------- #
+# Fallback: transport-level failures -> [query]
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_api_exception_falls_back_to_original_query(mock_create):
+    mock_create.side_effect = Exception("Groq API unavailable")
     query = "What is Article 21?"
 
     result = await decompose_query(query)
 
     assert result == [query]
 
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_timeout_error_falls_back_to_original_query(mock_create):
+    mock_create.side_effect = TimeoutError("request timed out")
+    query = "What is the procedure for filing an FIR?"
+
+    result = await decompose_query(query)
+
+    assert result == [query]
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_result_is_always_a_list_on_failure(mock_create):
+    mock_create.side_effect = RuntimeError("boom")
+
+    result = await decompose_query("anything")
+
+    assert isinstance(result, list)
+
+
+# --------------------------------------------------------------------------- #
+# Request construction
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_calls_groq_once_with_expected_parameters(mock_create):
+    mock_create.return_value = _mock_completion('["Q1"]')
+
+    await decompose_query("Some legal query")
+
+    mock_create.assert_awaited_once()
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["model"] == GROQ_MODEL_FAST
+    assert kwargs["temperature"] == 0.3
+    assert kwargs["max_tokens"] == 512
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_user_query_is_embedded_in_prompt(mock_create):
+    mock_create.return_value = _mock_completion('["Q1"]')
+    query = "What is the punishment under Section 302 IPC?"
+
+    await decompose_query(query)
+
+    kwargs = mock_create.call_args.kwargs
+    sent = kwargs["messages"][0]["content"]
+    assert query in sent
+    assert sent == DECOMPOSE_PROMPT.format(query=query)
+
+
+@pytest.mark.asyncio
+@patch(PATCH_TARGET, new_callable=AsyncMock)
+async def test_message_uses_user_role(mock_create):
+    mock_create.return_value = _mock_completion('["Q1"]')
+
+    await decompose_query("Query")
+
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["messages"][0]["role"] == "user"


### PR DESCRIPTION
# feat: Add unit tests for `decomposer.py`
 
Closes #852

## Description
 
The layer-1 query decomposer (`nlp-orchestrator/decomposer.py`) had only a thin smoke test. This PR replaces it with a comprehensive `pytest` suite that fully isolates the logic from the Groq LPU by mocking the async chat-completion call: no API key and no network are required to run it.
 
**Cases covered:**
- **Happy path**: parses a JSON array into sub-questions; preserves order and a single-item result; strips surrounding whitespace/newlines.
- **5-question cap**: returns the first 5 when the model emits more; leaves exactly-5 untouched.
- **Domain guardrail**: a non-legal query (model returns `[]`) yields an empty list.
- **Fallback branches**: every malformed/wrong-shape response falls back to `[query]`: invalid JSON, ` ```json ` markdown fences (the decomposer does not strip them), a JSON object, a JSON scalar string, a list of non-strings, and a mixed-type list.
- **Transport failures**: generic `Exception`, `TimeoutError`, and `RuntimeError` from the client all fall back to `[query]`; the result is always a list.
- **Request construction**: asserts the call uses `GROQ_MODEL_FAST`, `temperature=0.3`, `max_tokens=512`, the `"user"` role, and that the user's query is interpolated into `DECOMPOSE_PROMPT`. 

A clean `_mock_completion(content)` helper replaces the previous nested `type("obj", ...)` mock construction. The module sets a dummy `GROQ_API_KEY` before import so the suite is runnable standalone (the `config` module calls `sys.exit(1)` when the key is absent).
 
## Testing
```bash
PS C:\Users\madhu\Documents\nyay-setu-working> pytest -v nlp-orchestrator/tests/test_decomposer.py
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\madhu\Documents\nyay-setu-working
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-4.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 19 items

nlp-orchestrator/tests/test_decomposer.py::test_returns_parsed_sub_questions PASSED                              [  5%]
nlp-orchestrator/tests/test_decomposer.py::test_result_is_list_of_strings PASSED                                 [ 10%]
nlp-orchestrator/tests/test_decomposer.py::test_single_sub_question_preserved PASSED                             [ 15%]
nlp-orchestrator/tests/test_decomposer.py::test_surrounding_whitespace_is_stripped PASSED                        [ 21%]
nlp-orchestrator/tests/test_decomposer.py::test_caps_at_five_sub_questions PASSED                                [ 26%]
nlp-orchestrator/tests/test_decomposer.py::test_exactly_five_sub_questions_unchanged PASSED                      [ 31%]
nlp-orchestrator/tests/test_decomposer.py::test_non_legal_query_returns_empty_list PASSED                        [ 36%]
nlp-orchestrator/tests/test_decomposer.py::test_invalid_json_falls_back_to_original_query PASSED                 [ 42%]
nlp-orchestrator/tests/test_decomposer.py::test_markdown_fenced_json_falls_back PASSED                           [ 47%]
nlp-orchestrator/tests/test_decomposer.py::test_json_object_instead_of_list_falls_back PASSED                    [ 52%]
nlp-orchestrator/tests/test_decomposer.py::test_json_scalar_string_falls_back PASSED                             [ 57%]
nlp-orchestrator/tests/test_decomposer.py::test_list_with_non_string_items_falls_back PASSED                     [ 63%]
nlp-orchestrator/tests/test_decomposer.py::test_list_with_mixed_types_falls_back PASSED                          [ 68%]
nlp-orchestrator/tests/test_decomposer.py::test_api_exception_falls_back_to_original_query PASSED                [ 73%]
nlp-orchestrator/tests/test_decomposer.py::test_timeout_error_falls_back_to_original_query PASSED                [ 78%]
nlp-orchestrator/tests/test_decomposer.py::test_result_is_always_a_list_on_failure PASSED                        [ 84%]
nlp-orchestrator/tests/test_decomposer.py::test_calls_groq_once_with_expected_parameters PASSED                  [ 89%]
nlp-orchestrator/tests/test_decomposer.py::test_user_query_is_embedded_in_prompt PASSED                          [ 94%]
nlp-orchestrator/tests/test_decomposer.py::test_message_uses_user_role PASSED                                    [100%]Running teardown with pytest sessionfinish...


================================================= 19 passed in 0.65s ==================================================
```
 
## Type of change
- [x] Tests — adds/expands test coverage (non-breaking)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation update — N/A (test-only change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
