### PR TITLE
perf: replace interval polling with sequential face detection

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/auth/FaceLoginModal.jsx
+++ b/frontend/nyaysetu-frontend/src/components/auth/FaceLoginModal.jsx
@@ -13,48 +13,70 @@ export default function FaceLoginModal({ isOpen, onClose, onSuccess }) {
     const webcamRef = useRef(null);
     const { modelsLoaded, detectFace, loginWithFace } = useFaceRecognition();
 
+    // Stores the next scheduled face detection cycle.
+    const detectionTimeoutRef = useRef(null);
+
+    // Controls whether biometric scanning should continue.
+    const activeScanningRef = useRef(false);
+
     useEffect(() => {
-        let interval;
         if (step === 'scanning' && modelsLoaded) {
-            interval = startFaceDetection();
+            startFaceDetection();
         }
         return () => {
-            if (interval) clearInterval(interval);
+            activeScanningRef.current = false;
+            
+            if (detectionTimeoutRef.current) { 
+                clearTimeout(detectionTimeoutRef.current);
+                detectionTimeoutRef.current = null;
+            }
         };
     }, [step, modelsLoaded]);
 
     const startFaceDetection = () => {
-        const interval = setInterval(async () => {
-            if (webcamRef.current?.video) {
-                try {
-                    const result = await detectFace(webcamRef.current.video, 0.75); // High threshold for login
-                    if (result && result.isCentered) {
-                        setFaceDetected(true);
-                        clearInterval(interval);
-                        await handleFaceLogin(result.descriptor);
-                    } else if (result) {
-                        setFaceDetected(false);
-                        setMessage('CENTER FACE: Move closer to the HUD grid');
-                    } else {
-                        setFaceDetected(false);
-                        setMessage('SCANNING: No valid biometric signature found');
-                    }
-                } catch (err) {
-                    console.error('Face detection error:', err);
-                }
-            }
-        }, 800);
+        activeScanningRef.current = true;
+
+        // Begin sequential face detection polling.
+        void runFaceDetection();
 
         setTimeout(() => {
-            if (interval) clearInterval(interval);
+            activeScanningRef.current = false;
+
             if (step === 'scanning' && !faceDetected) {
                 setStep('error');
                 setMessage('Biometric timeout. Signal not acquired.');
             }
         }, 45000);
-
-        return interval;
     };
+
+    const runFaceDetection = async () => {
+        if (!activeScanningRef.current) return;
+
+        if (webcamRef.current?.video) {
+            try {
+                const result = await detectFace(webcamRef.current.video, 0.75); // High threshold for login
+                
+                if (result && result.isCentered) {
+                    setFaceDetected(true);
+                    activeScanningRef.current = false;
+                    await handleFaceLogin(result.descriptor);
+                } else if (result) {
+                    setFaceDetected(false);
+                    setMessage('CENTER FACE: Move closer to the HUD grid');
+                } else {
+                    setFaceDetected(false);
+                    setMessage('SCANNING: No valid biometric signature found');
+                }
+            } catch (err) {
+                console.error('Face detection error:', err);
+            }
+        }
+
+        //Schedule next detection only if biometric scanning is still active.
+        if (activeScanningRef.current) {
+            detectionTimeoutRef.current = setTimeout(runFaceDetection, 800);
+        }
+    }
 
     const handleFaceLogin = async (descriptor) => {
         try {


### PR DESCRIPTION
# Pull Request

## Description
- This PR replaces interval-based face detection polling with sequential polling to avoid overlapping face detection requests during biometric scanning.
- Previously, face detection was executed using `setInterval`, which could start a new detection cycle before the previous asynchronous detection had completed. This could become a performance bottleneck especially on slower devices or under heavy load.

### Implementation
- Replaced `setInterval`-based polling with sequential polling using `setTimeout`.
- Scheduled the next face detection cycle only after the current `detectFace()` invocation completes.
- Added refs to:
  1. Store the next scheduled face detection cycle.
  2. Control whether biometric scanning should continue.
- Updated cleanup logic to clear pending detection timeouts when either the scanning stops or the component unmounts.

## Related Issue
- Fixes #1414 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional details:
- Closes #1414 
- Label: GSSoC'2026