### PR TITLE
feat: add fail-closed Groq PII firewall

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ DB_PASSWORD=postgres
 # Leave empty; set a real value in your local .env file
 GROQ_API_KEY=
 
+# Local-only multilingual PII model and backend-to-orchestrator endpoint
+PII_NER_MODEL=ai4bharat/IndicNER
+PII_NER_URL=http://backend-python:8001/internal/pii/entities
+
 # Google Gemini API key — used for additional AI analysis features
 # Get your key at: https://aistudio.google.com/app/apikey
 # Leave empty; set a real value in your local .env file

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/AiService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/AiService.java
@@ -24,6 +24,7 @@ public class AiService {
 
     private final RestTemplate restTemplate; // Injected bean with timeouts — see RestTemplateConfig
     private final ObjectMapper objectMapper;
+    private final PiiSanitizer piiSanitizer;
 
     private static final String GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 
@@ -66,7 +67,7 @@ public class AiService {
             // User message
             ObjectNode userMsg = messagesArray.addObject();
             userMsg.put("role", "user");
-            userMsg.put("content", message);
+            userMsg.put("content", piiSanitizer.sanitizeForGroq(message));
 
             requestBody.put("temperature", 0.7);
 

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/BhashiniService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/BhashiniService.java
@@ -45,6 +45,7 @@ public class BhashiniService {
 
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate; // Injected bean with timeouts — see RestTemplateConfig
+    private final PiiSanitizer piiSanitizer;
 
     /**
      * Translate text from source language to target language
@@ -216,7 +217,7 @@ public class BhashiniService {
         userMsg.put("role", "user");
         userMsg.put("content", String.format(
             "Translate the following text from %s to %s. Return ONLY the translation:\n\n%s",
-            sourceLangName, targetLangName, text
+            sourceLangName, targetLangName, piiSanitizer.sanitizeForGroq(text)
         ));
         messagesArray.add(userMsg);
         

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/GroqDocumentVerificationService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/GroqDocumentVerificationService.java
@@ -34,6 +34,7 @@ public class GroqDocumentVerificationService {
 
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate; // Injected bean with timeouts — see RestTemplateConfig
+    private final PiiSanitizer piiSanitizer;
     
     private static final String GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 
@@ -302,13 +303,14 @@ public class GroqDocumentVerificationService {
     }
 
     private String callGroqAPI(String prompt) throws Exception {
+        String sanitizedPrompt = piiSanitizer.sanitizeForGroq(prompt);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("Authorization", "Bearer " + groqApiKey);
 
         Map<String, Object> message = new HashMap<>();
         message.put("role", "user");
-        message.put("content", prompt);
+        message.put("content", sanitizedPrompt);
 
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("model", groqModel);

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/NyaySetuBrainService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/NyaySetuBrainService.java
@@ -44,6 +44,7 @@ public class NyaySetuBrainService {
     private final OllamaService ollamaService;
     private final CaseRepository caseRepository;
     private final HearingRepository hearingRepository;
+    private final PiiSanitizer piiSanitizer;
 
     private static final String GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 
@@ -233,8 +234,15 @@ public class NyaySetuBrainService {
         systemMsg.put("role", "system");
         
         String basePrompt = ROLE_PROMPTS.getOrDefault(role, "You are a helpful legal assistant for NyaySetu.");
+        List<String> contentToSanitize = new ArrayList<>();
         if (!context.isEmpty()) {
-            basePrompt += "\n\n" + context;
+            contentToSanitize.add(context);
+        }
+        conversation.forEach(message -> contentToSanitize.add(message.get("content")));
+        List<String> sanitizedContent = piiSanitizer.sanitizeBatchForGroq(contentToSanitize);
+        int contentIndex = 0;
+        if (!context.isEmpty()) {
+            basePrompt += "\n\n" + sanitizedContent.get(contentIndex++);
         }
         
         systemMsg.put("content", basePrompt);
@@ -244,7 +252,7 @@ public class NyaySetuBrainService {
         for (Map<String, String> msg : conversation) {
             ObjectNode msgNode = objectMapper.createObjectNode();
             msgNode.put("role", msg.get("role"));
-            msgNode.put("content", msg.get("content"));
+            msgNode.put("content", sanitizedContent.get(contentIndex++));
             messagesArray.add(msgNode);
         }
 
@@ -297,7 +305,7 @@ public class NyaySetuBrainService {
                 
                 ObjectNode userMsg = objectMapper.createObjectNode();
                 userMsg.put("role", "user");
-                userMsg.put("content", userQuery);
+                userMsg.put("content", piiSanitizer.sanitizeForGroq(userQuery));
                 messagesArray.add(userMsg);
 
                 ObjectNode requestBody = objectMapper.createObjectNode();
@@ -397,10 +405,13 @@ public class NyaySetuBrainService {
 
     private String callGroqAPI(List<Map<String, String>> messages) throws Exception {
         ArrayNode messagesArray = objectMapper.createArrayNode();
+        List<String> sanitizedContent = piiSanitizer.sanitizeBatchForGroq(
+                messages.stream().map(message -> message.get("content")).toList());
+        int contentIndex = 0;
         for (Map<String, String> msg : messages) {
             ObjectNode msgNode = objectMapper.createObjectNode();
             msgNode.put("role", msg.get("role"));
-            msgNode.put("content", msg.get("content"));
+            msgNode.put("content", sanitizedContent.get(contentIndex++));
             messagesArray.add(msgNode);
         }
 

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiEntityDetector.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiEntityDetector.java
@@ -1,0 +1,12 @@
+package com.nyaysetu.backend.service;
+
+import java.util.List;
+
+/** Detects sensitive named entities inside the local deployment boundary. */
+@FunctionalInterface
+public interface PiiEntityDetector {
+
+    List<DetectedEntity> detectEntities(String text, boolean minorProtection);
+
+    record DetectedEntity(String value, String type) {}
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiNerClient.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiNerClient.java
@@ -1,0 +1,47 @@
+package com.nyaysetu.backend.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Client for the locally hosted multilingual named-entity recognizer. */
+@Service
+public class PiiNerClient implements PiiEntityDetector {
+
+    private final RestTemplate restTemplate;
+    private final String serviceUrl;
+
+    public PiiNerClient(
+            RestTemplate restTemplate,
+            @Value("${pii.sanitizer.ner-url:http://localhost:8001/internal/pii/entities}")
+                    String serviceUrl) {
+        this.restTemplate = restTemplate;
+        this.serviceUrl = serviceUrl;
+    }
+
+    /**
+     * Detects sensitive named entities without sending text outside the local deployment.
+     *
+     * @param text text that has already passed structural identifier redaction
+     * @param minorProtection whether the content relates to a child or POCSO case
+     * @return detected person, organization, and location entities
+     */
+    @Override
+    public List<DetectedEntity> detectEntities(String text, boolean minorProtection) {
+        NerResponse response = restTemplate.postForObject(
+                serviceUrl, new NerRequest(text, minorProtection), NerResponse.class);
+        if (response == null || response.entities() == null) {
+            throw new PiiSanitizationException("Local NER service returned no result");
+        }
+        return Arrays.asList(response.entities());
+    }
+
+    private record NerRequest(
+            String text, @JsonProperty("minor_protection") boolean minorProtection) {}
+
+    private record NerResponse(DetectedEntity[] entities) {}
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiSanitizationException.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiSanitizationException.java
@@ -1,0 +1,13 @@
+package com.nyaysetu.backend.service;
+
+public class PiiSanitizationException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public PiiSanitizationException(String message) {
+        super(message);
+    }
+
+    public PiiSanitizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiSanitizer.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/PiiSanitizer.java
@@ -1,0 +1,211 @@
+package com.nyaysetu.backend.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Fail-closed privacy boundary for text sent to third-party LLMs.
+ * Pseudonym maps exist only for the duration of one sanitize call.
+ */
+@Service
+@Slf4j
+public class PiiSanitizer {
+
+    private enum Type {
+        AADHAAR,
+        PAN,
+        PHONE,
+        VOTER_ID,
+        PASSPORT,
+        DRIVING_LICENCE,
+        EMAIL,
+        CASTE,
+        MEDICAL,
+        PERSON,
+        ORGANIZATION,
+        ADDRESS
+    }
+
+    private record Rule(Type type, Pattern pattern) {}
+
+    private static final List<Rule> STRUCTURAL_RULES = List.of(
+            new Rule(Type.AADHAAR, Pattern.compile("(?<!\\d)\\d{4}[ -]?\\d{4}[ -]?\\d{4}(?!\\d)")),
+            new Rule(Type.PAN, Pattern.compile("(?i)(?<![A-Z0-9])[A-Z]{5}\\d{4}[A-Z](?![A-Z0-9])")),
+            new Rule(Type.PHONE, Pattern.compile(
+                    "(?<!\\d)(?:(?:\\+|00)91[- ]?|0)?[6-9]\\d{4}[- ]?\\d{5}(?!\\d)")),
+            new Rule(Type.VOTER_ID, Pattern.compile(
+                    "(?i)(?<![A-Z0-9])[A-Z]{3}[ -]?\\d{7}(?![A-Z0-9])")),
+            new Rule(Type.PASSPORT, Pattern.compile(
+                    "(?i)(?<![A-Z0-9])[A-Z][1-9]\\d{6}(?![A-Z0-9])")),
+            new Rule(Type.DRIVING_LICENCE, Pattern.compile(
+                    "(?i)(?<![A-Z0-9])[A-Z]{2}[- ]?\\d{2}[- ]?(?:19|20)?\\d{2}"
+                            + "[- ]?\\d{7}(?![A-Z0-9])")),
+            new Rule(Type.EMAIL, Pattern.compile(
+                    "(?i)(?<![A-Z0-9._%+-])[A-Z0-9._%+-]+@[A-Z0-9.-]+"
+                            + "\\.[A-Z]{2,}(?![A-Z0-9.-])")),
+            new Rule(Type.CASTE, Pattern.compile(
+                    "(?i)(?<![\\p{L}])(?:SC\\s*/\\s*ST|SC|ST|OBC|EWS|Scheduled\\s+Caste|"
+                            + "Scheduled\\s+Tribe|Dalit|Brahmin|Brahminical)(?![\\p{L}])"))
+    );
+
+    private static final Pattern POCSO = Pattern.compile(
+            "(?i)\\b(?:POCSO|minor|child victim|age\\s*[:=]?\\s*(?:[0-9]|1[0-7])\\b)");
+    private static final Pattern ADDRESS_FIELD = Pattern.compile(
+            "(?iu)(?<prefix>(?:address|residence)\\s*(?:[:=]|is)\\s*[\\\"']?)"
+                    + "(?<value>[^,\\n\\r\\\"}]{5,100})");
+    private static final Pattern MEDICAL_FIELD = Pattern.compile(
+            "(?iu)(?<prefix>(?:diagnosis|medical\\s+history|health\\s+condition|blood\\s+group)"
+                    + "\\s*(?:[:=]|is)\\s*[\\\"']?)(?<value>[^,\\n\\r\\\"}]{2,100})");
+
+    private final boolean strictMode;
+    private final PiiEntityDetector piiEntityDetector;
+
+    public PiiSanitizer(
+            @Value("${pii.sanitizer.strict-mode:true}") boolean strictMode,
+            PiiEntityDetector piiEntityDetector) {
+        this.strictMode = strictMode;
+        this.piiEntityDetector = piiEntityDetector;
+    }
+
+    /**
+     * Applies structural redaction and local multilingual NER before a Groq request.
+     * The token map is request-scoped and is never persisted or transmitted.
+     *
+     * @param input outbound prompt content
+     * @return sanitized content containing stable relationship-preserving tokens
+     * @throws PiiSanitizationException when strict mode is enabled and sanitization fails
+     */
+    public String sanitizeForGroq(String input) {
+        return sanitizeBatchForGroq(Collections.singletonList(input)).get(0);
+    }
+
+    /**
+     * Sanitizes all content fields in one outbound request with one stable token map.
+     *
+     * @param inputs prompt and conversation fields belonging to one Groq request
+     * @return sanitized fields in input order
+     */
+    public List<String> sanitizeBatchForGroq(List<String> inputs) {
+        try {
+            SanitizeState state = new SanitizeState();
+            boolean minorProtection = inputs.stream()
+                    .filter(value -> value != null)
+                    .anyMatch(value -> POCSO.matcher(value).find());
+            List<String> sanitizedInputs = new ArrayList<>(inputs.size());
+            for (String input : inputs) {
+                String sanitized = input == null ? "" : input;
+                for (Rule rule : STRUCTURAL_RULES) {
+                    sanitized = replace(sanitized, rule.pattern(), rule.type(), state);
+                }
+                sanitized = replaceFieldValue(sanitized, ADDRESS_FIELD, Type.ADDRESS, state);
+                sanitized = replaceFieldValue(sanitized, MEDICAL_FIELD, Type.MEDICAL, state);
+                sanitizedInputs.add(replaceNamedEntities(sanitized, minorProtection, state));
+            }
+
+            log.info("SANITIZATION_AUDIT destination=GROQ minorProtection={} maskedTypes={}",
+                    minorProtection, state.counts);
+            return sanitizedInputs;
+        } catch (RuntimeException e) {
+            log.error(
+                    "SANITIZATION_AUDIT destination=GROQ status=FAILED "
+                            + "strictMode={} errorType={}",
+                    strictMode, e.getClass().getSimpleName());
+            if (strictMode) {
+                throw new PiiSanitizationException(
+                        "Groq call blocked because PII sanitization failed", e);
+            }
+            return new ArrayList<>(inputs);
+        }
+    }
+
+    private String replaceNamedEntities(
+            String text, boolean minorProtection, SanitizeState state) {
+        List<PiiEntityDetector.DetectedEntity> entities =
+                piiEntityDetector.detectEntities(text, minorProtection).stream()
+                        .filter(entity -> entity.value() != null && !entity.value().isBlank())
+                        .sorted((left, right) ->
+                                Integer.compare(right.value().length(), left.value().length()))
+                        .toList();
+        String result = text;
+        for (PiiEntityDetector.DetectedEntity entity : entities) {
+            Type type = switch (entity.type().toUpperCase(Locale.ROOT)) {
+                case "PER", "PERSON" -> Type.PERSON;
+                case "ORG", "ORGANIZATION" -> Type.ORGANIZATION;
+                case "LOC", "LOCATION", "GPE", "ADDRESS" -> Type.ADDRESS;
+                default -> null;
+            };
+            if (type != null) {
+                result = result.replace(entity.value(), state.token(type, entity.value()));
+            }
+        }
+        return result;
+    }
+
+    private String replace(String text, Pattern pattern, Type type, SanitizeState state) {
+        Matcher matcher = pattern.matcher(text);
+        StringBuffer output = new StringBuffer();
+        while (matcher.find()) {
+            String token = state.token(type, matcher.group());
+            matcher.appendReplacement(output, Matcher.quoteReplacement(token));
+        }
+        matcher.appendTail(output);
+        return output.toString();
+    }
+
+    private String replaceFieldValue(
+            String text, Pattern pattern, Type type, SanitizeState state) {
+        Matcher matcher = pattern.matcher(text);
+        StringBuffer output = new StringBuffer();
+        while (matcher.find()) {
+            String replacement = matcher.group("prefix")
+                    + state.token(type, matcher.group("value").trim());
+            matcher.appendReplacement(output, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(output);
+        return output.toString();
+    }
+
+    private static final class SanitizeState {
+        private final Map<Type, Integer> counts = new EnumMap<>(Type.class);
+        private final Map<Type, Map<String, String>> tokens = new EnumMap<>(Type.class);
+
+        private String token(Type type, String value) {
+            Map<String, String> values =
+                    tokens.computeIfAbsent(type, ignored -> new LinkedHashMap<>());
+            String normalized = value.toLowerCase(Locale.ROOT).replaceAll("[ -]", "");
+            String existing = values.get(normalized);
+            if (existing != null) {
+                return existing;
+            }
+
+            int index = values.size();
+            String token = type == Type.PERSON || type == Type.ORGANIZATION
+                    || type == Type.ADDRESS || type == Type.MEDICAL
+                    ? type.name() + "_" + alphabeticIndex(index)
+                    : "[" + type.name() + "_" + (index + 1) + "]";
+            values.put(normalized, token);
+            counts.merge(type, 1, Integer::sum);
+            return token;
+        }
+
+        private static String alphabeticIndex(int index) {
+            StringBuilder reversed = new StringBuilder();
+            do {
+                reversed.append((char) ('A' + index % 26));
+                index = index / 26 - 1;
+            } while (index >= 0);
+            return reversed.reverse().toString();
+        }
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendDocumentService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendDocumentService.java
@@ -55,6 +55,7 @@ public class VakilFriendDocumentService {
     // Robust helper services from fix branch
     private final FileStorageService fileStorageService;
     private final PdfTextExtractorService pdfTextExtractorService;
+    private final PiiSanitizer piiSanitizer;
 
     private static final String GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 
@@ -259,7 +260,7 @@ public class VakilFriendDocumentService {
 
             ObjectNode userMsg = objectMapper.createObjectNode();
             userMsg.put("role", "user");
-            userMsg.put("content", userPrompt);
+            userMsg.put("content", piiSanitizer.sanitizeForGroq(userPrompt));
             messagesArray.add(userMsg);
 
             // Build request

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VakilFriendService.java
@@ -60,7 +60,8 @@ public class VakilFriendService {
     private final OllamaService ollamaService;
     private final BhashiniService bhashiniService;
     private final VakilFriendDocumentService vakilFriendDocumentService;
- 
+    private final PiiSanitizer piiSanitizer;
+
     // Optional — only present when rag.enabled=true. Null-safe usage below.
     @Autowired(required = false)
     private RagService ragService;
@@ -596,8 +597,19 @@ public class VakilFriendService {
         systemMsg.put("role", "system");
         
         String finalSystemPrompt = SYSTEM_PROMPT;
-        if (ragContext != null && !ragContext.isEmpty() && !ragContext.equals("No specific legal context found.")) {
-            finalSystemPrompt += "\n\n### CRITICAL INDIAN LEGAL CONTEXT RELEVANT TO THIS USER ###\n" + ragContext + "\n\nUse this law to guide the user accurately.";
+        boolean hasRagContext = ragContext != null && !ragContext.isEmpty()
+                && !ragContext.equals("No specific legal context found.");
+        List<String> contentToSanitize = new ArrayList<>();
+        if (hasRagContext) {
+            contentToSanitize.add(ragContext);
+        }
+        conversation.forEach(message -> contentToSanitize.add(message.get("content")));
+        List<String> sanitizedContent = piiSanitizer.sanitizeBatchForGroq(contentToSanitize);
+        int contentIndex = 0;
+        if (hasRagContext) {
+            finalSystemPrompt += "\n\n### CRITICAL INDIAN LEGAL CONTEXT RELEVANT TO THIS USER ###\n"
+                    + sanitizedContent.get(contentIndex++)
+                    + "\n\nUse this law to guide the user accurately.";
         }
         
         systemMsg.put("content", finalSystemPrompt);
@@ -607,7 +619,7 @@ public class VakilFriendService {
         for (Map<String, String> msg : conversation) {
             ObjectNode msgNode = objectMapper.createObjectNode();
             msgNode.put("role", msg.get("role").equals("assistant") ? "assistant" : "user");
-            msgNode.put("content", msg.get("content"));
+            msgNode.put("content", sanitizedContent.get(contentIndex++));
             messagesArray.add(msgNode);
         }
         

--- a/backend/nyaysetu-backend/src/main/resources/application-prod.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application-prod.properties
@@ -25,9 +25,10 @@ cors.allowed.origins=${CORS_ALLOWED_ORIGINS}
 
 # AI Keys - Read from Env Vars
 groq.api.key=${GROQ_API_KEY}
+pii.sanitizer.strict-mode=true
+pii.sanitizer.ner-url=${PII_NER_URL:http://backend-python:8001/internal/pii/entities}
 jwt.secret=nyaysetu-development-secret-key-1234567890
 jwt.expiration=900000
-
 
 
 # File Upload Configuration (Production)

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -113,6 +113,8 @@ chat.max.messages.per.session=100
 # Groq AI Configuration
 groq.api.key=${GROQ_API_KEY:}
 groq.model=llama-3.1-8b-instant
+pii.sanitizer.strict-mode=true
+pii.sanitizer.ner-url=${PII_NER_URL:http://localhost:8001/internal/pii/entities}
 
 # Bhashini Configuration
 bhashini.api.key=${BHASHINI_API_KEY:}

--- a/backend/nyaysetu-backend/src/main/resources/application.properties.example
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties.example
@@ -123,6 +123,8 @@ chat.max.messages.per.session=100
 # Get your free API key at: https://console.groq.com
 groq.api.key=${GROQ_API_KEY:}
 groq.model=llama-3.1-8b-instant
+pii.sanitizer.strict-mode=true
+pii.sanitizer.ner-url=${PII_NER_URL:http://localhost:8001/internal/pii/entities}
 
 # ============================================
 # BHASHINI CONFIGURATION (National Language Translation Mission)

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/PiiNerClientTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/PiiNerClientTest.java
@@ -1,0 +1,38 @@
+package com.nyaysetu.backend.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class PiiNerClientTest {
+
+    @Test
+    void sendsMinorProtectionFlagAndReadsEntities() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        String url = "http://localhost:8001/internal/pii/entities";
+        server.expect(once(), requestTo(url))
+                .andExpect(content().json("""
+                        {"text":"Victim Raju","minor_protection":true}
+                        """))
+                .andRespond(withSuccess("""
+                        {"entities":[{"value":"Raju","type":"PERSON"}]}
+                        """, MediaType.APPLICATION_JSON));
+
+        List<PiiEntityDetector.DetectedEntity> entities =
+                new PiiNerClient(restTemplate, url).detectEntities("Victim Raju", true);
+
+        assertThat(entities).containsExactly(
+                new PiiEntityDetector.DetectedEntity("Raju", "PERSON"));
+        server.verify();
+    }
+}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/PiiSanitizerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/PiiSanitizerTest.java
@@ -1,0 +1,142 @@
+package com.nyaysetu.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PiiSanitizerTest {
+
+    private PiiSanitizer sanitizer;
+
+    @BeforeEach
+    void setUp() {
+        PiiEntityDetector entityDetector = (text, minorProtection) ->
+            Stream.of(
+                    personIfPresent(text, "Rahul Sharma"),
+                    personIfPresent(text, "राहुल शर्मा"),
+                    personIfPresent(text, "ரவிக்குமார்"),
+                    personIfPresent(text, "రవి కుమార్"),
+                    personIfPresent(text, "রাহুল শর্মা"),
+                    personIfPresent(text, "Priya Sharma"),
+                    personIfPresent(text, "Ravi Kumar"),
+                    personIfPresent(text, "Raju"))
+                    .filter(entity -> entity != null)
+                    .toList();
+        sanitizer = new PiiSanitizer(true, entityDetector);
+    }
+
+    @Test
+    void masksAadhaarAndIndianPhoneFormats() {
+        String result = sanitizer.sanitizeForGroq(
+                "Aadhaar 1234-5678-9012, 1234 5678 9012 and phone +91-9876543210");
+
+        assertThat(result)
+                .doesNotContain("1234-5678-9012", "1234 5678 9012", "9876543210")
+                .contains("[AADHAAR_1]", "[PHONE_1]");
+    }
+
+    @Test
+    void masksPanAndGovernmentIdentityDocuments() {
+        String result = sanitizer.sanitizeForGroq(
+                "PAN ABCDE1234F voter ABC1234567 passport A1234567 DL MH-12-2011-1234567");
+
+        assertThat(result)
+                .doesNotContain("ABCDE1234F", "ABC1234567", "A1234567", "MH-12-2011-1234567")
+                .contains("[PAN_1]", "[VOTER_ID_1]", "[PASSPORT_1]", "[DRIVING_LICENCE_1]");
+    }
+
+    @Test
+    void pseudonymizesNamesAcrossSupportedIndianScripts() {
+        String result = sanitizer.sanitizeForGroq(
+                "Rahul Sharma, राहुल शर्मा, ரவிக்குமார், రవి కుమార్, রাহুল শর্মা");
+
+        assertThat(result)
+                .doesNotContain(
+                        "Rahul Sharma", "राहुल शर्मा", "ரவிக்குமார்", "రవి కుమార్", "রাহুল শর্মা")
+                .contains("PERSON_A", "PERSON_B", "PERSON_C", "PERSON_D", "PERSON_E");
+    }
+
+    @Test
+    void pseudonymsAreStableWithinOnePayload() {
+        String result = sanitizer.sanitizeForGroq(
+                "Priya Sharma complained. Priya Sharma testified.");
+
+        assertThat(result).isEqualTo("PERSON_A complained. PERSON_A testified.");
+    }
+
+    @Test
+    void masksSingleWordAndJsonNamesInPocsoContext() {
+        String result = sanitizer.sanitizeForGroq(
+                "POCSO case: victim Raju, {\"victim\": \"Priya Sharma\", \"age\": 14}");
+
+        assertThat(result).doesNotContain("Raju", "Priya Sharma");
+        assertThat(result).contains("PERSON_");
+    }
+
+    @Test
+    void masksCasteIdentifiers() {
+        String result = sanitizer.sanitizeForGroq("Community: SC/ST, OBC and Scheduled Caste");
+
+        assertThat(result).doesNotContain("SC/ST", "OBC", "Scheduled Caste")
+                .contains("[CASTE_1]", "[CASTE_2]", "[CASTE_3]");
+    }
+
+    @Test
+    void masksLabelledAddressAndMedicalFields() {
+        String result = sanitizer.sanitizeForGroq(
+                "address: 12 MG Road, diagnosis: post-traumatic stress disorder");
+
+        assertThat(result)
+                .doesNotContain("12 MG Road", "post-traumatic stress disorder")
+                .contains("ADDRESS_A", "MEDICAL_A");
+    }
+
+    @Test
+    void keepsPseudonymsStableAcrossConversationFields() {
+        assertThat(sanitizer.sanitizeBatchForGroq(List.of(
+                "Priya Sharma filed the complaint", "Priya Sharma testified")))
+                .containsExactly("PERSON_A filed the complaint", "PERSON_A testified");
+    }
+
+    @Test
+    void handlesNamesNextToJsonFieldsWithoutLosingRelationshipTokens() {
+        String result = sanitizer.sanitizeForGroq(
+                "{\"victim\": \"Priya Sharma\", \"accused\": \"Ravi Kumar\"}");
+
+        assertThat(result).doesNotContain("Priya Sharma", "Ravi Kumar")
+                .contains("PERSON_A", "PERSON_B");
+    }
+
+    @Test
+    void blocksWhenLocalNerFailsInStrictMode() {
+        PiiEntityDetector failingDetector = (text, minorProtection) -> {
+            throw new IllegalStateException("NER unavailable");
+        };
+
+        assertThatThrownBy(() -> new PiiSanitizer(true, failingDetector)
+                .sanitizeForGroq("Victim Priya Sharma"))
+                .isInstanceOf(PiiSanitizationException.class)
+                .hasMessageContaining("blocked");
+    }
+
+    @Test
+    void permitsConfiguredFailOpenModeForLocalDevelopment() {
+        PiiEntityDetector failingDetector = (text, minorProtection) -> {
+            throw new IllegalStateException("NER unavailable");
+        };
+
+        String result = new PiiSanitizer(false, failingDetector)
+                .sanitizeForGroq("Victim Priya Sharma");
+
+        assertThat(result).isEqualTo("Victim Priya Sharma");
+    }
+
+    private static PiiEntityDetector.DetectedEntity personIfPresent(String text, String name) {
+        return text.contains(name) ? new PiiEntityDetector.DetectedEntity(name, "PERSON") : null;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      backend-python:
+        condition: service_started
     ports:
       - "8080:8080"
     environment:
@@ -37,6 +39,7 @@ services:
       - DB_USERNAME=${DB_USERNAME:-postgres}
       - DB_PASSWORD=${DB_PASSWORD:-postgres}
       - GROQ_API_KEY=${GROQ_API_KEY:?Please set GROQ_API_KEY in your .env file}
+      - PII_NER_URL=${PII_NER_URL:-http://backend-python:8001/internal/pii/entities}
       - JWT_SECRET=${JWT_SECRET:?Please set JWT_SECRET in your .env file}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost}
@@ -56,9 +59,10 @@ services:
       - ENV=production
       - GROQ_API_KEY=${GROQ_API_KEY:?Please set GROQ_API_KEY in your .env file}
       - GOOGLE_GEMINI_API_KEY=${GOOGLE_GEMINI_API_KEY}
+      - PII_NER_MODEL=${PII_NER_MODEL:-ai4bharat/IndicNER}
       # Keep this aligned with FRONTEND_URL; set both explicitly in .env when needed.
       - FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-http://localhost}
-    mem_limit: 256M
+    mem_limit: 2G
     restart: always
 
   # 4. Frontend (React + Nginx)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,6 +48,8 @@ DB_USERNAME=postgres
 DB_PASSWORD=your_secure_password
 JWT_SECRET=replace_with_a_long_random_256_bit_secret
 GROQ_API_KEY=your_groq_api_key_here
+PII_NER_MODEL=ai4bharat/IndicNER
+PII_NER_URL=http://backend-python:8001/internal/pii/entities
 FRONTEND_URL=http://localhost:5173
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost
 
@@ -63,6 +65,10 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4174,http://localhos
 ```
 
 Optional providers can be left blank unless you are using those features. Do not commit a filled `.env` file.
+
+`PII_NER_MODEL` runs inside the NLP orchestrator and must be available before any
+Groq request is made. The backend defaults to strict sanitization: if the local NER
+service fails, the external Groq request is blocked rather than sent unsanitized.
 
 > **Production requirement:** When running with `SPRING_PROFILES_ACTIVE=prod`, you **must** set `JWT_SECRET` as an environment variable. The backend now fails fast at startup in production if `JWT_SECRET` is missing or falls back to the default development secret.
 

--- a/nlp-orchestrator/main.py
+++ b/nlp-orchestrator/main.py
@@ -47,6 +47,7 @@ from validators.citation_validator import validate_citations_from_text
 from avatar_speech import get_interim_messages, convert_to_hinglish, detect_domain
 from services.kanoon_search import build_kanoon_context
 from sanitizer import sanitize_user_input, sanitize_prompt_input
+from pii_ner import router as pii_ner_router
 
 # Initialize clients for deep research pipeline
 from groq import AsyncGroq
@@ -135,6 +136,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.include_router(pii_ner_router)
 
 try:
     from routers.forensics import router as forensics_router

--- a/nlp-orchestrator/pii_ner.py
+++ b/nlp-orchestrator/pii_ner.py
@@ -1,0 +1,94 @@
+"""Local multilingual named-entity recognition for outbound PII sanitization."""
+
+import logging
+import os
+from functools import lru_cache
+from typing import Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("nlp-orchestrator.pii-ner")
+router = APIRouter(prefix="/internal/pii", tags=["internal-pii"])
+
+
+class NerRequest(BaseModel):
+    """Text submitted by the backend before an external LLM request."""
+
+    text: str = Field(max_length=50_000)
+    minor_protection: bool = False
+
+
+class DetectedEntity(BaseModel):
+    """An exact sensitive span and its normalized entity type."""
+
+    value: str
+    type: Literal["PERSON", "ORGANIZATION", "ADDRESS"]
+
+
+class NerResponse(BaseModel):
+    """Sensitive entities detected entirely inside the local deployment."""
+
+    entities: list[DetectedEntity]
+
+
+@lru_cache(maxsize=1)
+def _get_ner_pipeline():
+    """Load the configured model once; inference never calls a hosted API."""
+    from transformers import pipeline
+
+    model_name = os.getenv("PII_NER_MODEL", "ai4bharat/IndicNER")
+    logger.info("Loading local PII NER model: %s", model_name)
+    return pipeline(
+        "token-classification",
+        model=model_name,
+        tokenizer=model_name,
+        aggregation_strategy="simple",
+    )
+
+
+def detect_sensitive_entities(
+    text: str, minor_protection: bool = False
+) -> list[DetectedEntity]:
+    """Detect person, organization, and location spans in multilingual text."""
+    if not text.strip():
+        return []
+
+    threshold = 0.35 if minor_protection else 0.55
+    detected: list[DetectedEntity] = []
+    seen: set[tuple[str, str]] = set()
+    label_mapping = {
+        "PER": "PERSON",
+        "PERSON": "PERSON",
+        "ORG": "ORGANIZATION",
+        "ORGANIZATION": "ORGANIZATION",
+        "LOC": "ADDRESS",
+        "LOCATION": "ADDRESS",
+        "GPE": "ADDRESS",
+    }
+
+    for entity in _get_ner_pipeline()(text):
+        score = float(entity.get("score", 0.0))
+        raw_label = str(entity.get("entity_group", entity.get("entity", "")))
+        normalized_label = raw_label.upper().removeprefix("B-").removeprefix("I-")
+        entity_type = label_mapping.get(normalized_label)
+        start = entity.get("start")
+        end = entity.get("end")
+        if entity_type is None or score < threshold or start is None or end is None:
+            continue
+
+        value = text[int(start):int(end)].strip()
+        key = (value.casefold(), entity_type)
+        if value and key not in seen:
+            seen.add(key)
+            detected.append(DetectedEntity(value=value, type=entity_type))
+
+    return detected
+
+
+@router.post("/entities", response_model=NerResponse)
+def find_pii_entities(request: NerRequest) -> NerResponse:
+    """Return sensitive spans without persisting or forwarding the supplied text."""
+    return NerResponse(
+        entities=detect_sensitive_entities(request.text, request.minor_protection)
+    )

--- a/nlp-orchestrator/tests/test_pii_ner.py
+++ b/nlp-orchestrator/tests/test_pii_ner.py
@@ -1,0 +1,65 @@
+"""Tests for the local multilingual PII NER boundary."""
+
+import pytest
+
+import pii_ner
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["Rahul Sharma", "राहुल शर्मा", "ரவிக்குமார்", "రవి కుమార్", "রাহুল শর্মা"],
+)
+def test_detects_person_names_in_indian_scripts(monkeypatch, name):
+    monkeypatch.setattr(
+        pii_ner,
+        "_get_ner_pipeline",
+        lambda: lambda text: [
+            {
+                "entity_group": "PER",
+                "score": 0.99,
+                "start": text.index(name),
+                "end": text.index(name) + len(name),
+            }
+        ],
+    )
+
+    entities = pii_ner.detect_sensitive_entities(f"Victim: {name}")
+
+    assert entities == [pii_ner.DetectedEntity(value=name, type="PERSON")]
+
+
+def test_minor_mode_uses_lower_threshold(monkeypatch):
+    monkeypatch.setattr(
+        pii_ner,
+        "_get_ner_pipeline",
+        lambda: lambda text: [
+            {
+                "entity_group": "PER",
+                "score": 0.40,
+                "start": text.index("Raju"),
+                "end": text.index("Raju") + len("Raju"),
+            }
+        ],
+    )
+
+    assert pii_ner.detect_sensitive_entities("Victim Raju") == []
+    assert pii_ner.detect_sensitive_entities("Victim Raju", minor_protection=True)
+
+
+def test_maps_organizations_and_locations(monkeypatch):
+    text = "Priya visited Apollo Hospital in Chennai"
+    monkeypatch.setattr(
+        pii_ner,
+        "_get_ner_pipeline",
+        lambda: lambda _: [
+            {"entity_group": "ORG", "score": 0.9, "start": 14, "end": 29},
+            {"entity_group": "LOC", "score": 0.9, "start": 33, "end": 40},
+        ],
+    )
+
+    entities = pii_ner.detect_sensitive_entities(text)
+
+    assert entities == [
+        pii_ner.DetectedEntity(value="Apollo Hospital", type="ORGANIZATION"),
+        pii_ner.DetectedEntity(value="Chennai", type="ADDRESS"),
+    ]


### PR DESCRIPTION

## Description

Adds a fail-closed PII firewall before legal data is sent to Groq.

## Related Issue

Closes #1138 

## Changes Made

- Masks Aadhaar, PAN, phone numbers, voter IDs, passports, driving licences, emails, caste identifiers, addresses, and medical fields.
- Adds local multilingual NER using `ai4bharat/IndicNER`.
- Detects names in Hindi, Bengali, Tamil, Telugu, and other Indic languages.
- Uses stable request-scoped pseudonyms such as `PERSON_A`.
- Adds enhanced POCSO/minor protection.
- Sanitizes all Java Groq call sites.
- Adds safe `SANITIZATION_AUDIT` logs containing only token types and counts.
- Blocks Groq requests when sanitization fails in strict mode.
- Updates Docker, environment configuration, tests, and setup documentation.

## Security Behavior

Strict mode is enabled by default:

```properties
pii.sanitizer.strict-mode=true
If the local NER service is unavailable, the Groq request is blocked instead of sending unsanitized data.
Testing Completed

Backend: 24 tests passed

Frontend: 16 tests passed

NLP: 95 tests passed

Frontend production build passed

Docker Compose configuration validated

No test failures or errors
Test Proof
Backend Tests

<img width="918" height="320" alt="Screenshot 2026-06-21 132237" src="https://github.com/user-attachments/assets/2e0754a5-b34a-4a35-9f99-fdaadeb43ff9" />


Frontend Tests
<img width="863" height="267" alt="Screenshot 2026-06-21 132015" src="https://github.com/user-attachments/assets/c6fdfbac-c87e-4a74-88dd-a4b020be7a26" />



NLP Tests
<img width="928" height="177" alt="Screenshot 2026-06-21 132032" src="https://github.com/user-attachments/assets/7be2214a-4370-40c9-b89d-9b52ea649e80" />



Acceptance Coverage

Aadhaar formats are masked

Phone numbers with +91 are masked

PAN and government identity formats are masked

Devanagari, Bengali, Tamil, and Telugu names are detected

POCSO/minor cases receive enhanced protection

Caste identifiers are masked

Stable pseudonyms preserve relationships

Safe sanitization audit entries are written

Strict-mode failures block Groq requests
Operational Note
The NLP orchestrator must be running and the configured IndicNER model must be available before Groq-backed functionality can operate in strict mode.
Type of Change

Security fix

New feature

Tests

Configuration and documentation

Breaking API change
Checklist

Code follows the contribution guidelines

Unit and integration tests pass

Configuration is documented

Sensitive values are never logged

No unnecessary files are included