### PR TITLE
1193 feat ai feedback loop

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VakilFriendFeedbackController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VakilFriendFeedbackController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -15,6 +16,7 @@ import java.util.Map;
 /**
  * REST Controller that exposes API endpoints for submitting user feedback loops 
  * and retrieving AI response quality tracking metrics for Vakil Friend queries.
+ * Hardened with strict role-based access controls on administrative endpoints.
  */
 @RestController
 @RequestMapping("/api/v1/vakil-friend/feedback")
@@ -27,7 +29,7 @@ public class VakilFriendFeedbackController {
 
     /**
      * POST endpoint to submit user feedback loop parameters for an AI response.
-     * Maps query ID, response ID, feedback type (HELPFUL/NOT_HELPFUL), and comments.
+     * Mapped publicly to allow any authenticated user to rate responses.
      */
     @PostMapping
     public ResponseEntity<Map<String, Object>> submitFeedback(@RequestBody VakilFriendFeedback feedbackPayload) {
@@ -62,8 +64,10 @@ public class VakilFriendFeedbackController {
 
     /**
      * GET endpoint to aggregate all logs for administrator analytics dashboard panels.
+     * Hardened Security: Restricts execution explicitly to HIGH-PRIVILEGE ADMIN users.
      */
     @GetMapping("/analytics")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<VakilFriendFeedback>> getAdminAnalyticsMetrics() {
         log.info("[FeedbackAPI] Dispatching global feedback log histories row collection layer for admin metrics tracking.");
         try {
@@ -77,8 +81,10 @@ public class VakilFriendFeedbackController {
 
     /**
      * GET endpoint to filter feedback tracking parameters by target feedback type (e.g., NOT_HELPFUL).
+     * Hardened Security: Restricts execution explicitly to HIGH-PRIVILEGE ADMIN users.
      */
     @GetMapping("/analytics/filter")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<VakilFriendFeedback>> filterMetricsByType(@RequestParam String type) {
         log.info("[FeedbackAPI] Executing granular filter parameter query against feedback type matching: {}", type);
         try {

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VakilFriendFeedbackController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VakilFriendFeedbackController.java
@@ -1,0 +1,93 @@
+package com.nyaysetu.backend.controller;
+
+import com.nyaysetu.backend.entity.VakilFriendFeedback;
+import com.nyaysetu.backend.repository.VakilFriendFeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST Controller that exposes API endpoints for submitting user feedback loops 
+ * and retrieving AI response quality tracking metrics for Vakil Friend queries.
+ */
+@RestController
+@RequestMapping("/api/v1/vakil-friend/feedback")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
+@Slf4j
+public class VakilFriendFeedbackController {
+
+    private final VakilFriendFeedbackRepository feedbackRepository;
+
+    /**
+     * POST endpoint to submit user feedback loop parameters for an AI response.
+     * Maps query ID, response ID, feedback type (HELPFUL/NOT_HELPFUL), and comments.
+     */
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> submitFeedback(@RequestBody VakilFriendFeedback feedbackPayload) {
+        log.info("[FeedbackAPI] Ingesting feedback parameters loop for Query ID: {}", feedbackPayload.getQueryId());
+        Map<String, Object> responseMetadata = new HashMap<>();
+
+        if (feedbackPayload.getQueryId() == null || feedbackPayload.getQueryId().isBlank() ||
+            feedbackPayload.getResponseId() == null || feedbackPayload.getResponseId().isBlank() ||
+            feedbackPayload.getFeedbackType() == null || feedbackPayload.getFeedbackType().isBlank()) {
+            
+            log.warn("[FeedbackAPI] Validation failed across input parameters payload data structure keys.");
+            responseMetadata.put("success", false);
+            responseMetadata.put("message", "Required parameters missing: queryId, responseId, and feedbackType are mandatory.");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseMetadata);
+        }
+
+        try {
+            VakilFriendFeedback savedFeedback = feedbackRepository.save(feedbackPayload);
+            log.info("[FeedbackAPI] User feedback successfully committed to data pools with ID: {}", savedFeedback.getId());
+            
+            responseMetadata.put("success", true);
+            responseMetadata.put("message", "Feedback logged successfully.");
+            responseMetadata.put("feedbackId", savedFeedback.getId());
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseMetadata);
+        } catch (Exception e) {
+            log.error("[FeedbackAPI] Persistence runtime error encounter intercepted:", e);
+            responseMetadata.put("success", false);
+            responseMetadata.put("message", "Internal persistence failure: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseMetadata);
+        }
+    }
+
+    /**
+     * GET endpoint to aggregate all logs for administrator analytics dashboard panels.
+     */
+    @GetMapping("/analytics")
+    public ResponseEntity<List<VakilFriendFeedback>> getAdminAnalyticsMetrics() {
+        log.info("[FeedbackAPI] Dispatching global feedback log histories row collection layer for admin metrics tracking.");
+        try {
+            List<VakilFriendFeedback> feedbackLogsCollection = feedbackRepository.findAll();
+            return ResponseEntity.ok(feedbackLogsCollection);
+        } catch (Exception e) {
+            log.error("[FeedbackAPI] Administrative records compilation failure:", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * GET endpoint to filter feedback tracking parameters by target feedback type (e.g., NOT_HELPFUL).
+     */
+    @GetMapping("/analytics/filter")
+    public ResponseEntity<List<VakilFriendFeedback>> filterMetricsByType(@RequestParam String type) {
+        log.info("[FeedbackAPI] Executing granular filter parameter query against feedback type matching: {}", type);
+        try {
+            List<VakilFriendFeedback> filteredLogs = feedbackRepository.findByFeedbackType(type);
+            return ResponseEntity.ok(filteredLogs);
+        } catch (Exception e) {
+            log.error("[FeedbackAPI] Granular record isolation extraction failure:", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}
+

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/VakilFriendFeedback.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/VakilFriendFeedback.java
@@ -1,0 +1,48 @@
+package com.nyaysetu.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+/**
+ * Entity tracking model that persists user quality ratings, comments, and analytics metrics
+ * for AI-generated legal assistance queries delivered by Vakil Friend.
+ */
+@Entity
+@Table(name = "vakil_friend_feedback")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VakilFriendFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "query_id", nullable = false)
+    private String queryId;
+
+    @Column(name = "response_id", nullable = false)
+    private String responseId;
+
+    @Column(name = "feedback_type", nullable = false)
+    private String feedbackType; // HELPFUL, NOT_HELPFUL
+
+    @Column(name = "comment", length = 1000)
+    private String comment;
+
+    @Column(name = "timestamp", nullable = false)
+    private LocalDateTime timestamp;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.timestamp == null) {
+            this.timestamp = LocalDateTime.now();
+        }
+    }
+}
+

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/VakilFriendFeedbackRepository.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/VakilFriendFeedbackRepository.java
@@ -1,0 +1,26 @@
+package com.nyaysetu.backend.repository;
+
+import com.nyaysetu.backend.entity.VakilFriendFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Spring Data JPA Repository interface that exposes standardized database operations,
+ * inserts, and custom query boundaries for the vakil_friend_feedback analytics matrix.
+ */
+@Repository
+public interface VakilFriendFeedbackRepository extends JpaRepository<VakilFriendFeedback, Long> {
+    
+    /**
+     * Retrieves all user feedback entries associated with a specific AI processing session query.
+     */
+    List<VakilFriendFeedback> findByQueryId(String queryId);
+
+    /**
+     * Retrieves all feedback filtered by rating type (e.g., HELPFUL, NOT_HELPFUL) for analytical processing.
+     */
+    List<VakilFriendFeedback> findByFeedbackType(String feedbackType);
+}
+


### PR DESCRIPTION
# Pull Request: User Feedback Loops & AI Response Quality Analytics Tracking for Vakil Friend

## 📋 Problem Statement & Context
Prior to this implementation, the platform lacked an empirical or structured interface to monitor the accuracy, helpfulness, and structural behavior of the AI-generated legal guidance delivered by the Vakil Friend module. Consequently, low-quality or hallucinated responses could not be programmatically isolated, legal engineers lacked measurable performance timelines over model iterations, and repeatedly problematic legal subject anomalies remained undetected across data pools.

## 🛠️ Proposed Solution & Technical Implementations
This PR introduces a comprehensive, data-driven feedback orchestration infrastructure to ingest, persist, and aggregate user quality inputs for administrative reporting and assistant optimization passes:

1. **Relational Persistence Layer (`VakilFriendFeedback.java`)**:
   - Authored an explicit Spring Data JPA database entity mapping model (`vakil_friend_feedback` table) to track core quality metadata parameters:
     - `queryId`: Backreference tracking token linking to the user's initial prompt context.
     - `responseId`: Unique identifier tracking the specific LLM execution payload payload.
     - `feedbackType`: Enum-equivalent string criteria representing response helpfulness (`HELPFUL`, `NOT_HELPFUL`).
     - `comment`: Structural text block constraint (length = 1000) allowing optional user comments.
     - `timestamp`: Captures precise generation metrics automatically using `@PrePersist` hooks.

2. **Data Abstraction Interface (`VakilFriendFeedbackRepository.java`)**:
   - Implemented a Spring Data `JpaRepository` contract wrapper layer.
   - Appended specialized finder query vectors (`findByQueryId` and `findByFeedbackType`) to allow quick analytics compilation by administrative systems.

3. **REST Architecture Controllers Layer (`VakilFriendFeedbackController.java`)**:
   - Engineered a linter-hardened, `@RestController` API gateway framework mapped to base endpoint `/api/v1/vakil-friend/feedback`.
   - **`POST` Ingestion Boundary**: Implements defensive payload string validation guards to intercept and drop malformed payloads immediately with explicit `400 Bad Request` rejections before touching connection pools.
   - **`GET /analytics` Endpoint**: Exposes absolute transactional aggregate lookups for administrative monitoring panel dashboards.
   - **`GET /analytics/filter` Endpoint**: Enables granular administrative filtering parameters to isolate and study structural model failures (such as analyzing clusters of `NOT_HELPFUL` rejections).

## 🧪 Verification & Testing Completed
- Confirmed proper compilation tracking parameters against Spring Security path rules.
- Validated that all custom repository query methods conform flawlessly to JPA method-name patterns.
- Verified that all surrounding baseline core packages remain completely unaffected.

Closes #1193
