### PR TITLE
feat: Complete Google OAuth (Sign in with Google) - Closes #1102

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,20 @@ GOOGLE_GEMINI_API_KEY=
 JWT_SECRET=
 
 # ─────────────────────────────────────────────
+# Google OAuth 2.0 (Required for "Sign in with Google")
+# ─────────────────────────────────────────────
+
+# OAuth 2.0 Client ID from Google Cloud Console
+# Steps: https://console.cloud.google.com/apis/credentials
+#  1. Create a project (or select an existing one)
+#  2. Enable the "Google+ API" / "Google Identity" scopes
+#  3. Create OAuth 2.0 credentials (type: Web application)
+#  4. Add authorised redirect URI: http://localhost:8080/login/oauth2/code/google
+# Leave empty; set real values in your local .env file
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# ─────────────────────────────────────────────
 # Networking
 # ─────────────────────────────────────────────
 

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/OAuth2LoginSuccessHandler.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/config/OAuth2LoginSuccessHandler.java
@@ -1,27 +1,32 @@
 package com.nyaysetu.backend.config;
 
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.service.AuthService;
 import com.nyaysetu.backend.service.JwtService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
-
-
-import com.nyaysetu.backend.service.AuthService;
-import com.nyaysetu.backend.entity.User;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(OAuth2LoginSuccessHandler.class);
 
     private final JwtService jwtService;
     private final AuthService authService;
@@ -36,34 +41,43 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             Authentication authentication
     ) throws IOException, ServletException {
 
-        DefaultOAuth2User oauthUser =
-                (DefaultOAuth2User) authentication.getPrincipal();
+        DefaultOAuth2User oauthUser = (DefaultOAuth2User) authentication.getPrincipal();
 
         String email = oauthUser.getAttribute("email");
-        String name = oauthUser.getAttribute("name");
+        String name  = oauthUser.getAttribute("name");
 
-
-
-        String jwtToken = jwtService.generateToken(
-                new HashMap<>(),
-                new org.springframework.security.core.userdetails.User(
-                        email,
-                        "",
-                        java.util.Collections.emptyList()
-                )
-        );
-
-
-
+        // Look up the persisted user (created/updated by CustomOAuth2UserService).
         User dbUser = authService.findByEmail(email);
 
-        String role = dbUser.getRole().name();
+        if (dbUser == null) {
+            // Should not happen — CustomOAuth2UserService always upserts the user.
+            // Defensive guard to avoid a NullPointerException and redirect gracefully.
+            logger.error("OAuthSuccess: no DB user found for email={}", email);
+            response.sendRedirect(frontendUrl + "/login?error=user_not_found");
+            return;
+        }
+
+        String role = dbUser.getRole().name(); // e.g. "LITIGANT"
+
+        // Build extra claims map including the role so the JWT carries authority info.
+        Map<String, Object> extraClaims = new HashMap<>();
+        extraClaims.put("role", role);
+
+        // Build a UserDetails with the correct GrantedAuthority so any downstream
+        // role-extraction from the JWT works correctly.
+        UserDetails userDetails = new org.springframework.security.core.userdetails.User(
+                email,
+                "",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
+        );
+
+        String jwtToken = jwtService.generateToken(extraClaims, userDetails);
 
         response.sendRedirect(
                 frontendUrl + "/oauth-success"
                         + "?token=" + jwtToken
                         + "&email=" + email
-                        + "&name=" + java.net.URLEncoder.encode(name, "UTF-8")
+                        + "&name=" + java.net.URLEncoder.encode(name != null ? name : "", "UTF-8")
                         + "&role=" + role
         );
     }

--- a/backend/nyaysetu-backend/src/main/resources/application.properties.example
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties.example
@@ -140,4 +140,26 @@ bhashini.url=https://dhruva-api.bhashini.gov.in/services/inference/pipeline
 # ============================================
 # Python FastAPI service for legal document retrieval (FAISS + bge-m3)
 lawgpt.service.url=${LAWGPT_SERVICE_URL:http://localhost:8001}
+lawgpt.service.url=${LAWGPT_SERVICE_URL:http://localhost:8001}
 lawgpt.service.url=http://localhost:8001
+
+# ============================================
+# GOOGLE OAUTH 2.0 CONFIGURATION
+# ============================================
+# Required for the "Sign in with Google" feature on the Login page.
+#
+# Setup steps:
+#   1. Go to https://console.cloud.google.com/apis/credentials
+#   2. Create (or select) a project.
+#   3. Enable the Google Identity / People API.
+#   4. Create OAuth 2.0 credentials (Application type: Web application).
+#   5. Under "Authorised redirect URIs" add:
+#        http://localhost:8080/login/oauth2/code/google   (local dev)
+#        https://<your-domain>/login/oauth2/code/google  (production)
+#   6. Copy the Client ID and Client Secret into your environment:
+#        export GOOGLE_CLIENT_ID=<your-client-id>
+#        export GOOGLE_CLIENT_SECRET=<your-client-secret>
+#
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=email,profile

--- a/frontend/nyaysetu-frontend/public/locales/en/auth.json
+++ b/frontend/nyaysetu-frontend/public/locales/en/auth.json
@@ -20,6 +20,7 @@
         "signIn": "Sign In",
         "signingIn": "Signing in...",
         "loginWithFace": "Login with Face",
+        "continueWithGoogle": "Continue with Google",
         "noAccount": "Don't have an account?",
         "createAccount": "Create Account",
         "features": {

--- a/frontend/nyaysetu-frontend/public/locales/hi/auth.json
+++ b/frontend/nyaysetu-frontend/public/locales/hi/auth.json
@@ -20,6 +20,7 @@
         "signIn": "साइन इन करें",
         "signingIn": "साइन इन हो रहा है...",
         "loginWithFace": "चेहरे से लॉगिन करें",
+        "continueWithGoogle": "Google से जारी रखें",
         "noAccount": "खाता नहीं है?",
         "createAccount": "खाता बनाएं",
         "features": {

--- a/frontend/nyaysetu-frontend/public/locales/mr/auth.json
+++ b/frontend/nyaysetu-frontend/public/locales/mr/auth.json
@@ -20,6 +20,7 @@
     "signIn": "साइन इन करा",
     "signingIn": "साइन इन होत आहे...",
     "loginWithFace": "चेहऱ्याने लॉगिन करा",
+    "continueWithGoogle": "Google सह सुरू ठेवा",
     "noAccount": "खाते नाही?",
     "createAccount": "खाते तयार करा",
     "features": {

--- a/frontend/nyaysetu-frontend/public/locales/ta/auth.json
+++ b/frontend/nyaysetu-frontend/public/locales/ta/auth.json
@@ -30,6 +30,8 @@
 
     "loginWithFace": "முகஅடையாளம் மூலம் உள்நுழையவும்",
 
+    "continueWithGoogle": "Google மூலம் தொடரவும்",
+
     "noAccount": "கணக்கு இல்லையா?",
 
     "createAccount": "கணக்கை உருவாக்கவும்",

--- a/frontend/nyaysetu-frontend/public/locales/te/auth.json
+++ b/frontend/nyaysetu-frontend/public/locales/te/auth.json
@@ -35,6 +35,8 @@
 
     "loginWithFace": "ముఖ గుర్తింపుతో లాగిన్ అవ్వండి",
 
+    "continueWithGoogle": "Google తో కొనసాగండి",
+
     "noAccount": "ఖాతా లేదా?",
 
     "createAccount": "ఖాతా సృష్టించండి",

--- a/frontend/nyaysetu-frontend/src/pages/Login.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/Login.jsx
@@ -501,6 +501,7 @@ export default function Login() {
                             
                             {/* Google Login */}
                             <button
+                                id="google-oauth-btn"
                                 type="button"
                                 onClick={() => {
                                     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/google`;
@@ -545,7 +546,7 @@ export default function Login() {
                                     }}
                                 />
 
-                                Continue with Google
+                                {t('auth:login.continueWithGoogle')}
                             </button>
 
                             {/* Face Login */}

--- a/frontend/nyaysetu-frontend/src/pages/OAuthSuccess.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/OAuthSuccess.jsx
@@ -1,83 +1,161 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import useAuthStore from '../store/authStore';
+import { resolvePostAuthPath } from '../utils/authRedirect';
 
+/**
+ * OAuthSuccess
+ *
+ * Landing page for the Google OAuth redirect. The backend (OAuth2LoginSuccessHandler)
+ * redirects here with ?token=...&email=...&name=...&role=... query params after a
+ * successful Google sign-in.
+ *
+ * Responsibilities:
+ *  1. Parse token + user info from query params.
+ *  2. Persist them to the auth store.
+ *  3. Navigate to the correct role-based dashboard via resolvePostAuthPath.
+ *  4. Show a user-friendly error if anything goes wrong.
+ */
 export default function OAuthSuccess() {
-
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
     const { setAuth } = useAuthStore();
-   
-    useEffect(() => {
+    const [errorMsg, setErrorMsg] = useState(null);
 
+    useEffect(() => {
         const token = searchParams.get('token');
-    
-        if (token) {
-    
-            try {
-    
-                const email = searchParams.get('email');
-                const role = searchParams.get('role');
-                const name = searchParams.get('name');
-    
-                const cleanRole = role?.replace("ROLE_", "");
-    
-                const user = {
-                    email,
-                    role: cleanRole,
-                    name
-                };
-    
-                
-    
-                setAuth(user, token);
-    
-                switch (cleanRole) {
-    
-                    case 'JUDGE':
-                        navigate('/judge');
-                        break;
-    
-                    case 'LAWYER':
-                        navigate('/lawyer');
-                        break;
-    
-                    case 'ADMIN':
-                        navigate('/admin');
-                        break;
-    
-                    case 'POLICE':
-                        navigate('/police');
-                        break;
-    
-                    case 'LITIGANT':
-                    default:
-                        navigate('/litigant');
-                        break;
-                }
-    
-            } catch (error) {
-    
-               
-    
-                navigate('/login');
-            }
+
+        if (!token) {
+            // No token — the backend may have redirected with an error param instead.
+            const backendError = searchParams.get('error');
+            setErrorMsg(backendError || 'Google sign-in failed. Please try again.');
+            const timer = setTimeout(() => {
+                navigate(`/login${backendError ? `?error=${encodeURIComponent(backendError)}` : ''}`);
+            }, 3000);
+            return () => clearTimeout(timer);
         }
-    
+
+        try {
+            const email = searchParams.get('email');
+            const role = searchParams.get('role');
+            const name = searchParams.get('name');
+
+            // Strip the "ROLE_" prefix added by Spring Security if present
+            const cleanRole = role?.replace('ROLE_', '') ?? 'LITIGANT';
+
+            const user = { email, role: cleanRole, name };
+
+            setAuth(user, token);
+
+            // Use the shared utility to determine the correct dashboard path,
+            // keeping navigation logic in one place (same as Login.jsx).
+            navigate(resolvePostAuthPath(cleanRole, null), { replace: true });
+        } catch (error) {
+            console.error('OAuthSuccess: failed to process token', error);
+            setErrorMsg('Something went wrong during sign-in. Redirecting back to login...');
+            const timer = setTimeout(() => navigate('/login'), 3000);
+            return () => clearTimeout(timer);
+        }
     }, [searchParams, navigate, setAuth]);
 
+    // ── Loading / Error UI ──────────────────────────────────────────────────
     return (
         <div
             style={{
-                height: '100vh',
+                minHeight: '100vh',
                 display: 'flex',
-                justifyContent: 'center',
+                flexDirection: 'column',
                 alignItems: 'center',
-                fontSize: '24px',
-                fontWeight: 'bold'
+                justifyContent: 'center',
+                background: 'var(--bg-main, #f8fafc)',
+                gap: '1.5rem',
+                padding: '2rem',
             }}
         >
-            Logging you in with Google...
+            {errorMsg ? (
+                /* Error state */
+                <div
+                    style={{
+                        background: 'rgba(239, 68, 68, 0.08)',
+                        border: '1px solid rgba(239, 68, 68, 0.3)',
+                        borderRadius: '1rem',
+                        padding: '2rem 2.5rem',
+                        textAlign: 'center',
+                        maxWidth: '420px',
+                    }}
+                >
+                    <div style={{ fontSize: '2.5rem', marginBottom: '0.75rem' }}>⚠️</div>
+                    <p
+                        style={{
+                            color: '#ef4444',
+                            fontSize: '1rem',
+                            fontWeight: '600',
+                            margin: 0,
+                        }}
+                    >
+                        {errorMsg}
+                    </p>
+                    <p
+                        style={{
+                            color: 'var(--text-secondary, #64748b)',
+                            fontSize: '0.875rem',
+                            marginTop: '0.5rem',
+                        }}
+                    >
+                        Redirecting you back to login…
+                    </p>
+                </div>
+            ) : (
+                /* Loading state */
+                <>
+                    {/* Spinner */}
+                    <div
+                        style={{
+                            width: '56px',
+                            height: '56px',
+                            border: '4px solid rgba(30, 42, 68, 0.15)',
+                            borderTop: '4px solid var(--color-primary, #1E2A44)',
+                            borderRadius: '50%',
+                            animation: 'oauth-spin 0.8s linear infinite',
+                        }}
+                    />
+
+                    {/* Google logo + text */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                        <img
+                            src="https://www.svgrepo.com/show/475656/google-color.svg"
+                            alt="Google"
+                            style={{ width: '24px', height: '24px' }}
+                        />
+                        <span
+                            style={{
+                                fontSize: '1.1rem',
+                                fontWeight: '700',
+                                color: 'var(--text-main, #1e293b)',
+                            }}
+                        >
+                            Signing you in with Google…
+                        </span>
+                    </div>
+
+                    <p
+                        style={{
+                            fontSize: '0.875rem',
+                            color: 'var(--text-secondary, #64748b)',
+                            margin: 0,
+                        }}
+                    >
+                        Please wait while we set up your session.
+                    </p>
+                </>
+            )}
+
+            <style>{`
+                @keyframes oauth-spin {
+                    from { transform: rotate(0deg); }
+                    to   { transform: rotate(360deg); }
+                }
+            `}</style>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Completes and fixes the partial Google OAuth implementation for issue #1102.

The login page already had a `Continue with Google` button, but several bugs prevented the flow from working end-to-end. This PR fixes all of them.

## Changes

### 🐛 Bug Fixes

| File | Fix |
|------|-----|
| `Login.jsx` | Replace bare string `"Continue with Google"` with `t("auth:login.continueWithGoogle")` (i18n) + add `id="google-oauth-btn"` |
| `OAuthSuccess.jsx` | Use `resolvePostAuthPath()` utility instead of hardcoded `switch` (consistent with `Login.jsx`) |
| `OAuthSuccess.jsx` | Add branded loading spinner + error feedback UI (users no longer see a blank page on failure) |
| `OAuth2LoginSuccessHandler.java` | JWT now includes `role` as an extra claim + proper `SimpleGrantedAuthority` |
| `OAuth2LoginSuccessHandler.java` | Null-guard on `findByEmail()` — redirects to `/login?error=user_not_found` instead of throwing NPE |

### 🌐 i18n

Added `continueWithGoogle` translation key to all 5 supported locales:
- English: `"Continue with Google"`
- Hindi: `"Google से जारी रखें"`
- Tamil: `"Google மூலம் தொடரவும்"`
- Marathi: `"Google सह सुरू ठेवा"`
- Telugu: `"Google తో కొనసాగండి"`

### 📄 Docs

- Root `.env.example` — added `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` placeholders with setup steps
- `application.properties.example` — added Google OAuth 2.0 configuration section

## OAuth Flow

```
User clicks "Continue with Google"
  → /oauth2/authorization/google (Spring Security)
  → Google consent screen
  → /login/oauth2/code/google (Spring Security callback)
  → CustomOAuth2UserService upserts user in DB
  → OAuth2LoginSuccessHandler generates JWT with role claim
  → Redirects to /oauth-success?token=...&email=...&name=...&role=...
  → OAuthSuccess.jsx parses params → setAuth() → navigate to dashboard
```

## Testing Checklist

- [ ] Click "Continue with Google" on `/login` → Google consent screen opens
- [ ] Complete sign-in → lands on the correct role-based dashboard
- [ ] Bad credentials → `/login?error=...` with error banner shown
- [ ] JWT decoded at jwt.io contains `role` claim
- [ ] Frontend tests pass: `npm run test`

Closes #1102