### PR TITLE
feat: added retrieval-augmented legal reasoning

### DIFF
--- a/nlp-orchestrator/grounding.py
+++ b/nlp-orchestrator/grounding.py
@@ -1,0 +1,173 @@
+"""
+Corpus grounding for the legal-reasoning pipeline (Phase 2 — issue #674).
+
+This module turns a user query into ready-to-inject **grounded context** by
+calling the reusable retrieval facade from Phase 1 (#673) and assembling the
+retrieved passages into a single, citation-preserving, token-budgeted string.
+
+How this differs from `services.kanoon_search.build_kanoon_context`
+-------------------------------------------------------------------
+`build_kanoon_context` always performs a *live Indian Kanoon HTTP search*
+first, then vector-searches over the (live + seed) corpus. It is therefore
+gated by an API token and a circuit breaker, and it labels everything it
+returns as "Indian Kanoon" context even when the served chunks actually came
+from the local seed corpus.
+
+`build_grounded_context` is **Kanoon-independent**: it grounds purely against
+the persistent local corpus via `retriever.retrieve()`. No network, no token,
+no circuit breaker. That makes grounding available even when the live Kanoon
+search is unavailable or disabled, and it is the path the reasoning pipeline
+uses by default.
+
+The two are complementary. `merge_contexts` lets the pipeline combine local
+corpus grounding with any live-Kanoon context into one de-duplicated block.
+
+Public API
+----------
+    await build_grounded_context(query, *, top_k=..., min_score=...,
+                                 max_context_tokens=...)
+        -> (context_str, sources)
+    merge_contexts(*contexts) -> str
+"""
+
+import logging
+import re
+
+from services.retrieval import chunker, retriever
+
+logger = logging.getLogger("grounding")
+
+# Default token budget for the assembled context block. Kept comfortably below
+# typical model context windows so the grounded passages never crowd out the
+# system prompt, the question, and the model's own answer.
+DEFAULT_MAX_CONTEXT_TOKENS = 3000
+
+
+# ─── Building grounded context ────────────────────────────────────────────────
+
+
+async def build_grounded_context(
+    query: str,
+    *,
+    top_k: int | None = None,
+    min_score: float = 0.0,
+    max_context_tokens: int = DEFAULT_MAX_CONTEXT_TOKENS,
+) -> tuple[str, list[dict]]:
+    """
+    Retrieve and assemble grounded legal context for `query`.
+
+    Uses the Phase 1 retrieval facade to fetch the most relevant corpus
+    passages, then concatenates them into a single citation-friendly string
+    (one ``=== Title [doc_id=...] ===`` block per passage), stopping before the
+    assembled text exceeds ``max_context_tokens``. The first passage is always
+    included even if it alone exceeds the budget, so a relevant-but-long top hit
+    is never silently dropped.
+
+    Args:
+        query:              the user's legal question.
+        top_k:              max passages to retrieve (default: facade/config).
+        min_score:          drop passages below this effective score.
+        max_context_tokens: soft cap on the assembled context size.
+
+    Returns:
+        ``(context_str, sources)`` where ``sources`` is a list of provenance
+        dicts (``doc_id``, ``title``, ``source``, ``score``, ``chunk_index``)
+        for exactly the passages included in ``context_str``. Returns
+        ``("", [])`` when retrieval yields nothing or is unavailable — callers
+        can treat grounding as best-effort.
+    """
+    chunks = await retriever.retrieve(query, top_k=top_k, min_score=min_score)
+    if not chunks:
+        return "", []
+
+    blocks: list[str] = []
+    sources: list[dict] = []
+    used_tokens = 0
+
+    for ch in chunks:
+        block = ch.as_context_block()
+        block_tokens = chunker.count_tokens(block)
+        # Respect the budget, but guarantee at least the top passage.
+        if blocks and used_tokens + block_tokens > max_context_tokens:
+            break
+        blocks.append(block)
+        used_tokens += block_tokens
+        sources.append(
+            {
+                "doc_id": ch.doc_id,
+                "title": ch.title,
+                "source": ch.source,
+                "score": round(ch.score, 4),
+                "chunk_index": ch.chunk_index,
+            }
+        )
+
+    context = "\n\n".join(blocks)
+    logger.info(
+        "build_grounded_context: query=%r | served=%d/%d chunks | tokens~%d",
+        query[:40],
+        len(blocks),
+        len(chunks),
+        used_tokens,
+    )
+    return context, sources
+
+
+# ─── Merging contexts ─────────────────────────────────────────────────────────
+
+
+# A context block starts at a line of the form "=== ... ===".
+_BLOCK_BOUNDARY = re.compile(r"(?m)(?=^=== )")
+
+
+def _split_blocks(context: str) -> list[str]:
+    """Split a formatted context string into individual ``=== ... ===`` blocks.
+
+    Works for both the grounding format produced here and the kanoon_search
+    format, since both delimit passages with a leading ``=== `` header line. A
+    context with no such header is returned as a single block.
+    """
+    if not context or not context.strip():
+        return []
+    return [b.strip() for b in _BLOCK_BOUNDARY.split(context) if b.strip()]
+
+
+def _block_body_key(block: str) -> str:
+    """Normalized de-dup key for a block, based on its body (header ignored).
+
+    Two passages with identical text but different headers (e.g. an "excerpt 2"
+    suffix) collapse to the same key, which is what lets us drop the seed-corpus
+    chunks that appear in both a local-grounding context and a live-Kanoon
+    context.
+    """
+    lines = block.splitlines()
+    body = "\n".join(lines[1:]) if lines and lines[0].startswith("=== ") else block
+    return " ".join(body.split()).lower()
+
+
+def merge_contexts(*contexts: str) -> str:
+    """
+    Merge several formatted context strings into one, de-duplicating passages.
+
+    Empty / whitespace-only inputs are ignored. A single non-empty input is
+    returned unchanged (aside from trimming). When two or more inputs are
+    present, their blocks are concatenated in order with duplicates removed
+    (first occurrence wins, compared by normalized body text), so overlapping
+    seed chunks are not repeated.
+    """
+    present = [c for c in contexts if c and c.strip()]
+    if not present:
+        return ""
+    if len(present) == 1:
+        return present[0].strip()
+
+    merged: list[str] = []
+    seen: set[str] = set()
+    for ctx in present:
+        for block in _split_blocks(ctx):
+            key = _block_body_key(block)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            merged.append(block)
+    return "\n\n".join(merged)

--- a/nlp-orchestrator/main.py
+++ b/nlp-orchestrator/main.py
@@ -46,6 +46,7 @@ from synthesizer import (
 from validators.citation_validator import validate_citations_from_text
 from avatar_speech import get_interim_messages, convert_to_hinglish, detect_domain
 from services.kanoon_search import build_kanoon_context
+from grounding import build_grounded_context, merge_contexts
 from sanitizer import sanitize_user_input, sanitize_prompt_input
 from pii_ner import router as pii_ner_router
 
@@ -225,6 +226,7 @@ async def legal_reasoning_pipeline(query: str, language: str):
         )
 
         kanoon_task = asyncio.create_task(build_kanoon_context(query, max_results=3))
+        grounding_task = asyncio.create_task(build_grounded_context(query))
 
         sub_questions = await decompose_query(safe_query)
         logger.info(f"[Layer 1] Got {len(sub_questions)} sub-questions")
@@ -241,6 +243,12 @@ async def legal_reasoning_pipeline(query: str, language: str):
         except Exception as e:
             logger.error("[Layer 2] Indian Kanoon fetch failed: %s", e)
             kanoon_context = ""
+        try:
+            local_context, _ = await grounding_task
+        except Exception as e:
+            logger.error("[Layer 2] Corpus grounding failed: %s", e)
+            local_context = ""
+        kanoon_context = merge_contexts(local_context, kanoon_context)
 
         # ── Layer 5a: Interim Avatar Messages (to stream while research runs) ──
         interim_messages = get_interim_messages(query, count=3)
@@ -409,7 +417,13 @@ async def analyze_sync(body: LegalQuery):
     except Exception as e:
         logger.error("[Sync] Indian Kanoon fetch failed: %s", e)
         kanoon_context = ""
-    results = await run_parallel_research(routed, kanoon_context=kanoon_context)
+    try:
+        local_context, _ = await build_grounded_context(body.query)
+    except Exception as e:
+        logger.error("[Sync] Corpus grounding failed: %s", e)
+        local_context = ""
+    grounded_context = merge_contexts(local_context, kanoon_context)
+    results = await run_parallel_research(routed, kanoon_context=grounded_context)
     synthesis = await synthesize_answers_structured(body.query, results)
     synthesized = synthesis.answer_markdown
 

--- a/nlp-orchestrator/research.py
+++ b/nlp-orchestrator/research.py
@@ -80,7 +80,7 @@ Keep your answer focused, factual, and written for a common Indian citizen.
 # This is the single biggest hallucination guardrail we have at the prompt
 # level — when the retrieval finds the right passage, the model quotes it;
 # when retrieval misses, the model is supposed to say so out loud.
-KANOON_CONTEXT_PROMPT = """Use the INDIAN KANOON CONTEXT below as your primary source.
+KANOON_CONTEXT_PROMPT = """Use the RETRIEVED LEGAL CONTEXT below as your primary source.
 
 - If the answer is fully covered there, quote the exact section number, article, or judgment.
 - If the context is partial or missing, you may fall back to your training knowledge, but you
@@ -96,7 +96,7 @@ def _build_user_prompt(question: str, kanoon_context: str | None) -> str:
 
     return (
         f"{question}\n\n"
-        "INDIAN KANOON CONTEXT:\n"
+        "RETRIEVED LEGAL CONTEXT:\n"
         f"{kanoon_context}\n\n"
         "If the answer is not present in the context, say you cannot verify it."
     )

--- a/nlp-orchestrator/services/kanoon_search.py
+++ b/nlp-orchestrator/services/kanoon_search.py
@@ -125,28 +125,6 @@ async def search_kanoon(query: str, max_results: int = 3) -> list[dict]:
         logger.error(f"Indian Kanoon search error: {type(e).__name__}: {e}")
         return []
 
-    url = f"{INDIAN_KANOON_API_URL}/search/"
-    params = {"formInput": query, "pagenum": 0}
-    headers = {
-        "Authorization": f"Token {INDIAN_KANOON_TOKEN}",
-        "Accept": "application/json",
-    }
-
-    try:
-        result = await _search_kanoon_with_retry(
-            query,
-            url,
-            params,
-            headers,
-            max_results,
-        )
-        kanoon_breaker.call_succeeded()
-        return result
-    except Exception as e:
-        kanoon_breaker.call_failed()
-        logger.error(f"Indian Kanoon search error: {type(e).__name__}: {e}")
-        return []
-
 
 @retry_transient
 async def _fetch_doc(

--- a/nlp-orchestrator/tests/test_grounding.py
+++ b/nlp-orchestrator/tests/test_grounding.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for the Phase 2 grounding module (issue #674).
+
+The retrieval facade is mocked, so these tests need no models, no vector store,
+and no network. `chunker.count_tokens` is patched where a deterministic token
+budget is required, so the suite does not depend on whether tiktoken is
+installed.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the orchestrator root is importable and config does not sys.exit when
+# GROQ_API_KEY is absent in the test environment (CI sets a real key).
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+os.environ.setdefault("GROQ_API_KEY", "test-key")
+
+import grounding  # noqa: E402
+from services.retrieval.retriever import RetrievedChunk  # noqa: E402
+
+
+def _chunk(text, *, score=0.9, doc_id="d1", title="Some Act", source="seed", idx=0):
+    return RetrievedChunk(
+        text=text,
+        score=score,
+        similarity=score,
+        rerank_score=None,
+        doc_id=doc_id,
+        title=title,
+        source=source,
+        chunk_index=idx,
+        metadata={"doc_id": doc_id, "title": title, "source": source},
+    )
+
+
+# ─── build_grounded_context ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_grounded_context_happy_path(mocker):
+    chunks = [
+        _chunk("Section 300 defines murder.", doc_id="bns", title="BNS", idx=0),
+        _chunk("Section 103 prescribes punishment.", doc_id="bns", title="BNS", idx=1),
+    ]
+    retrieve = mocker.patch.object(
+        grounding.retriever, "retrieve", new=mocker.AsyncMock(return_value=chunks)
+    )
+    mocker.patch.object(grounding.chunker, "count_tokens", return_value=10)
+
+    context, sources = await grounding.build_grounded_context("what is murder")
+
+    retrieve.assert_awaited_once()
+    # Both passages present, each rendered as a citation block.
+    assert "Section 300 defines murder." in context
+    assert "Section 103 prescribes punishment." in context
+    assert context.count("=== ") == 2
+    assert "[doc_id=bns]" in context
+    # Sources mirror exactly the included passages, in order.
+    assert [s["chunk_index"] for s in sources] == [0, 1]
+    assert sources[0]["doc_id"] == "bns"
+    assert sources[0]["title"] == "BNS"
+    assert sources[0]["source"] == "seed"
+    assert sources[0]["score"] == pytest.approx(0.9)
+
+
+@pytest.mark.asyncio
+async def test_build_grounded_context_empty_when_no_hits(mocker):
+    mocker.patch.object(
+        grounding.retriever, "retrieve", new=mocker.AsyncMock(return_value=[])
+    )
+    context, sources = await grounding.build_grounded_context("nothing matches")
+    assert context == ""
+    assert sources == []
+
+
+@pytest.mark.asyncio
+async def test_build_grounded_context_forwards_top_k_and_min_score(mocker):
+    retrieve = mocker.patch.object(
+        grounding.retriever, "retrieve", new=mocker.AsyncMock(return_value=[])
+    )
+    await grounding.build_grounded_context("q", top_k=7, min_score=0.5)
+    retrieve.assert_awaited_once_with("q", top_k=7, min_score=0.5)
+
+
+@pytest.mark.asyncio
+async def test_build_grounded_context_respects_token_budget(mocker):
+    chunks = [
+        _chunk("first passage", idx=0),
+        _chunk("second passage", idx=1),
+        _chunk("third passage", idx=2),
+    ]
+    mocker.patch.object(
+        grounding.retriever, "retrieve", new=mocker.AsyncMock(return_value=chunks)
+    )
+    # Each block "costs" 1000 tokens; budget admits only the first two.
+    mocker.patch.object(grounding.chunker, "count_tokens", return_value=1000)
+
+    context, sources = await grounding.build_grounded_context(
+        "q", max_context_tokens=2500
+    )
+
+    assert "first passage" in context
+    assert "second passage" in context
+    assert "third passage" not in context
+    assert len(sources) == 2
+
+
+@pytest.mark.asyncio
+async def test_build_grounded_context_always_keeps_first_passage(mocker):
+    chunks = [_chunk("a very long but highly relevant passage", idx=0)]
+    mocker.patch.object(
+        grounding.retriever, "retrieve", new=mocker.AsyncMock(return_value=chunks)
+    )
+    # First block alone exceeds the budget, but must still be included.
+    mocker.patch.object(grounding.chunker, "count_tokens", return_value=5000)
+
+    context, sources = await grounding.build_grounded_context(
+        "q", max_context_tokens=100
+    )
+
+    assert "a very long but highly relevant passage" in context
+    assert len(sources) == 1
+
+
+# ─── merge_contexts ───────────────────────────────────────────────────────────
+
+
+def test_merge_contexts_all_empty_returns_empty():
+    assert grounding.merge_contexts("", "   ", None) == ""
+    assert grounding.merge_contexts() == ""
+
+
+def test_merge_contexts_single_input_returned_trimmed():
+    ctx = "=== BNS [doc_id=bns] ===\nSection 300 text"
+    assert grounding.merge_contexts("", ctx, "  ") == ctx
+
+
+def test_merge_contexts_deduplicates_shared_blocks():
+    local = (
+        "=== BNS [doc_id=bns] ===\nSection 300 defines murder.\n\n"
+        "=== Constitution [doc_id=coi] ===\nArticle 21 protects life."
+    )
+    kanoon = (
+        "=== BNS (excerpt 2) [doc_id=bns] ===\nSection 300 defines murder.\n\n"
+        "=== Judgment [doc_id=sc1] ===\nThe court held that intent matters."
+    )
+    merged = grounding.merge_contexts(local, kanoon)
+
+    # The shared Section 300 body appears once despite different headers.
+    assert merged.count("Section 300 defines murder.") == 1
+    # The unique blocks from both contexts survive.
+    assert "Article 21 protects life." in merged
+    assert "The court held that intent matters." in merged
+    # Three distinct passages remain.
+    assert merged.count("=== ") == 3
+
+
+def test_merge_contexts_preserves_first_occurrence_order():
+    a = "=== A [doc_id=a] ===\nalpha body"
+    b = "=== B [doc_id=b] ===\nbeta body"
+    merged = grounding.merge_contexts(a, b)
+    assert merged.index("alpha body") < merged.index("beta body")
+
+
+def test_merge_contexts_handles_unheadered_text():
+    # A plain string with no "=== " header is treated as one block.
+    merged = grounding.merge_contexts("plain context one", "plain context two")
+    assert "plain context one" in merged
+    assert "plain context two" in merged


### PR DESCRIPTION
# Pull request
## Phase 2: Retrieval-augmented legal reasoning integration
 
Closes #674
 
> **Builds on Phase 1 (#673), already merged.** The Phase 1 retrieval facade (`services/retrieval/retriever.py`, `__init__.py`) landed on `main` via #1477, so this PR applies directly on top of the current `main`: no branch stacking required. It depends on that facade's API (`retriever.retrieve`, `RetrievedChunk.as_context_block`) and does not re-introduce any Phase 1 files.
 
## Summary
 
Phase 1 gave us a reusable, corpus-only retrieval facade. This PR wires it into the **reasoning pipeline** so that answers are grounded in retrieved legal passages, completing the flow the issue describes:
 
```
user query -> semantic retrieval (corpus) -> grounded prompt -> LLM reasoning
```
 
The grounding path is **independent of the live Indian Kanoon search**. It retrieves against the persistent local corpus, with no outbound HTTP call and no API-token / circuit-breaker gating, so grounding still works when the live Kanoon service is unavailable, rate-limited, or disabled. Where a live-Kanoon context is also available, the two are merged into a single deduplicated context.
 
## Why this is needed
 
Before this change, the *only* way the reasoning pipeline ever received retrieved context was as a side effect of `services.kanoon_search.build_kanoon_context`, which:
 
- Always performs a **live Indian Kanoon HTTP search first** (so no live search ⇒ no grounding)
- Labels everything it returns as *"Indian Kanoon"* context even when the served chunks actually came from the **local seed corpus**.

There was no first-class, Kanoon-independent way to ground a query against the local corpus and feed that into reasoning. This PR adds exactly that, on top of the Phase 1 facade.
 
## What's in this PR
 
### `grounding.py` (new)
A small grounding layer, sibling to `research.py`:
 
- **`async build_grounded_context(query, *, top_k, min_score, max_context_tokens)` -> `(context_str, sources)`**: calls `retriever.retrieve()` and assembles the hits into one citation-friendly string (one `=== Title [doc_id=...] ===` block per passage), stopping before the assembled text exceeds `max_context_tokens`. The top passage is always included even if it alone exceeds the budget, so a long-but-relevant best hit is never silently dropped. Returns `("", [])` when retrieval yields nothing: callers treat grounding as best-effort.
- **`merge_contexts(*contexts)` -> `str`**: concatenates several formatted context strings, dropping duplicate passages by **normalized body text** (header ignored). This is what removes the seed-corpus chunks that appear in *both* a local-grounding context and a live-Kanoon context. A single non-empty input is returned unchanged; all-empty inputs yield `""`.
Design choices reflect the rest of the system: graceful degradation, async-first, citation-preserving output consistent with `kanoon_search._format_context`.
 
### `main.py`: wire grounding into both reasoning entry points
- **`analyze_sync`** (sync `/analyze`): after the existing Kanoon fetch, build the local grounded context and `merge_contexts(local, kanoon)` before calling `run_parallel_research`.
- **`legal_reasoning_pipeline`** (streaming `/analyze-stream`): launch `build_grounded_context` as a task **concurrently** with the existing Kanoon task, then merge both at the existing await point. Because grounding overlaps the decompose/route/Kanoon work that already happens, it adds **no latency on the critical path**.
Both call sites are defensively wrapped (matching the existing Kanoon `try/except`) and are **backward compatible**: when local grounding returns empty, the merged context is byte-for-byte the previous Kanoon-only context, so existing behaviour is unchanged. `deep_research_pipeline` is intentionally left as-is.
 
### `research.py`: generalize the context label
The injected context can now originate from the local corpus, Kanoon, or both, so the human-readable label is generalized from `INDIAN KANOON CONTEXT` to `RETRIEVED LEGAL CONTEXT` (two strings: the system-prompt preamble and the user-prompt section header). The `kanoon_context` **parameter name is deliberately kept** so no callers or tests need to change.
 
### `services/kanoon_search.py`: remove dead bad-merge code
`search_kanoon` contained an **unreachable** block after its `try/except` (which always returns): a duplicated `url`/`params`/`headers` setup and a second `try/except` that used the **old non-`await`** circuit-breaker calls (`kanoon_breaker.call_succeeded()` / `call_failed()`), inconsistent with the live `await`ed calls above it. This is a leftover from a bad merge; it can never run and is removed. No behavioural change.
 
### `tests/test_grounding.py` (new)
10 unit tests, retriever mocked (no models / network):
- `build_grounded_context`: happy-path block/source assembly, empty-on-no-hits, `top_k`/`min_score` forwarding, token-budget truncation, and the always-keep-first-passage guarantee.
- `merge_contexts`: all-empty, single-input passthrough, de-duplication of shared blocks across contexts (different headers, same body), first-occurrence ordering, and unheadered plain-text inputs.

## Testing
 
Applied on top of the current `main`, every test related to this change passes, and the **only** failures in the full `nlp-orchestrator` suite are 6 pre-existing `test_pii_ner.py` failures that also fail on a clean `main` (introduced by the recent NER work, unrelated to this PR):
 
```bash
PS C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator> pytest -v tests/test_grounding.py tests/test_research.py tests/test_pipeline.py tests/test_retriever.py tests/test_chunker.py
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\madhu\Documents\nyay-setu-working\nlp-orchestrator
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-7.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 63 items

tests/test_grounding.py::test_build_grounded_context_happy_path PASSED                                           [  1%]
tests/test_grounding.py::test_build_grounded_context_empty_when_no_hits PASSED                                   [  3%]
tests/test_grounding.py::test_build_grounded_context_forwards_top_k_and_min_score PASSED                         [  4%]
tests/test_grounding.py::test_build_grounded_context_respects_token_budget PASSED                                [  6%]
tests/test_grounding.py::test_build_grounded_context_always_keeps_first_passage PASSED                           [  7%]
tests/test_grounding.py::test_merge_contexts_all_empty_returns_empty PASSED                                      [  9%]
tests/test_grounding.py::test_merge_contexts_single_input_returned_trimmed PASSED                                [ 11%]
tests/test_grounding.py::test_merge_contexts_deduplicates_shared_blocks PASSED                                   [ 12%]
tests/test_grounding.py::test_merge_contexts_preserves_first_occurrence_order PASSED                             [ 14%]
tests/test_grounding.py::test_merge_contexts_handles_unheadered_text PASSED                                      [ 15%]
tests/test_research.py::test_primary_provider_success PASSED                                                     [ 17%]
tests/test_research.py::test_retry_then_success PASSED                                                           [ 19%]
tests/test_research.py::test_circuit_breaker_provider_skipped PASSED                                             [ 20%]
tests/test_research.py::test_fallback_to_secondary_provider PASSED                                               [ 22%]
tests/test_research.py::test_all_providers_fail PASSED                                                           [ 23%]
tests/test_research.py::test_non_retryable_error PASSED                                                          [ 25%]
tests/test_pipeline.py::test_deep_research_pipeline_flow PASSED                                                  [ 26%]
tests/test_pipeline.py::test_deep_research_pipeline_gemini_cache_hit PASSED                                      [ 28%]
tests/test_pipeline.py::test_pipeline_error_handling PASSED                                                      [ 30%]
tests/test_retriever.py::test_retrieved_chunk_from_raw_bi_encoder PASSED                                         [ 31%]
tests/test_retriever.py::test_retrieved_chunk_effective_score_uses_rerank PASSED                                 [ 33%]
tests/test_retriever.py::test_retrieved_chunk_defaults_for_missing_metadata PASSED                               [ 34%]
tests/test_retriever.py::test_as_context_block_includes_citation_header PASSED                                   [ 36%]
tests/test_retriever.py::test_retrieve_happy_path_orders_and_types PASSED                                        [ 38%]
tests/test_retriever.py::test_retrieve_empty_query_returns_empty PASSED                                          [ 39%]
tests/test_retriever.py::test_retrieve_disabled_flag_returns_empty PASSED                                        [ 41%]
tests/test_retriever.py::test_retrieve_embedder_unavailable_returns_empty PASSED                                 [ 42%]
tests/test_retriever.py::test_retrieve_no_candidates_returns_empty PASSED                                        [ 44%]
tests/test_retriever.py::test_retrieve_top_k_limits_results PASSED                                               [ 46%]
tests/test_retriever.py::test_retrieve_fetch_k_never_below_top_k PASSED                                          [ 47%]
tests/test_retriever.py::test_retrieve_source_filter PASSED                                                      [ 49%]
tests/test_retriever.py::test_retrieve_min_score_threshold PASSED                                                [ 50%]
tests/test_retriever.py::test_retrieve_runs_reranker_when_enabled PASSED                                         [ 52%]
tests/test_retriever.py::test_retrieve_skips_reranker_when_disabled PASSED                                       [ 53%]
tests/test_retriever.py::test_retrieve_sync_happy_path PASSED                                                    [ 55%]
tests/test_retriever.py::test_retrieve_sync_embedder_unavailable PASSED                                          [ 57%]
tests/test_retriever.py::test_ingest_documents_chunks_embeds_and_upserts PASSED                                  [ 58%]
tests/test_retriever.py::test_ingest_documents_skips_existing PASSED                                             [ 60%]
tests/test_retriever.py::test_ingest_documents_skips_empty PASSED                                                [ 61%]
tests/test_retriever.py::test_ingest_documents_respects_per_doc_source_and_metadata PASSED                       [ 63%]
tests/test_retriever.py::test_corpus_size_delegates_to_store PASSED                                              [ 65%]
tests/test_retriever.py::test_is_available_true_when_enabled_and_populated PASSED                                [ 66%]
tests/test_retriever.py::test_is_available_false_when_empty PASSED                                               [ 68%]
tests/test_retriever.py::test_is_available_false_when_disabled PASSED                                            [ 69%]
tests/test_retriever.py::test_package_lazy_exports_resolve PASSED                                                [ 71%]
tests/test_retriever.py::test_package_unknown_attribute_raises PASSED                                            [ 73%]
tests/test_chunker.py::test_empty_returns_empty PASSED                                                           [ 74%]
tests/test_chunker.py::test_short_text_one_chunk PASSED                                                          [ 76%]
tests/test_chunker.py::test_chunks_are_unique PASSED                                                             [ 77%]
tests/test_chunker.py::test_chunks_respect_size_with_some_slack PASSED                                           [ 79%]
tests/test_chunker.py::test_long_paragraph_without_sentence_boundary_chunks_correctly PASSED                     [ 80%]
tests/test_chunker.py::test_realistic_chunk_sizes PASSED                                                         [ 82%]
tests/test_chunker.py::test_overlap_provides_continuity PASSED                                                   [ 84%]
tests/test_chunker.py::test_count_tokens_handles_empty PASSED                                                    [ 85%]
tests/test_chunker.py::test_split_legal_sections_basic PASSED                                                    [ 87%]
tests/test_chunker.py::test_split_legal_sections_no_headings_is_noop PASSED                                      [ 88%]
tests/test_chunker.py::test_split_legal_sections_preserves_preamble PASSED                                       [ 90%]
tests/test_chunker.py::test_split_legal_sections_recognises_article_and_symbol PASSED                            [ 92%]
tests/test_chunker.py::test_chunk_text_keeps_sections_separate_without_blank_lines PASSED                        [ 93%]
tests/test_chunker.py::test_chunk_text_every_chunk_anchored_to_a_heading PASSED                                  [ 95%]
tests/test_chunker.py::test_respect_sections_false_restores_legacy_merge PASSED                                  [ 96%]
tests/test_chunker.py::test_overlap_does_not_cross_section_boundary PASSED                                       [ 98%]
tests/test_chunker.py::test_long_section_still_splits_within_section PASSED                                      [100%]Running teardown with pytest sessionfinish...


================================================= 63 passed in 14.89s =================================================
```
 
The tests exercising this PR (all green):
- `tests/test_grounding.py`: 10 (new, this PR)
- `tests/test_research.py`: 6 (confirms the label generalization did not break research; no test asserts on the label string)
- `tests/test_pipeline.py`: 3 (confirms `main.py` imports cleanly with the grounding additions and `deep_research_pipeline` still works)
- `tests/test_retriever.py`: 27
- `tests/test_chunker.py`: 17 (the merged Phase 1 facade)

 
(`config.py` exits if `GROQ_API_KEY` is unset, so it must be present in the environment — CI already provides it. Running the full suite also requires the normal runtime deps from `requirements.txt`: `groq`, `google-genai`, `aiohttp`, `fastapi`, `sse-starlette`, `python-multipart`, etc.)
 
## Linting / formatting (CI)
 
All files added or modified by this PR pass the repo's lint workflow checks:
 
- `black --check`: clean on `grounding.py`, `tests/test_grounding.py`, `main.py`, `research.py`, and `services/kanoon_search.py`.
- `flake8 . --max-line-length=88 --extend-ignore=E203`: the new files (`grounding.py`, `tests/test_grounding.py`) report **zero** issues. For the edited files, my changes introduce **no new** findings: `main.py` and `research.py` report the exact same pre-existing `flake8` counts as `main` (15 and 12 respectively, all in lines this PR does not touch), and `services/kanoon_search.py` is clean.
> **Note on pre-existing CI debt (not introduced here):** the `nlp-orchestrator` CI is already red on `main`, independent of this PR: `pii_ner.py` fails `black`, `flake8 .` reports ~120 findings across many files, and 6 `test_pii_ner.py` tests fail (all from the recent NER work). Because CI runs `black --check .` / `flake8 .` / `pytest` over the **whole** tree, those pre-existing failures surface on any PR. Fixing them is out of scope for this focused change and is better handled as a separate cleanup PR.
 
## Scope and follow-ups
 
- **Synthesizer is intentionally untouched.** `synthesizer.py` consumes the *already-grounded* research results, not raw retrieval context. Grounding therefore reaches it **transitively** through `research.py`. Touching it would add risk for no benefit (and it is covered by existing tests that stay green).
- **Backward compatible.** With an empty corpus or grounding disabled, behaviour is identical to before this PR.
- **Follow-up optimization (not addressed here):** when both grounding paths run, the query is embedded twice: once inside `build_kanoon_context`'s vector search and once inside `build_grounded_context` via `retriever.retrieve`. A future change could compute the query embedding once and share it across both paths to save one embedding call per request. It is intentionally left out to keep this PR focused and low-risk.