### PR TITLE
fix: replace forced page reload with proper state reset in ErrorBoundary

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/nyaysetu-frontend/src/components/ErrorBoundary.jsx
@@ -20,8 +20,7 @@ class ErrorBoundary extends React.Component {
     }
 
     handleReset = () => {
-        this.setState({ hasError: false, error: null, errorInfo: null });
-        window.location.reload();
+    this.setState({ hasError: false, error: null, errorInfo: null });
     };
 
     render() {


### PR DESCRIPTION
# Pull Request

## Description

Fixes a logic bug in `ErrorBoundary.jsx` where `handleReset` called
`setState` to clear the error state and then immediately called
`window.location.reload()`. Since the reload discards the component
instance before React can re-render, the `setState` call was
unreachable — the boundary only ever recovered via a full hard reload, which loses any unrelated in-memory application state.

This change removes the forced reload so `handleReset` performs a
proper soft reset via `setState` alone, allowing the app to recover
in place.

Closes #1434 

## Type of change
<!-- Please delete options that are not relevant. ->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
