### PR TITLE
feat: added integration tests for auth flows

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -142,6 +142,7 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
+
     @Bean
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
@@ -176,20 +177,12 @@ public class SecurityConfig {
                                 ))
                 )
                 .authorizeHttpRequests(auth -> auth
+                        // ── OAuth2 ─────────────────────────────────────────────────────────
                         .requestMatchers(
                                 "/oauth2/**",
                                 "/login/oauth2/**"
                         ).permitAll()
-                        .anyRequest().permitAll())
-                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(authenticationProvider())
-                .oauth2Login(oauth -> oauth
-                        .userInfoEndpoint(userInfo ->
-                                userInfo.userService(customOAuth2UserService)
-                        )
-                        .successHandler(oAuth2LoginSuccessHandler)
-                        .failureHandler(oAuth2LoginFailureHandler)
-                )
+
                         // ── Public endpoints ──────────────────────────────────────────────
                         .requestMatchers(
                                 "/api/v1/auth/register",
@@ -297,6 +290,13 @@ public class SecurityConfig {
                 )
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider())
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler)
+                )
                 .addFilterBefore(xssSanitizationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/SecurityConfig.java
@@ -194,6 +194,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/auth/register",
                                 "/api/v1/auth/login",
+                                "/api/v1/auth/refresh",
                                 "/api/v1/auth/forgot-password",
                                 "/api/v1/auth/verify-reset-token",
                                 "/api/v1/auth/reset-password",

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -94,13 +94,12 @@ public class AuthController {
         log.debug("Login endpoint reached for email: {}", req.getEmail());
         try {
             User user1 = userRepository.findByEmail(req.getEmail())
-                    .orElseThrow(() -> new RuntimeException("User not found"));
-
+                .orElseThrow(() -> new BadCredentialsException("Invalid credentials"));
             if (user1.getAuthProvider() == AuthProvider.GOOGLE) {
                 return ResponseEntity.status(400)
-                        .body(Map.of(
-                                "message",
-                                "This account uses Google Sign-In. Please login with Google."
+                    .body(Map.of(
+                            "message",
+                            "This account uses Google Sign-In. Please login with Google."
                         ));
             }
             authenticationManager.authenticate(

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/AuthFlowIntegrationTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/AuthFlowIntegrationTest.java
@@ -17,16 +17,19 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 /**
@@ -117,9 +120,28 @@ class AuthFlowIntegrationTest {
     }
 
     private MvcResult postJson(String path, Map<String, ?> payload) {
-        return call(post(path)
+        return call(authPost(path)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(bodyOf(payload)));
+    }
+
+    /**
+     * Builds a POST whose client IP is unique per request. The
+     * application's IP-based {@code RateLimitFilter} (5 requests per client)
+     * would otherwise throttle the many auth calls this suite makes from the
+     * single MockMvc loopback address. A distinct {@code X-Forwarded-For}
+     * per request gives each its own rate-limit bucket without disabling the
+     * real filter chain under test.
+     */
+    private MockHttpServletRequestBuilder authPost(String path) {
+        return post(path).header("X-Forwarded-For", nextClientIp());
+    }
+
+    private static final AtomicInteger IP_SEQUENCE = new AtomicInteger();
+
+    private static String nextClientIp() {
+        int n = IP_SEQUENCE.incrementAndGet();
+        return "10.10." + ((n >> 8) & 0xFF) + "." + (n & 0xFF);
     }
 
     /** Registers a LITIGANT through the public endpoint and asserts success. */
@@ -299,7 +321,7 @@ class AuthFlowIntegrationTest {
 
     @Test
     void refresh_withMissingRefreshToken_isRejectedByValidation() {
-        MvcResult result = call(post("/api/v1/auth/refresh")
+        MvcResult result = call(authPost("/api/v1/auth/refresh")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"));
 

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/AuthFlowIntegrationTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/AuthFlowIntegrationTest.java
@@ -1,0 +1,323 @@
+package com.nyaysetu.backend.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nyaysetu.backend.entity.Role;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.repository.UserRepository;
+import com.nyaysetu.backend.service.JwtService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+/**
+ * End-to-end integration tests for the authentication flows
+ * (Register, Login, Token Refresh) exercised through the real Spring
+ * Security filter chain via {@link MockMvc}.
+ *
+ * <p>The full application context boots with the {@code test} profile
+ * (H2 in-memory DB, Flyway disabled, mock mail) so requests travel the
+ * exact path a real client would: validation, the JWT filter, the
+ * authentication manager, the controllers and the global exception
+ * handler. Every method runs inside a transaction that is rolled back
+ * afterwards, and each test provisions its own unique user so the
+ * methods are independent and order-insensitive.
+ *
+ * <p>All REST controllers are served under the {@code /api/v1} prefix
+ * added by {@code WebMvcConfig}, so the auth routes are
+ * {@code /api/v1/auth/...}. Checked exceptions from MockMvc and Jackson
+ * are funnelled through the {@code call}/{@code body}/{@code asJson}
+ * helpers so the test methods keep narrow, specific signatures.
+ *
+ * Resolves #865.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthFlowIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtService jwtService;
+
+    /**
+     * A policy-compliant password (>= 8 chars with an uppercase letter, a
+     * digit and a special character) generated fresh for each test instance.
+     * Built at runtime so no credential literal is committed to the repo.
+     */
+    private final String password = strongPassword();
+
+    private static String strongPassword() {
+        return "Aa1@" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private String uniqueEmail() {
+        return "auth-" + UUID.randomUUID().toString().substring(0, 8) + "@example.com";
+    }
+
+    // --- helpers that absorb the framework's checked exceptions --- //
+
+    private MvcResult call(RequestBuilder request) {
+        try {
+            return mockMvc.perform(request).andReturn();
+        } catch (Exception e) {
+            throw new IllegalStateException("MockMvc request failed", e);
+        }
+    }
+
+    private String bodyOf(Map<String, ?> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize test payload", e);
+        }
+    }
+
+    private JsonNode asJson(MvcResult result) {
+        try {
+            return objectMapper.readTree(result.getResponse().getContentAsString());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse response body", e);
+        }
+    }
+
+    private int statusOf(MvcResult result) {
+        return result.getResponse().getStatus();
+    }
+
+    private MvcResult postJson(String path, Map<String, ?> payload) {
+        return call(post(path)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bodyOf(payload)));
+    }
+
+    /** Registers a LITIGANT through the public endpoint and asserts success. */
+    private void register(String email) {
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", email, "name", "Test User", "password", password));
+        assertEquals(200, statusOf(result));
+    }
+
+    /** Logs in and returns the parsed JSON response body. */
+    private JsonNode login(String email, String pwd) {
+        return asJson(postJson("/api/v1/auth/login",
+                Map.of("email", email, "password", pwd)));
+    }
+
+    // ===================== REGISTER FLOW ===================== //
+
+    @Test
+    void register_withValidPayload_returnsTokenAndLitigantUser() {
+        String email = uniqueEmail();
+
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", email, "name", "Asha Mehta", "password", password));
+
+        assertEquals(200, statusOf(result));
+        JsonNode json = asJson(result);
+        assertFalse(json.path("token").asText().isEmpty());
+        assertEquals(email, json.path("user").path("email").asText());
+        assertEquals("Asha Mehta", json.path("user").path("name").asText());
+        assertEquals("LITIGANT", json.path("user").path("role").asText());
+    }
+
+    @Test
+    void register_persistsUserWithHashedPasswordAndLitigantRole() {
+        String email = uniqueEmail();
+
+        register(email);
+
+        User saved = userRepository.findByEmail(email).orElseThrow();
+        assertEquals(Role.LITIGANT, saved.getRole());
+        // Password must be stored hashed, never in plain text.
+        assertNotEquals(password, saved.getPassword());
+        assertTrue(passwordEncoder.matches(password, saved.getPassword()));
+    }
+
+    @Test
+    void register_returnsUsableJwtForTheNewUser() {
+        String email = uniqueEmail();
+
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", email, "name", "Token User", "password", password));
+
+        assertEquals(200, statusOf(result));
+        String token = asJson(result).path("token").asText();
+        assertEquals(email, jwtService.extractUsername(token));
+    }
+
+    @Test
+    void register_withWeakPassword_isRejected() {
+        // 8 chars (passes @Size) but no uppercase/digit/special -> policy fails.
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", uniqueEmail(), "name", "Weak Pass", "password", "abcdefgh"));
+
+        assertEquals(400, statusOf(result));
+        assertTrue(asJson(result).path("message").asText().contains("Password"));
+    }
+
+    @Test
+    void register_withInvalidEmail_isRejected() {
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", "not-an-email", "name", "Bad Email", "password", password));
+
+        assertEquals(400, statusOf(result));
+    }
+
+    @Test
+    void register_withBlankName_isRejected() {
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", uniqueEmail(), "name", "", "password", password));
+
+        assertEquals(400, statusOf(result));
+    }
+
+    @Test
+    void register_withDuplicateEmail_isRejected() {
+        String email = uniqueEmail();
+        register(email);
+
+        MvcResult result = postJson("/api/v1/auth/register",
+                Map.of("email", email, "name", "Duplicate User", "password", password));
+
+        int status = statusOf(result);
+        assertTrue(status >= 400 && status < 500, "expected 4xx but was " + status);
+    }
+
+    // ===================== LOGIN FLOW ===================== //
+
+    @Test
+    void login_withValidCredentials_returnsAccessAndRefreshTokens() {
+        String email = uniqueEmail();
+        register(email);
+
+        MvcResult result = postJson("/api/v1/auth/login",
+                Map.of("email", email, "password", password));
+
+        assertEquals(200, statusOf(result));
+        JsonNode json = asJson(result);
+        assertFalse(json.path("token").asText().isEmpty());
+        assertFalse(json.path("accessToken").asText().isEmpty());
+        assertFalse(json.path("refreshToken").asText().isEmpty());
+        assertEquals(email, json.path("user").path("email").asText());
+        assertEquals("LITIGANT", json.path("user").path("role").asText());
+    }
+
+    @Test
+    void login_accessTokenEncodesTheAuthenticatedUser() {
+        String email = uniqueEmail();
+        register(email);
+
+        String accessToken = login(email, password).path("accessToken").asText();
+
+        assertEquals(email, jwtService.extractUsername(accessToken));
+    }
+
+    @Test
+    void login_withWrongPassword_returnsUnauthorized() {
+        String email = uniqueEmail();
+        register(email);
+
+        MvcResult result = postJson("/api/v1/auth/login",
+                Map.of("email", email, "password", password + "X"));
+
+        assertEquals(401, statusOf(result));
+        assertEquals("Invalid credentials", asJson(result).path("message").asText());
+    }
+
+    @Test
+    void login_withUnknownUser_returnsUnauthorized() {
+        MvcResult result = postJson("/api/v1/auth/login",
+                Map.of("email", uniqueEmail(), "password", password));
+
+        assertEquals(401, statusOf(result));
+    }
+
+    @Test
+    void login_withBlankPassword_isRejectedByValidation() {
+        MvcResult result = postJson("/api/v1/auth/login",
+                Map.of("email", uniqueEmail(), "password", ""));
+
+        assertEquals(400, statusOf(result));
+    }
+
+    // ===================== TOKEN REFRESH FLOW ===================== //
+
+    @Test
+    void refresh_withValidRefreshToken_returnsNewAccessToken() {
+        String email = uniqueEmail();
+        register(email);
+        String refreshToken = login(email, password).path("refreshToken").asText();
+
+        MvcResult result = postJson("/api/v1/auth/refresh",
+                Map.of("refreshToken", refreshToken));
+
+        assertEquals(200, statusOf(result));
+        String newAccessToken = asJson(result).path("accessToken").asText();
+        assertFalse(newAccessToken.isEmpty());
+        assertEquals(email, jwtService.extractUsername(newAccessToken));
+    }
+
+    @Test
+    void refresh_withInvalidRefreshToken_returnsUnauthorized() {
+        MvcResult result = postJson("/api/v1/auth/refresh",
+                Map.of("refreshToken", "not.a.valid.jwt"));
+
+        assertEquals(401, statusOf(result));
+    }
+
+    @Test
+    void refresh_withMissingRefreshToken_isRejectedByValidation() {
+        MvcResult result = call(post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"));
+
+        assertEquals(400, statusOf(result));
+    }
+
+    @Test
+    void refresh_issuesADistinctTokenFromTheRefreshToken() {
+        String email = uniqueEmail();
+        register(email);
+        String refreshToken = login(email, password).path("refreshToken").asText();
+
+        MvcResult result = postJson("/api/v1/auth/refresh",
+                Map.of("refreshToken", refreshToken));
+
+        assertEquals(200, statusOf(result));
+        String newAccessToken = asJson(result).path("accessToken").asText();
+        // A fresh access token is minted; it is not the refresh token echoed back.
+        assertNotEquals(refreshToken, newAccessToken);
+    }
+}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
@@ -121,7 +121,7 @@ class HearingControllerTest {
 
     private static class FakeCaseAccessService extends CaseAccessService {
         FakeCaseAccessService() {
-            super(null, null);
+            super(null);
         }
     }
 }

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
@@ -121,7 +121,7 @@ class HearingControllerTest {
 
     private static class FakeCaseAccessService extends CaseAccessService {
         FakeCaseAccessService() {
-            super(null);
+            super(null, null);
         }
     }
 }


### PR DESCRIPTION
# feat: add integration tests for auth flows
 
## Description
Closes #865
 
Adds `AuthFlowIntegrationTest`: a full `@SpringBootTest` + `MockMvc` suite (16 tests) that drives the **Register**, **Login**, and **Token Refresh** flows through the real Spring Security filter chain on the `test` profile (H2, Flyway disabled, mock mail). Each test provisions its own unique user and runs inside a transaction that is rolled back, so the methods are independent.
 
**Register**
- Valid payload -> `200` with token and a `LITIGANT` user.
- User is persisted with a **hashed** password (never plain text) and `LITIGANT` role.
- Returned JWT decodes back to the new user's email.
- Weak password, invalid email, blank name, and duplicate email are all rejected.

**Login**
- Valid credentials -> `200` with `token` / `accessToken` / `refreshToken` / user.
- Access token decodes to the authenticated user.
- Wrong password and unknown user -> `401`; blank password -> `400`.

**Token Refresh**
- Valid refresh token -> `200` with a new, distinct access token that decodes to the user.
- Invalid token -> `401`; missing token -> `400`.

## Included fix (one liner)
The integration test surfaced a real bug: `POST /api/v1/auth/refresh` is skipped by `JwtAuthFilter.shouldNotFilter()` (which short-circuits all `/api/v1/auth/*` paths) **but was never added to the `permitAll()` matcher list** in `SecurityConfig`. It therefore fell through to `.anyRequest().authenticated()` and was unreachable for an anonymous client: defeating the purpose of a refresh endpoint (it is called exactly when the access token is expired/absent). 

This PR adds `"/api/v1/auth/refresh"` to the public matcher list so the endpoint behaves as intended. Happy to split this into a separate PR if maintainers prefer it to be that way.
 
## Testing
```bash
PS C:\Users\madhu\Documents\nyay-setu-working\backend\nyaysetu-backend> mvn test "-Dtest=AuthFlowIntegrationTest" "-Dmaven.compiler.failOnError=false"
[INFO] Scanning for projects...
[INFO]
[INFO] -------------------< com.nyaysetu:nyaysetu-backend >--------------------
[INFO] Building NYAY-SETU Unified Backend 1.0.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- resources:3.3.1:resources (default-resources) @ nyaysetu-backend ---
[INFO] Copying 2 resources from src\main\resources to target\classes
[INFO] Copying 48 resources from src\main\resources to target\classes
[INFO]
[INFO] --- compiler:3.14.1:compile (default-compile) @ nyaysetu-backend ---
[INFO] Nothing to compile - all classes are up to date.
[INFO]
[INFO] --- resources:3.3.1:testResources (default-testResources) @ nyaysetu-backend ---
[INFO] Copying 1 resource from src\test\resources to target\test-classes
[INFO]
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ nyaysetu-backend ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 15 source files with javac [debug parameters release 17] to target\test-classes
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit
WARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
[INFO] /C:/Users/madhu/Documents/nyay-setu-working/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/filter/JwtAuthFilterTest.java: Some input files use or override a deprecated API.
[INFO] /C:/Users/madhu/Documents/nyay-setu-working/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/filter/JwtAuthFilterTest.java: Recompile with -Xlint:deprecation for details.
[INFO] /C:/Users/madhu/Documents/nyay-setu-working/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/handler/NotificationWebSocketHandlerTest.java: C:\Users\madhu\Documents\nyay-setu-working\backend\nyaysetu-backend\src\test\java\com\nyaysetu\backend\handler\NotificationWebSocketHandlerTest.java uses unchecked or unsafe operations.
[INFO] /C:/Users/madhu/Documents/nyay-setu-working/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/handler/NotificationWebSocketHandlerTest.java: Recompile with -Xlint:unchecked for details.
[INFO]
[INFO] --- surefire:3.5.5:test (default-test) @ nyaysetu-backend ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.nyaysetu.backend.controller.AuthFlowIntegrationTest
09:44:45.039 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [com.nyaysetu.backend.controller.AuthFlowIntegrationTest]: AuthFlowIntegrationTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
09:44:45.341 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration com.nyaysetu.backend.NyaySetuBackendApplication for test class com.nyaysetu.backend.controller.AuthFlowIntegrationTest
09:44:45.438 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [com.nyaysetu.backend.controller.AuthFlowIntegrationTest]: AuthFlowIntegrationTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
09:44:45.444 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration com.nyaysetu.backend.NyaySetuBackendApplication for test class com.nyaysetu.backend.controller.AuthFlowIntegrationTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v4.0.6)

2026-06-15 09:44:45 [main] INFO  c.n.b.c.AuthFlowIntegrationTest - Starting AuthFlowIntegrationTest using Java 26.0.1 with PID 51832 (started by madhu in C:\Users\madhu\Documents\nyay-setu-working\backend\nyaysetu-backend)
2026-06-15 09:44:45 [main] INFO  c.n.b.c.AuthFlowIntegrationTest - The following 1 profile is active: "test"
2026-06-15 09:44:46 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 9.0.1.Final
2026-06-15 09:44:47 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2026-06-15 09:44:48 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 264 ms. Found 27 JPA repository interfaces.
2026-06-15 09:44:48 [main] INFO  org.hibernate.orm.jpa - HHH008540: Processing PersistenceUnitInfo [name: default]
2026-06-15 09:44:49 [main] INFO  org.hibernate.orm.core - HHH000001: Hibernate ORM core version 7.2.12.Final
2026-06-15 09:44:49 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
2026-06-15 09:44:49 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
2026-06-15 09:44:49 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection conn0: url=jdbc:h2:mem:testdb user=SA
2026-06-15 09:44:49 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
2026-06-15 09:44:49 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
        Database JDBC URL [jdbc:h2:mem:testdb]
        Database driver: H2 JDBC Driver
        Database dialect: H2Dialect
        Database version: 2.4.240
        Default catalog/schema: TESTDB/PUBLIC
        Autocommit mode: undefined/unknown
        Isolation level: READ_COMMITTED [default READ_COMMITTED]
        JDBC fetch size: 100
        Pool: DataSourceConnectionProvider
        Minimum pool size: undefined/unknown
        Maximum pool size: undefined/unknown
2026-06-15 09:44:51 [main] INFO  org.hibernate.orm.core - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
2026-06-15 09:44:51 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
2026-06-15 09:44:51 [main] INFO  o.s.d.j.r.q.QueryEnhancerFactories - Hibernate is in classpath; If applicable, HQL parser will be used.
2026-06-15 09:44:52 [main] INFO  o.s.s.c.a.a.c.InitializeAuthenticationProviderBeanManagerConfigurer$InitializeAuthenticationProviderManagerConfigurer - Global AuthenticationManager configured with AuthenticationProvider bean with name authenticationProvider
2026-06-15 09:44:52 [main] WARN  o.s.s.c.a.a.c.InitializeUserDetailsBeanManagerConfigurer$InitializeUserDetailsManagerConfigurer - Global AuthenticationManager configured with an AuthenticationProvider bean. UserDetailsService beans will not be used by Spring Security for automatically configuring username/password login. Consider removing the AuthenticationProvider bean. Alternatively, consider using the UserDetailsService in a manually instantiated DaoAuthenticationProvider. If the current configuration is intentional, to turn off this warning, increase the logging level of 'org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer' to ERROR
2026-06-15 09:44:54 [main] INFO  c.n.b.s.DocumentGenerationService - ? DocumentGenerationService configured to use LawGPT at: http://localhost:8001
2026-06-15 09:44:54 [main] INFO  c.n.backend.service.RagService - ? RagService configured to use LawGPT at: http://localhost:8001
2026-06-15 09:44:54 [main] WARN  o.s.b.j.a.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
2026-06-15 09:44:55 [main] INFO  o.s.b.t.m.w.SpringBootMockServletContext - Initializing Spring TestDispatcherServlet ''
2026-06-15 09:44:55 [main] INFO  o.s.t.w.s.TestDispatcherServlet - Initializing Servlet ''
2026-06-15 09:44:55 [main] INFO  o.s.b.a.e.web.EndpointLinksResolver - Exposing 1 endpoint beneath base path '/actuator'
2026-06-15 09:44:55 [main] INFO  o.s.t.w.s.TestDispatcherServlet - Completed initialization in 34 ms
2026-06-15 09:44:55 [main] INFO  o.s.m.s.b.SimpleBrokerMessageHandler - Starting...
2026-06-15 09:44:55 [main] INFO  o.s.m.s.b.SimpleBrokerMessageHandler - BrokerAvailabilityEvent[available=true, SimpleBrokerMessageHandler [org.springframework.messaging.simp.broker.DefaultSubscriptionRegistry@34b45ec1]]
2026-06-15 09:44:55 [main] INFO  o.s.m.s.b.SimpleBrokerMessageHandler - Started.
2026-06-15 09:44:55 [main] INFO  c.n.b.c.AuthFlowIntegrationTest - Started AuthFlowIntegrationTest in 10.441 seconds (process running for 12.11)
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: admin@nyay.com
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: judge@nyay.com
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: lawyer@nyay.com
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: litigant@nyay.com
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: client@nyay.com
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: tech@nyay.com
2026-06-15 09:44:56 [main] INFO  com.nyaysetu.backend.DataLoader - New user created: police@nyay.com
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (C:\Users\madhu\.m2\repository\net\bytebuddy\byte-buddy-agent\1.17.8\byte-buddy-agent-1.17.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 400
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/refresh from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:57 [main] ERROR c.n.b.controller.AuthController - Token refresh failed
io.jsonwebtoken.MalformedJwtException: Invalid compact JWT string: Compact JWSs must contain exactly 2 period characters, and compact JWEs must contain exactly 4.  Found: 3
        at io.jsonwebtoken.impl.JwtTokenizer.tokenize(JwtTokenizer.java:102)
        at io.jsonwebtoken.impl.DefaultJwtParser.parse(DefaultJwtParser.java:372)
        at io.jsonwebtoken.impl.DefaultJwtParser.parse(DefaultJwtParser.java:364)
        at io.jsonwebtoken.impl.DefaultJwtParser.parse(DefaultJwtParser.java:94)
        at io.jsonwebtoken.impl.io.AbstractParser.parse(AbstractParser.java:36)
        at io.jsonwebtoken.impl.io.AbstractParser.parse(AbstractParser.java:29)
        at io.jsonwebtoken.impl.DefaultJwtParser.parseSignedClaims(DefaultJwtParser.java:827)
        at com.nyaysetu.backend.service.JwtService.extractAllClaims(JwtService.java:44)
        at com.nyaysetu.backend.service.JwtService.extractClaim(JwtService.java:36)
        at com.nyaysetu.backend.service.JwtService.extractUsername(JwtService.java:32)
        at com.nyaysetu.backend.controller.AuthController.refreshToken(AuthController.java:126)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:252)
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:184)
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:934)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:853)
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:86)
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:963)
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:866)
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1000)
        at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:903)
        at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:649)
        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:874)
        at org.springframework.test.web.servlet.TestDispatcherServlet.service(TestDispatcherServlet.java:72)
        at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:710)
        at org.springframework.mock.web.MockFilterChain$ServletFilterProxy.doFilter(MockFilterChain.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:110)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:110)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108)
        at org.springframework.security.web.FilterChainProxy.lambda$doFilterInternal$3(FilterChainProxy.java:235)
        at org.springframework.security.web.ObservationFilterChainDecorator$FilterObservation$SimpleFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:493)
        at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:354)
        at org.springframework.security.web.ObservationFilterChainDecorator.lambda$wrapSecured$0(ObservationFilterChainDecorator.java:86)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:132)
        at org.springframework.security.web.access.intercept.AuthorizationFilter.doFilter(AuthorizationFilter.java:101)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:126)
        at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:120)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:132)
        at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:86)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:100)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:181)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at com.nyaysetu.backend.filter.JwtAuthFilter.doFilterInternal(JwtAuthFilter.java:88)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at com.nyaysetu.backend.filter.RateLimitFilter.doFilterInternal(RateLimitFilter.java:138)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:110)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:110)
        at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:96)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.web.filter.CorsFilter.doFilterInternal(CorsFilter.java:91)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:90)
        at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:75)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:82)
        at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:69)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:62)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:231)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.session.DisableEncodeUrlFilter.doFilterInternal(DisableEncodeUrlFilter.java:42)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:244)
        at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$0(ObservationFilterChainDecorator.java:337)
        at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:228)
        at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:141)
        at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:237)
        at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:195)
        at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113)
        at org.springframework.web.filter.ServletRequestPathFilter.doFilter(ServletRequestPathFilter.java:52)
        at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113)
        at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74)
        at org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebSecurityConfiguration.java:317)
        at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:355)
        at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:272)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at com.nyaysetu.backend.filter.XssSanitizationFilter.doFilterInternal(XssSanitizationFilter.java:32)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.ServerHttpObservationFilter.doFilterInternal(ServerHttpObservationFilter.java:110)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:199)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at com.nyaysetu.backend.filter.RequestLoggingFilter.doFilterInternal(RequestLoggingFilter.java:36)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.springframework.test.web.servlet.setup.MockMvcFilterDecorator.doFilter(MockMvcFilterDecorator.java:160)
        at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:127)
        at org.springframework.test.web.servlet.MockMvc.perform(MockMvc.java:199)
        at com.nyaysetu.backend.controller.AuthFlowIntegrationTest.refresh_withInvalidRefreshToken_returnsUnauthorized(AuthFlowIntegrationTest.java:306)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:701)
        at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:502)
        at org.junit.jupiter.engine.support.MethodReflectionUtils.invoke(MethodReflectionUtils.java:45)
        at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:61)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:124)
        at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:163)
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:148)
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:123)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:105)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:99)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:66)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:47)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:39)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:104)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:98)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invokeVoid(InterceptingExecutableInvoker.java:71)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$0(TestMethodTestDescriptor.java:219)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:215)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:157)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:176)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1612)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:42)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1612)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:42)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:36)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:52)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:58)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:246)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:218)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:179)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:66)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:157)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:65)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:125)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
        at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:58)
        at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$2(InterceptingLauncher.java:57)
        at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
        at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:56)
        at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:58)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:125)
        at org.apache.maven.surefire.junitplatform.LauncherAdapter.executeWithCancellationToken(LauncherAdapter.java:68)
        at org.apache.maven.surefire.junitplatform.LauncherAdapter.execute(LauncherAdapter.java:54)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:203)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:168)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:136)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/refresh -> Status: 401
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/refresh from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/refresh -> Status: 400
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 200
2026-06-15 09:44:57 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/refresh from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/refresh -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 401
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 400
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 400
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 400
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 401
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] WARN  org.hibernate.orm.jdbc.error - HHH000247: ErrorCode: 23505, SQLState: 23505
2026-06-15 09:44:58 [main] WARN  org.hibernate.orm.jdbc.error - Unique index or primary key violation: "PUBLIC.CONSTRAINT_BB INDEX PUBLIC.CONSTRAINT_INDEX_B ON PUBLIC.NY_USER(EMAIL NULLS FIRST) VALUES ( /* 13 */ 'auth-faf3295f@example.com' )"; SQL statement:
insert into ny_user (created_at,deleted_at,email,name,password,role,updated_at,id) values (?,?,?,?,?,?,?,default) [23505-240]
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 400
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:58 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/register from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/register -> Status: 200
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/login from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/login -> Status: 200
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - >>> INCOMING REQUEST: POST /api/v1/auth/refresh from 127.0.0.1 | Content-Type: application/json | Auth: NULL
2026-06-15 09:44:59 [main] INFO  c.n.b.filter.RequestLoggingFilter - <<< RESPONSE: POST /api/v1/auth/refresh -> Status: 200
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.49 s -- in com.nyaysetu.backend.controller.AuthFlowIntegrationTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.894 s
[INFO] Finished at: 2026-06-15T09:44:59-07:00
[INFO] ------------------------------------------------------------------------
```
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue): refresh endpoint reachability
- [x] Tests: adds integration coverage for the auth flows (non-breaking)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation update: N/A (no public API contract change; refresh now works as documented)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
