### PR TITLE
1232 feat validated request dtos

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseAssignmentController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/CaseAssignmentController.java
@@ -1,10 +1,14 @@
 package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.dto.LawyerDTO;
+import com.nyaysetu.backend.dto.LawyerProposalRequest;
+import com.nyaysetu.backend.dto.ProposalResponseRequest;
+import com.nyaysetu.backend.dto.CognizanceRequest;
 import com.nyaysetu.backend.entity.CaseEntity;
 import com.nyaysetu.backend.entity.User;
 import com.nyaysetu.backend.service.CaseAssignmentService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -71,11 +75,10 @@ public class CaseAssignmentController {
     @PostMapping("/{caseId}/propose-lawyer")
     public ResponseEntity<Map<String, Object>> proposeLawyer(
             @PathVariable UUID caseId,
-            @RequestBody Map<String, Object> request
+            @Valid @RequestBody LawyerProposalRequest request
     ) {
         try {
-            Long lawyerId = Long.parseLong(request.get("lawyerId").toString());
-            caseAssignmentService.proposeLawyerToCase(caseId, lawyerId);
+            caseAssignmentService.proposeLawyerToCase(caseId, request.getLawyerId());
             
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
@@ -98,11 +101,10 @@ public class CaseAssignmentController {
     @PostMapping("/{caseId}/respond-proposal")
     public ResponseEntity<Map<String, Object>> respondProposal(
             @PathVariable UUID caseId,
-            @RequestBody Map<String, Object> request
+            @Valid @RequestBody ProposalResponseRequest request
     ) {
         try {
-            String status = request.get("status").toString();
-            caseAssignmentService.respondToLawyerProposal(caseId, status);
+            caseAssignmentService.respondToLawyerProposal(caseId, request.getStatus());
             
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
@@ -138,15 +140,17 @@ public class CaseAssignmentController {
         return ResponseEntity.ok(workload);
     }
 
+    /**
+     * Take cognizance for a case
+     */
     @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
     @PostMapping("/{caseId}/take-cognizance")
     public ResponseEntity<Map<String, Object>> takeCognizance(
             @PathVariable UUID caseId,
-            @RequestBody Map<String, Object> request
+            @Valid @RequestBody CognizanceRequest request
     ) {
         try {
-            Long judgeId = Long.parseLong(request.get("judgeId").toString());
-            caseAssignmentService.takeCognizance(caseId, judgeId);
+            caseAssignmentService.takeCognizance(caseId, request.getJudgeId());
 
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
@@ -162,7 +166,9 @@ public class CaseAssignmentController {
         }
     }
 
-
+    /**
+     * Update summons status
+     */
     @PreAuthorize("hasAnyRole('POLICE', 'JUDGE', 'SUPER_JUDGE', 'ADMIN')")
     @PostMapping("/{caseId}/update-summons")
     public ResponseEntity<Map<String, Object>> updateSummons(
@@ -178,6 +184,9 @@ public class CaseAssignmentController {
         }
     }
 
+    /**
+     * Update document status
+     */
     @PreAuthorize("hasAnyRole('JUDGE', 'LAWYER', 'ADMIN')")
     @PostMapping("/{caseId}/document-status")
     public ResponseEntity<Map<String, Object>> updateDocumentStatus(
@@ -186,7 +195,6 @@ public class CaseAssignmentController {
     ) {
         try {
             String statusStr = request.get("status");
-            // Assuming DocumentStatus enum is available or imported
             com.nyaysetu.backend.entity.DocumentStatus status = com.nyaysetu.backend.entity.DocumentStatus.valueOf(statusStr);
             caseAssignmentService.updateDocumentStatus(caseId, status);
             return ResponseEntity.ok(Map.of("success", true, "message", "Document status updated"));

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/CognizanceRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/CognizanceRequest.java
@@ -1,0 +1,15 @@
+package com.nyaysetu.backend.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Validated request contract data transfer object for case cognizance.
+ * Enforces strict presence of judge identification to secure case docket transitions.
+ */
+@Data
+public class CognizanceRequest {
+
+    @NotNull(message = "Judge identification validation profile token key cannot be null or omitted.")
+    private Long judgeId;
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/LawyerProposalRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/LawyerProposalRequest.java
@@ -1,0 +1,16 @@
+package com.nyaysetu.backend.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Validated request contract data transfer object for lawyer proposals.
+ * Satisfies strict Bean Validation criteria to prevent unvalidated field injection.
+ */
+@Data
+public class LawyerProposalRequest {
+
+    @NotNull(message = "Lawyer identification token key cannot be null or omitted.")
+    private Long lawyerId;
+}
+

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/ProposalResponseRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/ProposalResponseRequest.java
@@ -1,0 +1,17 @@
+package com.nyaysetu.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Validated request contract data transfer object for proposal responses.
+ * Enforces character constraints to prevent empty parameters from hitting cores.
+ */
+@Data
+public class ProposalResponseRequest {
+
+    @NotBlank(message = "Proposal response status mapping token string cannot be blank or empty.")
+    @Size(min = 3, max = 20, message = "Status length configuration properties must stay between 3 and 20 characters.")
+    private String status;
+}


### PR DESCRIPTION
## What does this PR do?
This PR resolves Issue #1232 by removing unvalidated `Map<String, Object>` request bodies inside `CaseAssignmentController` and replacing them with explicit, type-safe Data Transfer Objects (DTOs) integrated with explicit bean validation constraints.

## Proposed Changes
- **Data Transfer Object Layer Integration**:
  - `LawyerProposalRequest.java`: Enforces explicit presence of a non-null `lawyerId` token key.
  - `ProposalResponseRequest.java`: Enforces non-blank validation parameter rules for `status` with a length guard property constraint between 3 and 20 characters.
  - `CognizanceRequest.java`: Enforces a strict non-null validator wrapper around `judgeId`.
- **Controller Refactoring (`CaseAssignmentController.java`)**: Replaced unvalidated payload captures with explicit `@Valid @RequestBody` interceptor binds across the `proposeLawyer`, `respondProposal`, and `takeCognizance` endpoint operations.

## Related issue
Closes #1232

## Checklist
- [x] Implicit payload map configurations are substituted with explicit type-safe DTO structures
- [x] Requests are bound tightly to standard `@Valid` bean verification interceptor properties
- [x] The branch tracking lineage is isolated from raw upstream master branches to avoid build anomalies
- [x] All newly created or refactored Java files terminate cleanly with a single POSIX trailing newline row
