### PR TITLE
feat: add Discord link to footer social icons

### DIFF
--- a/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
+++ b/frontend/nyaysetu-frontend/src/components/landing/Footer.jsx
@@ -2,7 +2,7 @@
 // fixed GitHub icon hover from #333 (invisible on dark) to a visible grey
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { FaLinkedin, FaTwitter, FaGithub, FaEnvelope, FaHeart } from 'react-icons/fa';
+import { FaLinkedin, FaTwitter, FaGithub, FaDiscord, FaEnvelope, FaHeart } from 'react-icons/fa';
 import { Scale } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
@@ -37,6 +37,12 @@ export default function Footer() {
             href: 'https://github.com/viru0909-dev/nyay-setu-working',
             label: 'GitHub',
             color: '#8b949e'
+        },
+        {
+            icon: <FaDiscord size={20} />,
+            href: 'https://discord.gg/nyaysetu',
+            label: 'Discord',
+            color: '#5865F2'
         }
     ];
 


### PR DESCRIPTION
## Description

This PR adds a Discord social media icon and link to the footer alongside the existing Email, LinkedIn, X (Twitter), and GitHub links.

The Discord icon follows the existing footer styling, hover effects, spacing, and responsive design patterns to maintain visual consistency across the application. The link opens the official Discord community in a new tab, making it easier for users and contributors to connect with the project community.

## Issue Resolved

Closes #1145

## Changes Made

* Added Discord icon to the footer social links section
* Added external Discord invite link
* Configured the link to open in a new browser tab
* Maintained existing footer styling and animations
* Preserved responsive behavior across screen sizes
* Ensured consistency with existing social media icons

## Screenshots

### Before

<img width="908" height="246" alt="image" src="https://github.com/user-attachments/assets/788aa822-e571-427b-ba65-3ebb8a0cb7c5" />


### After

<img width="835" height="222" alt="Screenshot 2026-06-22 102133" src="https://github.com/user-attachments/assets/62e2e613-e921-43b4-a498-c7b43cbf8652" />


## How to Test

1. Run the application locally.
2. Navigate to the footer section.
3. Verify that the Discord icon appears alongside the existing social icons.
4. Click the Discord icon.
5. Confirm that the Discord invite link opens in a new browser tab.
6. Verify the icon styling matches the existing social media icons.
7. Test responsiveness on different screen sizes.

## Testing Completed

* [x] Manual testing completed
* [x] Footer renders correctly
* [x] Discord link opens successfully
* [x] Responsive layout verified
* [x] No visual regressions observed

## Breaking Changes

None.