### PR TITLE
feat(auth): enforce password policy in reset-password endpoint

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -206,6 +206,13 @@ public class AuthController {
     @PostMapping("/reset-password")
     public ResponseEntity<?> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
         try {
+            // Enforce password policy
+            Pattern pwPattern = Pattern.compile("^(?=.*[A-Z])(?=.*[0-9])(?=.*[@#$!%*?&]).{8,}$");
+            if (!pwPattern.matcher(req.getNewPassword()).matches()) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("message", "Password must be at least 8 characters and include an uppercase letter, a number, and a special character (@#$!%*?&)."));
+            }
+
             String hashedToken = PasswordResetToken.hashToken(req.getToken());
             PasswordResetToken resetToken = tokenRepository.findByToken(hashedToken)
                     .orElseThrow(() -> new RuntimeException("Invalid token"));


### PR DESCRIPTION
# Pull Request

## Description
This PR enforces the same password policy in the `/auth/reset-password` endpoint as in `/auth/register`.  
Previously, users could set weak passwords during reset, bypassing the policy.

Closes #1491 

**Changes Made**
- Added regex-based validation in `resetPassword()`.
- Returns `400 Bad Request` with descriptive error message if password does not meet requirements.
- Ensures consistency and improves security across registration and reset flows.

**Password Policy**
- Minimum 8 characters
- At least one uppercase letter
- At least one number
- At least one special character (@#$!%*?&)

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes