### PR TITLE
Feat/hybrid vec search

### DIFF
--- a/nlp-orchestrator/services/retrieval/__init__.py
+++ b/nlp-orchestrator/services/retrieval/__init__.py
@@ -1,0 +1,57 @@
+"""
+Semantic retrieval package for the NLP orchestrator.
+
+Low-level building blocks:
+    chunker      — token/section-aware chunking of legal text
+    embedder     — bi-encoder embeddings (InLegalBERT by default)
+    vectorstore  — persistent Chroma vector store wrapper
+    reranker     — cross-encoder reranking of candidates
+
+High-level reusable facade (Phase 1, issue #673):
+    retrieve / retrieve_sync — semantic search over the corpus
+    ingest_documents          — add documents to the corpus
+    corpus_size / is_available
+    RetrievedChunk            — typed result row
+
+The facade symbols are exported lazily via module ``__getattr__`` so that
+importing a single low-level submodule (e.g. ``from services.retrieval import
+chunker``) does not pull in ``config`` or the embedding/vector-store stack.
+"""
+
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "RetrievedChunk",
+    "retrieve",
+    "retrieve_sync",
+    "ingest_documents",
+    "corpus_size",
+    "is_available",
+]
+
+# Names re-exported from the retriever facade, resolved on first access.
+_FACADE_EXPORTS = set(__all__)
+
+
+def __getattr__(name: str):
+    """Lazily resolve facade symbols (PEP 562) without eager heavy imports."""
+    if name in _FACADE_EXPORTS:
+        from services.retrieval import retriever
+
+        return getattr(retriever, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + list(_FACADE_EXPORTS))
+
+
+if TYPE_CHECKING:  # pragma: no cover - import-time hints only for type checkers
+    from services.retrieval.retriever import (  # noqa: F401
+        RetrievedChunk,
+        corpus_size,
+        ingest_documents,
+        is_available,
+        retrieve,
+        retrieve_sync,
+    )

--- a/nlp-orchestrator/services/retrieval/chunker.py
+++ b/nlp-orchestrator/services/retrieval/chunker.py
@@ -138,41 +138,6 @@ def split_legal_sections(text: str) -> list[str]:
     return blocks
 
 
-def chunk_text(
-    text: str,
-    max_tokens: int = 512,
-    overlap_tokens: int = 64,
-) -> list[str]:
-    """
-    Split `text` into section-aligned blocks at legal-section headings.
-
-    Each returned block begins with its heading (e.g. "Section 304A ...") and
-    runs up to — but not including — the next heading. Any preamble before the
-    first heading is returned as its own leading block so no content is lost.
-
-    If the text contains no recognisable headings, a single-element list with
-    the whole (stripped) text is returned, which makes this a safe no-op for
-    free-form prose.
-    """
-    if not text or not text.strip():
-        return []
-
-    starts = [m.start() for m in _SECTION_HEADING_RE.finditer(text)]
-    if not starts:
-        return [text.strip()]
-
-    # Ensure the preamble (anything before the first heading) is preserved.
-    boundaries = starts if starts[0] == 0 else [0, *starts]
-
-    blocks: list[str] = []
-    for idx, start in enumerate(boundaries):
-        end = boundaries[idx + 1] if idx + 1 < len(boundaries) else len(text)
-        block = text[start:end].strip()
-        if block:
-            blocks.append(block)
-    return blocks
-
-
 def _chunk_block(
     text: str,
     max_tokens: int,

--- a/nlp-orchestrator/services/retrieval/retriever.py
+++ b/nlp-orchestrator/services/retrieval/retriever.py
@@ -41,7 +41,6 @@ Public API
     RetrievedChunk                                     # typed result row
 """
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional
@@ -136,9 +135,7 @@ def _resolve_defaults(
 def _filter_by_source(candidates: list[dict], source: Optional[str]) -> list[dict]:
     if not source:
         return candidates
-    return [
-        c for c in candidates if (c.get("metadata") or {}).get("source") == source
-    ]
+    return [c for c in candidates if (c.get("metadata") or {}).get("source") == source]
 
 
 def _finalize(

--- a/nlp-orchestrator/services/retrieval/retriever.py
+++ b/nlp-orchestrator/services/retrieval/retriever.py
@@ -1,0 +1,337 @@
+"""
+Reusable semantic-retrieval facade (Phase 1 — issue #673).
+
+This module is the single, dependency-light entry point that the rest of the
+orchestrator (and any future NLP-reasoning integration) should call to perform
+semantic search over the persistent legal corpus. It composes the existing
+low-level building blocks — `embedder` (bi-encoder), `vectorstore` (persistent
+Chroma), and `reranker` (cross-encoder) — behind one stable, typed API so that
+callers never have to wire those three together by hand.
+
+Why a facade
+------------
+Before this module, the only place the retrieval primitives were assembled was
+inside `services.kanoon_search.build_kanoon_context`, tightly coupled to the
+live Indian Kanoon search flow. There was no way to "just retrieve the top-k
+legal passages for a query" without dragging in a live HTTP search. This facade
+provides exactly that — a corpus-only, Kanoon-independent retrieval utility —
+which Phase 2 (issue #674) then uses to ground the reasoning pipeline.
+
+Design principles (consistent with the existing retrieval package)
+------------------------------------------------------------------
+  * Graceful degradation: if embeddings, the vector store, or the reranker are
+    unavailable, calls return empty results / zero counts and log once, rather
+    than raising. A caller can always treat retrieval as best-effort.
+  * Async-first: `retrieve` / `ingest_documents` are async and never block the
+    FastAPI event loop (the heavy work happens in the embedder/reranker
+    executors). A synchronous `retrieve_sync` is provided for scripts.
+  * Typed results: `RetrievedChunk` replaces ad-hoc dicts so downstream code
+    can rely on attribute access and stable field names.
+  * Config-driven defaults: top-k / fetch-k / rerank / model names come from
+    `config` so behaviour matches the rest of the system, but every call can
+    override them.
+
+Public API
+----------
+    await retrieve(query, *, top_k=..., fetch_k=..., rerank=..., min_score=..., source=...)
+    retrieve_sync(query, ...)                          # blocking variant
+    await ingest_documents(documents, *, source=...)   # add docs to the corpus
+    corpus_size()                                      # number of chunks stored
+    is_available()                                     # retrieval usable right now?
+    RetrievedChunk                                     # typed result row
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from config import (
+    CHROMA_PATH,
+    EMBEDDING_MODEL,
+    RERANKER_ENABLED,
+    RERANKER_MODEL,
+    RETRIEVAL_ENABLED,
+    RETRIEVAL_FETCH_K,
+    RETRIEVAL_TOP_K,
+)
+from services.retrieval import chunker, embedder, vectorstore
+from services.retrieval import reranker as rr
+
+logger = logging.getLogger("retrieval-facade")
+
+
+# ─── Typed result row ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class RetrievedChunk:
+    """
+    One retrieved passage plus its provenance.
+
+    `score` is the effective relevance score used for ordering/threshholding:
+    the cross-encoder `rerank_score` when reranking ran, otherwise the
+    bi-encoder cosine similarity in [0, 1]. The raw cosine similarity is always
+    preserved in `similarity` so callers can inspect both.
+    """
+
+    text: str
+    score: float
+    similarity: float = 0.0
+    rerank_score: Optional[float] = None
+    doc_id: str = ""
+    title: str = ""
+    source: str = ""
+    chunk_index: int = -1
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_raw(cls, raw: dict) -> "RetrievedChunk":
+        """Build a RetrievedChunk from a `vectorstore.query` row.
+
+        The row shape is {chunk, score, metadata}; reranking additionally
+        attaches `rerank_score`. Missing fields degrade to sensible defaults.
+        """
+        meta = raw.get("metadata") or {}
+        similarity = float(raw.get("score", 0.0))
+        rerank_score = raw.get("rerank_score")
+        rerank_score = None if rerank_score is None else float(rerank_score)
+        effective = similarity if rerank_score is None else rerank_score
+        return cls(
+            text=raw.get("chunk", "") or "",
+            score=float(effective),
+            similarity=similarity,
+            rerank_score=rerank_score,
+            doc_id=str(meta.get("doc_id", "")),
+            title=str(meta.get("title", "")) or "Untitled",
+            source=str(meta.get("source", "")),
+            chunk_index=int(meta.get("chunk_index", -1)),
+            metadata=meta,
+        )
+
+    def as_context_block(self) -> str:
+        """Render a single citation-friendly context block for prompts."""
+        header = self.title or "Untitled"
+        if self.doc_id:
+            header = f"{header} [doc_id={self.doc_id}]"
+        return f"=== {header} ===\n{self.text}"
+
+
+# ─── Retrieval ────────────────────────────────────────────────────────────────
+
+
+def _resolve_defaults(
+    top_k: Optional[int],
+    fetch_k: Optional[int],
+    rerank: Optional[bool],
+) -> tuple[int, int, bool]:
+    top_k = RETRIEVAL_TOP_K if top_k is None else int(top_k)
+    fetch_k = RETRIEVAL_FETCH_K if fetch_k is None else int(fetch_k)
+    rerank = RERANKER_ENABLED if rerank is None else bool(rerank)
+    # Never fetch fewer candidates than we intend to return.
+    fetch_k = max(fetch_k, top_k)
+    return top_k, fetch_k, rerank
+
+
+def _filter_by_source(candidates: list[dict], source: Optional[str]) -> list[dict]:
+    if not source:
+        return candidates
+    return [
+        c for c in candidates if (c.get("metadata") or {}).get("source") == source
+    ]
+
+
+def _finalize(
+    candidates: list[dict],
+    top_k: int,
+    min_score: float,
+) -> list[RetrievedChunk]:
+    out: list[RetrievedChunk] = []
+    for raw in candidates[:top_k]:
+        chunk = RetrievedChunk.from_raw(raw)
+        if chunk.score < min_score:
+            continue
+        out.append(chunk)
+    return out
+
+
+async def retrieve(
+    query: str,
+    *,
+    top_k: Optional[int] = None,
+    fetch_k: Optional[int] = None,
+    rerank: Optional[bool] = None,
+    min_score: float = 0.0,
+    source: Optional[str] = None,
+) -> list[RetrievedChunk]:
+    """
+    Semantic search over the persistent corpus.
+
+    Args:
+        query:     the natural-language query to ground.
+        top_k:     max passages to return (default: config.RETRIEVAL_TOP_K).
+        fetch_k:   candidates to pull from the vector store before reranking
+                   (default: config.RETRIEVAL_FETCH_K). Clamped to >= top_k.
+        rerank:    run the cross-encoder rerank (default: config.RERANKER_ENABLED).
+        min_score: drop chunks whose effective score is below this. For cosine
+                   similarity this is in [0, 1]; for cross-encoder rerank scores
+                   it is an unbounded logit (0.0 keeps only non-negative ones).
+        source:    if set, keep only chunks whose metadata `source` matches
+                   (e.g. "seed", "indian_kanoon").
+
+    Returns an ordered list (most relevant first), or [] if retrieval is
+    disabled or unavailable. Never raises for the common failure modes.
+    """
+    if not query or not query.strip():
+        return []
+    if not RETRIEVAL_ENABLED:
+        logger.debug("retrieve: RETRIEVAL_ENABLED is false; returning []")
+        return []
+
+    top_k, fetch_k, rerank = _resolve_defaults(top_k, fetch_k, rerank)
+
+    q_emb = await embedder.embed_async([query], EMBEDDING_MODEL)
+    if not q_emb:
+        logger.warning("retrieve: embedder unavailable; returning []")
+        return []
+
+    candidates = vectorstore.query(
+        query_embedding=q_emb[0],
+        top_k=fetch_k,
+        persist_dir=CHROMA_PATH,
+    )
+    candidates = _filter_by_source(candidates, source)
+    if not candidates:
+        return []
+
+    if rerank:
+        candidates = await rr.rerank_async(query, candidates, top_k, RERANKER_MODEL)
+
+    return _finalize(candidates, top_k, min_score)
+
+
+def retrieve_sync(
+    query: str,
+    *,
+    top_k: Optional[int] = None,
+    fetch_k: Optional[int] = None,
+    rerank: Optional[bool] = None,
+    min_score: float = 0.0,
+    source: Optional[str] = None,
+) -> list[RetrievedChunk]:
+    """Blocking variant of :func:`retrieve` for scripts / non-async callers."""
+    if not query or not query.strip():
+        return []
+    if not RETRIEVAL_ENABLED:
+        return []
+
+    top_k, fetch_k, rerank = _resolve_defaults(top_k, fetch_k, rerank)
+
+    q_emb = embedder.embed_sync([query], EMBEDDING_MODEL)
+    if not q_emb:
+        logger.warning("retrieve_sync: embedder unavailable; returning []")
+        return []
+
+    candidates = vectorstore.query(
+        query_embedding=q_emb[0],
+        top_k=fetch_k,
+        persist_dir=CHROMA_PATH,
+    )
+    candidates = _filter_by_source(candidates, source)
+    if not candidates:
+        return []
+
+    if rerank:
+        candidates = rr.rerank_sync(query, candidates, top_k, RERANKER_MODEL)
+
+    return _finalize(candidates, top_k, min_score)
+
+
+# ─── Ingestion ────────────────────────────────────────────────────────────────
+
+
+async def ingest_documents(
+    documents: list[dict],
+    *,
+    source: str = "corpus",
+    max_tokens: int = 512,
+    overlap_tokens: int = 64,
+    skip_existing: bool = True,
+) -> int:
+    """
+    Chunk, embed, and upsert a batch of documents into the corpus.
+
+    Each document is a dict:
+        {
+            "doc_id": str,              # required, stable id (idempotency key)
+            "text": str,                # required, raw document text
+            "title": str,               # optional, human-readable title
+            "source": str,              # optional, overrides the `source` arg
+            "metadata": dict,           # optional, extra metadata to store
+        }
+
+    Re-ingesting the same `doc_id` is safe: by default existing docs are
+    skipped; pass `skip_existing=False` to force a re-embed (the vector store
+    replaces all chunks for that doc_id atomically).
+
+    Returns the total number of chunks written across all documents.
+    """
+    total = 0
+    for doc in documents or []:
+        doc_id = (doc.get("doc_id") or "").strip()
+        text = doc.get("text") or ""
+        if not doc_id or not text.strip():
+            logger.debug("ingest_documents: skipping doc with empty id/text")
+            continue
+
+        if skip_existing and vectorstore.has_doc(doc_id, CHROMA_PATH):
+            logger.debug("ingest_documents: %s already present; skipping", doc_id)
+            continue
+
+        chunks = chunker.chunk_text(
+            text, max_tokens=max_tokens, overlap_tokens=overlap_tokens
+        )
+        if not chunks:
+            logger.warning("ingest_documents: %s produced no chunks", doc_id)
+            continue
+
+        embeddings = await embedder.embed_async(chunks, EMBEDDING_MODEL)
+        if not embeddings:
+            logger.error("ingest_documents: embedder unavailable for %s", doc_id)
+            continue
+
+        base_metadata = {
+            "title": doc.get("title", ""),
+            "source": doc.get("source") or source,
+        }
+        extra = doc.get("metadata") or {}
+        if isinstance(extra, dict):
+            base_metadata.update(extra)
+
+        added = vectorstore.upsert_chunks(
+            doc_id=doc_id,
+            chunks=chunks,
+            embeddings=embeddings,
+            base_metadata=base_metadata,
+            persist_dir=CHROMA_PATH,
+        )
+        total += added
+        logger.info("ingest_documents: %s -> %d chunks", doc_id, added)
+
+    return total
+
+
+# ─── Introspection ────────────────────────────────────────────────────────────
+
+
+def corpus_size() -> int:
+    """Number of chunks currently stored (0 if the store is unavailable)."""
+    return vectorstore.count(CHROMA_PATH)
+
+
+def is_available() -> bool:
+    """
+    True when retrieval can actually serve results right now: the feature flag
+    is on and the persistent store holds at least one chunk.
+    """
+    return RETRIEVAL_ENABLED and corpus_size() > 0

--- a/nlp-orchestrator/tests/test_retriever.py
+++ b/nlp-orchestrator/tests/test_retriever.py
@@ -26,7 +26,6 @@ os.environ.setdefault("GROQ_API_KEY", "test-key")
 from services.retrieval import retriever  # noqa: E402
 from services.retrieval.retriever import RetrievedChunk  # noqa: E402
 
-
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/nlp-orchestrator/tests/test_retriever.py
+++ b/nlp-orchestrator/tests/test_retriever.py
@@ -1,0 +1,324 @@
+"""
+Unit tests for the reusable retrieval facade (services/retrieval/retriever.py).
+
+These tests mock the heavy primitives (embedder, vector store, reranker) so the
+facade's orchestration logic — candidate fetching, source filtering, rerank
+toggling, top-k limiting, score thresholding, ingestion, and graceful
+degradation — is exercised without any model downloads or a live Chroma store.
+
+Run with: python -m pytest tests/test_retriever.py -v
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Ensure the orchestrator root is importable and config does not sys.exit when
+# GROQ_API_KEY is absent in the test environment (CI sets a real key).
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+os.environ.setdefault("GROQ_API_KEY", "test-key")
+
+from services.retrieval import retriever  # noqa: E402
+from services.retrieval.retriever import RetrievedChunk  # noqa: E402
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _raw(chunk, score, *, doc_id="d1", title="Doc 1", source="seed", idx=0):
+    """Build a raw vectorstore.query row."""
+    return {
+        "chunk": chunk,
+        "score": score,
+        "metadata": {
+            "doc_id": doc_id,
+            "title": title,
+            "source": source,
+            "chunk_index": idx,
+        },
+    }
+
+
+@pytest.fixture
+def mocked_primitives(monkeypatch):
+    """Patch embedder / vectorstore / reranker on the retriever module."""
+    fake_embedder = MagicMock()
+    fake_embedder.embed_async = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    fake_embedder.embed_sync = MagicMock(return_value=[[0.1, 0.2, 0.3]])
+
+    fake_vectorstore = MagicMock()
+    fake_vectorstore.query = MagicMock(return_value=[])
+    fake_vectorstore.count = MagicMock(return_value=0)
+    fake_vectorstore.has_doc = MagicMock(return_value=False)
+    fake_vectorstore.upsert_chunks = MagicMock(return_value=0)
+
+    fake_reranker = MagicMock()
+    fake_reranker.rerank_async = AsyncMock(side_effect=lambda q, c, k, m: c[:k])
+    fake_reranker.rerank_sync = MagicMock(side_effect=lambda q, c, k, m: c[:k])
+
+    fake_chunker = MagicMock()
+    fake_chunker.chunk_text = MagicMock(return_value=["chunk-a", "chunk-b"])
+
+    monkeypatch.setattr(retriever, "embedder", fake_embedder)
+    monkeypatch.setattr(retriever, "vectorstore", fake_vectorstore)
+    monkeypatch.setattr(retriever, "rr", fake_reranker)
+    monkeypatch.setattr(retriever, "chunker", fake_chunker)
+    monkeypatch.setattr(retriever, "RETRIEVAL_ENABLED", True)
+    return {
+        "embedder": fake_embedder,
+        "vectorstore": fake_vectorstore,
+        "reranker": fake_reranker,
+        "chunker": fake_chunker,
+    }
+
+
+# ─── RetrievedChunk ───────────────────────────────────────────────────────────
+
+
+def test_retrieved_chunk_from_raw_bi_encoder():
+    rc = RetrievedChunk.from_raw(_raw("hello", 0.87, doc_id="abc", title="T", idx=3))
+    assert rc.text == "hello"
+    assert rc.similarity == pytest.approx(0.87)
+    assert rc.rerank_score is None
+    assert rc.score == pytest.approx(0.87)  # effective == similarity when no rerank
+    assert rc.doc_id == "abc"
+    assert rc.title == "T"
+    assert rc.source == "seed"
+    assert rc.chunk_index == 3
+
+
+def test_retrieved_chunk_effective_score_uses_rerank():
+    raw = _raw("x", 0.40)
+    raw["rerank_score"] = 9.5
+    rc = RetrievedChunk.from_raw(raw)
+    assert rc.similarity == pytest.approx(0.40)
+    assert rc.rerank_score == pytest.approx(9.5)
+    assert rc.score == pytest.approx(9.5)  # effective switches to rerank score
+
+
+def test_retrieved_chunk_defaults_for_missing_metadata():
+    rc = RetrievedChunk.from_raw({"chunk": "body", "score": 0.5})
+    assert rc.title == "Untitled"
+    assert rc.doc_id == ""
+    assert rc.chunk_index == -1
+
+
+def test_as_context_block_includes_citation_header():
+    rc = RetrievedChunk.from_raw(_raw("the body", 0.5, doc_id="42", title="BNS 103"))
+    block = rc.as_context_block()
+    assert "BNS 103" in block
+    assert "doc_id=42" in block
+    assert "the body" in block
+
+
+# ─── retrieve() ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retrieve_happy_path_orders_and_types(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [
+        _raw("first", 0.9, doc_id="a"),
+        _raw("second", 0.7, doc_id="b"),
+    ]
+    out = await retriever.retrieve("murder punishment", top_k=2, rerank=False)
+    assert len(out) == 2
+    assert all(isinstance(c, RetrievedChunk) for c in out)
+    assert out[0].text == "first"
+    assert out[1].doc_id == "b"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_empty_query_returns_empty(mocked_primitives):
+    assert await retriever.retrieve("   ") == []
+    mocked_primitives["embedder"].embed_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_disabled_flag_returns_empty(monkeypatch, mocked_primitives):
+    monkeypatch.setattr(retriever, "RETRIEVAL_ENABLED", False)
+    assert await retriever.retrieve("anything") == []
+    mocked_primitives["embedder"].embed_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_embedder_unavailable_returns_empty(mocked_primitives):
+    mocked_primitives["embedder"].embed_async.return_value = None
+    assert await retriever.retrieve("query") == []
+    mocked_primitives["vectorstore"].query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_no_candidates_returns_empty(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = []
+    assert await retriever.retrieve("query") == []
+
+
+@pytest.mark.asyncio
+async def test_retrieve_top_k_limits_results(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [
+        _raw(f"c{i}", 1.0 - i * 0.1, doc_id=str(i)) for i in range(10)
+    ]
+    out = await retriever.retrieve("q", top_k=3, rerank=False)
+    assert len(out) == 3
+
+
+@pytest.mark.asyncio
+async def test_retrieve_fetch_k_never_below_top_k(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [_raw("c", 0.5)]
+    await retriever.retrieve("q", top_k=8, fetch_k=2, rerank=False)
+    # fetch_k passed to the store must be clamped up to top_k (8), not 2.
+    _, kwargs = mocked_primitives["vectorstore"].query.call_args
+    assert kwargs["top_k"] == 8
+
+
+@pytest.mark.asyncio
+async def test_retrieve_source_filter(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [
+        _raw("seed-chunk", 0.9, source="seed"),
+        _raw("kanoon-chunk", 0.8, source="indian_kanoon"),
+    ]
+    out = await retriever.retrieve("q", source="seed", rerank=False)
+    assert len(out) == 1
+    assert out[0].source == "seed"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_min_score_threshold(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [
+        _raw("strong", 0.92),
+        _raw("weak", 0.31),
+    ]
+    out = await retriever.retrieve("q", min_score=0.5, rerank=False)
+    assert [c.text for c in out] == ["strong"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_runs_reranker_when_enabled(mocked_primitives):
+    cands = [_raw("a", 0.5), _raw("b", 0.6), _raw("c", 0.7)]
+    mocked_primitives["vectorstore"].query.return_value = cands
+    out = await retriever.retrieve("q", top_k=2, rerank=True)
+    mocked_primitives["reranker"].rerank_async.assert_awaited_once()
+    assert len(out) == 2
+
+
+@pytest.mark.asyncio
+async def test_retrieve_skips_reranker_when_disabled(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [_raw("a", 0.5)]
+    await retriever.retrieve("q", rerank=False)
+    mocked_primitives["reranker"].rerank_async.assert_not_called()
+
+
+# ─── retrieve_sync() ──────────────────────────────────────────────────────────
+
+
+def test_retrieve_sync_happy_path(mocked_primitives):
+    mocked_primitives["vectorstore"].query.return_value = [_raw("only", 0.8)]
+    out = retriever.retrieve_sync("q", rerank=False)
+    assert len(out) == 1
+    assert out[0].text == "only"
+    mocked_primitives["embedder"].embed_sync.assert_called_once()
+
+
+def test_retrieve_sync_embedder_unavailable(mocked_primitives):
+    mocked_primitives["embedder"].embed_sync.return_value = None
+    assert retriever.retrieve_sync("q") == []
+
+
+# ─── ingest_documents() ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_documents_chunks_embeds_and_upserts(mocked_primitives):
+    mocked_primitives["embedder"].embed_async.return_value = [[0.0], [0.1]]
+    mocked_primitives["vectorstore"].upsert_chunks.return_value = 2
+    n = await retriever.ingest_documents(
+        [{"doc_id": "bns_103", "text": "Section 103 ...", "title": "BNS 103"}]
+    )
+    assert n == 2
+    mocked_primitives["chunker"].chunk_text.assert_called_once()
+    args, kwargs = mocked_primitives["vectorstore"].upsert_chunks.call_args
+    assert kwargs["doc_id"] == "bns_103"
+    assert kwargs["base_metadata"]["source"] == "corpus"
+
+
+@pytest.mark.asyncio
+async def test_ingest_documents_skips_existing(mocked_primitives):
+    mocked_primitives["vectorstore"].has_doc.return_value = True
+    n = await retriever.ingest_documents([{"doc_id": "d", "text": "t"}])
+    assert n == 0
+    mocked_primitives["chunker"].chunk_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_documents_skips_empty(mocked_primitives):
+    n = await retriever.ingest_documents(
+        [{"doc_id": "", "text": "t"}, {"doc_id": "d", "text": "   "}]
+    )
+    assert n == 0
+    mocked_primitives["vectorstore"].upsert_chunks.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_documents_respects_per_doc_source_and_metadata(mocked_primitives):
+    mocked_primitives["embedder"].embed_async.return_value = [[0.0], [0.1]]
+    mocked_primitives["vectorstore"].upsert_chunks.return_value = 2
+    await retriever.ingest_documents(
+        [
+            {
+                "doc_id": "x",
+                "text": "body",
+                "source": "indian_kanoon",
+                "metadata": {"court": "SC"},
+            }
+        ]
+    )
+    _, kwargs = mocked_primitives["vectorstore"].upsert_chunks.call_args
+    assert kwargs["base_metadata"]["source"] == "indian_kanoon"
+    assert kwargs["base_metadata"]["court"] == "SC"
+
+
+# ─── introspection ────────────────────────────────────────────────────────────
+
+
+def test_corpus_size_delegates_to_store(mocked_primitives):
+    mocked_primitives["vectorstore"].count.return_value = 1234
+    assert retriever.corpus_size() == 1234
+
+
+def test_is_available_true_when_enabled_and_populated(mocked_primitives):
+    mocked_primitives["vectorstore"].count.return_value = 5
+    assert retriever.is_available() is True
+
+
+def test_is_available_false_when_empty(mocked_primitives):
+    mocked_primitives["vectorstore"].count.return_value = 0
+    assert retriever.is_available() is False
+
+
+def test_is_available_false_when_disabled(monkeypatch, mocked_primitives):
+    monkeypatch.setattr(retriever, "RETRIEVAL_ENABLED", False)
+    mocked_primitives["vectorstore"].count.return_value = 5
+    assert retriever.is_available() is False
+
+
+# ─── package surface ──────────────────────────────────────────────────────────
+
+
+def test_package_lazy_exports_resolve():
+    import services.retrieval as pkg
+
+    assert pkg.retrieve is retriever.retrieve
+    assert pkg.RetrievedChunk is RetrievedChunk
+    assert "ingest_documents" in dir(pkg)
+
+
+def test_package_unknown_attribute_raises():
+    import services.retrieval as pkg
+
+    with pytest.raises(AttributeError):
+        _ = pkg.does_not_exist


### PR DESCRIPTION
# Pull Request
## Title: reusable semantic-retrieval facade for legal retrieval

Closes #673

## Summary

This PR adds a single, dependency-light **retrieval facade** that the rest of the orchestrator (and the Phase 2 reasoning integration in #674) can call to perform semantic search over the persistent legal corpus. It composes the building blocks that already live in `services/retrieval/` - `embedder` (bi-encoder), `vectorstore` (persistent Chroma), and `reranker` (cross-encoder) - behind one stable, typed API.

This is **purely additive infrastructure**. As the issue requests, the reasoning pipeline is intentionally **not** touched here - wiring retrieval into reasoning is Phase 2 (#674). Keeping the two phases separate makes each one small and reviewable.

## Why this is needed

The repo already has the low-level retrieval primitives, but the only place they were ever assembled was inside `services.kanoon_search.build_kanoon_context`, which is tightly coupled to the **live Indian Kanoon HTTP search** flow. There was no way to *"only retrieve the top-k legal passages for a query"* against the local corpus without dragging in a live network search.

This facade provides just that: a corpus-only, Kanoon-independent retrieval utility with a typed result type, which Phase 2 then uses to ground the reasoning pipeline.

## What's in this PR

### `services/retrieval/retriever.py` (new file)
The facade itself.

- **`RetrievedChunk`** dataclass: replaces ad-hoc result dicts with a typed row carrying `text`, `score` (the effective score used for ordering), `similarity` (raw cosine), `rerank_score`, `doc_id`, `title`, `source`, `chunk_index`, and `metadata`. Includes `from_raw()` to build from a `vectorstore.query` row and `as_context_block()` to render a citation-friendly prompt block.
- **`async retrieve(query, *, top_k, fetch_k, rerank, min_score, source)`**: the main entry point. Embeds the query, pulls `fetch_k` candidates from the vector store, optionally source-filters, optionally reranks, applies a `min_score` threshold, and returns an ordered `list[RetrievedChunk]`.
- **`retrieve_sync(...)`**: blocking variant for scripts / non-async callers.
- **`async ingest_documents(documents, *, source, max_tokens, overlap_tokens, skip_existing)`** — chunk + embed + upsert a batch of documents; idempotent by `doc_id`.
- **`corpus_size()`** and **`is_available()`**: introspection helpers.

Design choices deliberately reflect the rest of the retrieval package:
- **Graceful degradation**: if embeddings, the store, or the reranker are unavailable, calls return empty results / zero counts and log once, rather than raising. Retrieval is always best-effort from a caller's perspective.
- **Async-first**: heavy work runs in the embedder/reranker executors so the FastAPI event loop is never blocked.
- **Config-driven defaults**: `top_k` / `fetch_k` / `rerank` / model names default from `config` so behaviour matches the rest of the system, but every call can override them. `fetch_k` is always clamped to `>= top_k`.

### `services/retrieval/__init__.py` (new file)
The retrieval package previously had no `__init__.py` and worked as an implicit namespace package. This adds an explicit one that **lazily** re-exports the facade symbols (`retrieve`, `retrieve_sync`, `ingest_documents`, `corpus_size`, `is_available`, `RetrievedChunk`) via a PEP 562 module-level `__getattr__`.

The "laziness" matters: a low-level import like `from services.retrieval import chunker` must **not** transitively import `config` (which calls `sys.exit(1)` when `GROQ_API_KEY` is unset) or the embedding stack. With `__getattr__`, the facade is only imported when one of its symbols is actually accessed, so existing submodule imports stay config-free. (The existing `test_chunker.py` suite, which imports `chunker` directly, confirms this: all 17 tests still pass.)

### `services/retrieval/chunker.py` (removing dead code)
Removes a **dead, shadowed duplicate** `chunk_text()` definition. Its body simply duplicated `split_legal_sections` (heading-split with no token-aware chunking) and, crucially, it lacked the `respect_sections` parameter. Because it was defined *before* the real, token-aware `chunk_text` later in the same module, it was always overridden and never executed. Removing it has no behavioral effect.

> **Regression guard:** the existing `test_respect_sections_false_restores_legacy_merge` test calls `chunk_text(..., respect_sections=False)`. If the dead duplicate ever been the live symbol, that call would raise `TypeError` (unexpected keyword argument). That test passing both before and after this change already locks in that the correct `chunk_text` is the active one, so no new test is needed for the removal.

### `tests/test_retriever.py` (new file)
27 unit tests covering:
- `RetrievedChunk.from_raw` scoring (bi-encoder vs. rerank), default handling for missing metadata, and `as_context_block` citation headers.
- `retrieve` happy-path ordering/types, and every graceful-degradation branch (empty query, disabled flag, embedder unavailable, no candidates).
- `top_k` limiting, `fetch_k >= top_k` clamping, `source` filtering, `min_score` thresholding, and rerank on/off.
- `retrieve_sync` happy path + embedder-unavailable.
- `ingest_documents` chunk/embed/upsert, `skip_existing`, empty-doc skipping, and per-doc source/metadata override.
- `corpus_size` delegation and `is_available` truth table.
- Lazy package exports (`__getattr__` resolves facade symbols; unknown attributes raise `AttributeError`).

All primitives (`embedder`, `vectorstore`, `reranker`, `chunker`) are mocked, so the suite needs **no models or network**.

## Testing

```bash
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> pytest tests/test_retriever.py -v
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-7.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 27 items

tests/test_retriever.py::test_retrieved_chunk_from_raw_bi_encoder PASSED                                         [  3%]
tests/test_retriever.py::test_retrieved_chunk_effective_score_uses_rerank PASSED                                 [  7%]
tests/test_retriever.py::test_retrieved_chunk_defaults_for_missing_metadata PASSED                               [ 11%]
tests/test_retriever.py::test_as_context_block_includes_citation_header PASSED                                   [ 14%]
tests/test_retriever.py::test_retrieve_happy_path_orders_and_types PASSED                                        [ 18%]
tests/test_retriever.py::test_retrieve_empty_query_returns_empty PASSED                                          [ 22%]
tests/test_retriever.py::test_retrieve_disabled_flag_returns_empty PASSED                                        [ 25%]
tests/test_retriever.py::test_retrieve_embedder_unavailable_returns_empty PASSED                                 [ 29%]
tests/test_retriever.py::test_retrieve_no_candidates_returns_empty PASSED                                        [ 33%]
tests/test_retriever.py::test_retrieve_top_k_limits_results PASSED                                               [ 37%]
tests/test_retriever.py::test_retrieve_fetch_k_never_below_top_k PASSED                                          [ 40%]
tests/test_retriever.py::test_retrieve_source_filter PASSED                                                      [ 44%]
tests/test_retriever.py::test_retrieve_min_score_threshold PASSED                                                [ 48%]
tests/test_retriever.py::test_retrieve_runs_reranker_when_enabled PASSED                                         [ 51%]
tests/test_retriever.py::test_retrieve_skips_reranker_when_disabled PASSED                                       [ 55%]
tests/test_retriever.py::test_retrieve_sync_happy_path PASSED                                                    [ 59%]
tests/test_retriever.py::test_retrieve_sync_embedder_unavailable PASSED                                          [ 62%]
tests/test_retriever.py::test_ingest_documents_chunks_embeds_and_upserts PASSED                                  [ 66%]
tests/test_retriever.py::test_ingest_documents_skips_existing PASSED                                             [ 70%]
tests/test_retriever.py::test_ingest_documents_skips_empty PASSED                                                [ 74%]
tests/test_retriever.py::test_ingest_documents_respects_per_doc_source_and_metadata PASSED                       [ 77%]
tests/test_retriever.py::test_corpus_size_delegates_to_store PASSED                                              [ 81%]
tests/test_retriever.py::test_is_available_true_when_enabled_and_populated PASSED                                [ 85%]
tests/test_retriever.py::test_is_available_false_when_empty PASSED                                               [ 88%]
tests/test_retriever.py::test_is_available_false_when_disabled PASSED                                            [ 92%]
tests/test_retriever.py::test_package_lazy_exports_resolve PASSED                                                [ 96%]
tests/test_retriever.py::test_package_unknown_attribute_raises PASSED                                            [100%]Running teardown with pytest sessionfinish...


================================================= 27 passed in 1.33s ==================================================
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> pytest tests/test_chunker.py -v
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-7.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 17 items

tests/test_chunker.py::test_empty_returns_empty PASSED                                                           [  5%]
tests/test_chunker.py::test_short_text_one_chunk PASSED                                                          [ 11%]
tests/test_chunker.py::test_chunks_are_unique PASSED                                                             [ 17%]
tests/test_chunker.py::test_chunks_respect_size_with_some_slack PASSED                                           [ 23%]
tests/test_chunker.py::test_long_paragraph_without_sentence_boundary_chunks_correctly PASSED                     [ 29%]
tests/test_chunker.py::test_realistic_chunk_sizes PASSED                                                         [ 35%]
tests/test_chunker.py::test_overlap_provides_continuity PASSED                                                   [ 41%]
tests/test_chunker.py::test_count_tokens_handles_empty PASSED                                                    [ 47%]
tests/test_chunker.py::test_split_legal_sections_basic PASSED                                                    [ 52%]
tests/test_chunker.py::test_split_legal_sections_no_headings_is_noop PASSED                                      [ 58%]
tests/test_chunker.py::test_split_legal_sections_preserves_preamble PASSED                                       [ 64%]
tests/test_chunker.py::test_split_legal_sections_recognises_article_and_symbol PASSED                            [ 70%]
tests/test_chunker.py::test_chunk_text_keeps_sections_separate_without_blank_lines PASSED                        [ 76%]
tests/test_chunker.py::test_chunk_text_every_chunk_anchored_to_a_heading PASSED                                  [ 82%]
tests/test_chunker.py::test_respect_sections_false_restores_legacy_merge PASSED                                  [ 88%]
tests/test_chunker.py::test_overlap_does_not_cross_section_boundary PASSED                                       [ 94%]
tests/test_chunker.py::test_long_section_still_splits_within_section PASSED                                      [100%]Running teardown with pytest sessionfinish...


================================================= 17 passed in 0.63s ==================================================
```

**Verified locally:** the full `test_retriever.py` suite (27) and `test_chunker.py` (17) pass. The patch was also confirmed to apply cleanly onto a fresh `main`.

**Note on environment:** these unit tests mock the heavy primitives by design. Any test that exercises the *real* embedder / Chroma / cross-encoder (i.e. that downloads InLegalBERT or the reranker model) needs those models available and so is expected to run in CI instead of in a sandboxed/offline environment.

## Scope

- [ ] No changes to `research.py`, `synthesizer.py`, `main.py`, or any reasoning logic: that integration is Phase 2 (#674).
- [ ] No changes to the live Kanoon search path.
- [x] Backward compatible: nothing that exists today calls the new module, so behavior is unchanged until Phase 2 wires it in.
