### PR TITLE
fix: add Authentication and judge ownership check to addParticipant e…

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HearingController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HearingController.java
@@ -94,17 +94,29 @@ public class HearingController {
         return ResponseEntity.ok(response);
     }
     
-    @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
-    @PostMapping("/{hearingId}/participants")
-    public ResponseEntity<Map<String, Object>> addParticipant(
-            @PathVariable UUID hearingId,
-            @RequestBody AddParticipantRequest request
-    ) {
-        HearingParticipant participant = hearingService.addParticipant(
-                hearingId,
-                request.getUserId(),
-                request.getRole()
-        );
+        @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
+        @PostMapping("/{hearingId}/participants")
+        public ResponseEntity<Map<String, Object>> addParticipant(
+                @PathVariable UUID hearingId,
+                @RequestBody AddParticipantRequest request,
+                Authentication authentication
+        ) {
+            User requestingUser = authService.findByEmail(authentication.getName());
+            Hearing hearing = hearingService.getHearing(hearingId);
+            if (hearing.getCaseEntity() != null &&
+                !requestingUser.getRole().name().equals("ADMIN") &&
+                !requestingUser.getRole().name().equals("SUPER_JUDGE")) {
+                Long assignedJudgeId = hearing.getCaseEntity().getJudgeId();
+                if (!requestingUser.getId().equals(assignedJudgeId)) {
+                    return ResponseEntity.status(403)
+                        .body(Map.of("error", "You are not the assigned judge for this hearing's case"));
+                }
+            }
+            HearingParticipant participant = hearingService.addParticipant(
+                    hearingId,
+                    request.getUserId(),
+                    request.getRole()
+            );
         
         Map<String, Object> response = new HashMap<>();
         response.put("id", participant.getId());


### PR DESCRIPTION
## Description

`addParticipant` endpoint accepted no `Authentication` parameter — any JUDGE/ADMIN
role token could add any user to any hearing with any role, regardless of whether
they were assigned to that hearing's case.

**Changes made:**
- `HearingController.java` → added `Authentication` parameter to `addParticipant`
- Added judge ownership check: only the case-assigned judge (or ADMIN/SUPER_JUDGE)
  can add participants to a hearing
- Unauthorized access now returns `403 Forbidden`

Closes #1496 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes