### PR TITLE
fix: use actual case count instead of hardcoded 0 for lawyer casesHandled (#1297)

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseAssignmentService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/CaseAssignmentService.java
@@ -109,7 +109,7 @@ public class CaseAssignmentService {
                         .name(lawyer.getName())
                         .email(lawyer.getEmail())
                         .specialization("General Practice") // TODO: Add specialization field
-                        .casesHandled(0) // TODO: Count from cases
+                        .casesHandled((int) caseRepository.countByLawyer(lawyer))
                         .rating(4.5) // TODO: Add rating system
                         .build())
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Description
The available lawyers endpoint returned a hardcoded `0` for the `casesHandled` field for every lawyer, even though `CaseRepository.countByLawyer()` was available.

## Fix
Replaced the hardcoded `0` with the actual count from `caseRepository.countByLawyer(lawyer)`.

Closes #1297