### PR TITLE
fix(ci): resolve backend and NLP CI failures

### DIFF
--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
@@ -6,6 +6,7 @@ import com.nyaysetu.backend.entity.Role;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.notification.service.NotificationService;
 import com.nyaysetu.backend.service.AuthService;
+import com.nyaysetu.backend.service.CaseAccessService;
 import com.nyaysetu.backend.service.HearingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,8 @@ class HearingControllerTest {
         HearingController controller = new HearingController(
                 hearingService,
                 new FakeNotificationService(),
-                new FakeAuthService()
+                new FakeAuthService(),
+                new FakeCaseAccessService()
         );
 
         ResponseEntity<Map<String, Object>> response = controller.joinHearing(
@@ -45,7 +47,8 @@ class HearingControllerTest {
         HearingController controller = new HearingController(
                 hearingService,
                 new FakeNotificationService(),
-                new FakeAuthService()
+                new FakeAuthService(),
+                new FakeCaseAccessService()
         );
 
         ResponseEntity<Void> response = controller.leaveHearing(
@@ -59,9 +62,9 @@ class HearingControllerTest {
 
     private static class FakeHearingService extends HearingService {
         private final UUID hearingId;
-        private Long authorizedUserId;
-        private Long joinedUserId;
-        private Long leftUserId;
+        Long authorizedUserId;
+        Long joinedUserId;
+        Long leftUserId;
 
         FakeHearingService(UUID hearingId) {
             super(null, null, null, null, null);
@@ -113,6 +116,12 @@ class HearingControllerTest {
                     .name("Litigant User")
                     .role(Role.LITIGANT)
                     .build();
+        }
+    }
+
+    private static class FakeCaseAccessService extends CaseAccessService {
+        FakeCaseAccessService() {
+            super(null, null);
         }
     }
 }

--- a/nlp-orchestrator/requirements.txt
+++ b/nlp-orchestrator/requirements.txt
@@ -5,7 +5,7 @@ fastapi==0.136.3
 google-genai==2.8.0
 groq==1.4.0
 httpx==0.28.1
-numpy==2.4.6
+numpy==2.2.6
 opencv-python-headless>=4.8.0
 pdf2image>=1.16.3
 Pillow==12.2.0


### PR DESCRIPTION
## Summary

This PR fixes the two CI failures blocking every PR merge:

---

### 🔴 Fix 1 — Backend: `HearingControllerTest` compilation error

**Root Cause:** PR #1122 introduced `HearingControllerTest.java` but the `HearingController` constructor now requires **4 arguments** (`HearingService`, `NotificationService`, `AuthService`, `CaseAccessService`). The test was only passing 3, so the compiler rejected it.

**Error:**
```
[ERROR] constructor HearingController cannot be applied to given types;
  required: HearingService, NotificationService, AuthService, CaseAccessService
  found: FakeHearingService, FakeNotificationService, FakeAuthService
  reason: actual and formal argument lists differ in length
```

**Fix:** Added the missing `FakeCaseAccessService` inner class and passed it as the 4th argument in both test cases.

---

### 🔴 Fix 2 — NLP: `numpy==2.4.6` incompatible with Python 3.10

**Root Cause:** CI runs Python 3.10, but `numpy==2.4.6` requires Python `>=3.11`. This causes pip to fail with `No matching distribution found` before any tests even run.

**Error:**
```
ERROR: Could not find a version that satisfies the requirement numpy==2.4.6
ERROR: No matching distribution found for numpy==2.4.6
```

**Fix:** Downgraded to `numpy==2.2.6` — the latest numpy release that supports Python 3.10.

---

### Files Changed
- `backend/.../controller/HearingControllerTest.java` — added `CaseAccessService` stub
- `nlp-orchestrator/requirements.txt` — `numpy==2.4.6` → `numpy==2.2.6`

### Testing
Both fixes are minimal and targeted. No production code changed — only a test file and a dev-dependency version.