### PR TITLE
docs: clarify LawGPT service is standalone, not in docker-compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,10 +133,17 @@ git checkout -b feat/your-feature-name
 
 Services will be available at:
 - Backend: `http://localhost:8080`
-- LawGPT: `http://localhost:8000`
 - NLP Orchestrator: `http://localhost:8001`
-- Signaling Server: `http://localhost:3001`
 - Frontend: `http://localhost:3000`
+
+> **Note:** `LawGPT` (port 8000) and `Signaling Server` (port 3001) are **not part of
+> the Docker Compose setup**. LawGPT must be started manually if needed:
+> ```bash
+> cd lawgpt-service
+> pip install -r requirements.txt
+> uvicorn main:app --port 8000
+> ```
+> The backend will fall back gracefully if LawGPT is unavailable.
 
 ### Manual Setup (Without Docker)
 


### PR DESCRIPTION
What was wrong
CONTRIBUTING.md listed LawGPT (localhost:8000) and Signaling Server (localhost:3001) under "Services will be available at:" after docker-compose up -d — but neither service is defined in docker-compose.yml.
This confused new contributors who expected these services to start automatically with Docker.
What I changed
CONTRIBUTING.md

Removed LawGPT and Signaling Server from the Docker Compose service list
Added a note clarifying that lawgpt-service is a standalone service that must be started manually
Added manual startup instructions for lawgpt-service
Kept only the services actually defined in docker-compose.yml: Backend (8080), NLP Orchestrator (8001), Frontend (3000)

Type of Change

 Documentation update

Testing

Verified docker-compose.yml does not define a lawgpt-service or signaling server
Verified lawgpt-service/ exists as a standalone directory with its own requirements.txt