### PR TITLE
feat: add document search endpoint with pagination and keyword filtering

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
@@ -173,6 +173,17 @@ public class DocumentManagementController {
         return ResponseEntity.ok(documents);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<Page<DocumentDto>> searchDocuments(
+            @RequestParam String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<DocumentDto> documents =
+                documentManagementService.searchDocuments(keyword, pageable);
+
+        return ResponseEntity.ok(documents);
+    }
+
     @GetMapping("/user/cases")
     public ResponseEntity<Page<CaseSummaryDto>> getUserCases(
             Authentication authentication,

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/DocumentRepository.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/DocumentRepository.java
@@ -32,4 +32,9 @@ public interface DocumentRepository extends JpaRepository<DocumentEntity, UUID> 
         WHERE d.caseId = :caseId
     """)
     List<DocumentDto> findCaseDocumentsWithDetails(UUID caseId);
+        Page<DocumentEntity> findByFileNameContainingIgnoreCaseOrCategoryContainingIgnoreCase(
+            String fileName,
+            String category,
+            Pageable pageable
+    );
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/DocumentManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/DocumentManagementService.java
@@ -77,6 +77,16 @@ public class DocumentManagementService {
                 .map(this::convertToDto);
     }
 
+    public Page<DocumentDto> searchDocuments(String keyword, Pageable pageable) {
+        return documentRepository
+                .findByFileNameContainingIgnoreCaseOrCategoryContainingIgnoreCase(
+                        keyword,
+                        keyword,
+                        pageable
+                )
+                .map(this::convertToDto);
+    }
+
     public List<DocumentDto> getCaseDocuments(UUID caseId) {
         return documentRepository.findCaseDocumentsWithDetails(caseId);
     }

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/AuditChainServiceTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/AuditChainServiceTest.java
@@ -1,0 +1,131 @@
+package com.nyaysetu.backend.service;
+
+import com.nyaysetu.backend.entity.AuditLog;
+import com.nyaysetu.backend.repository.AuditLogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AuditChainServiceTest {
+
+    private AuditChainService chainService;
+    private AuditLogRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = Mockito.mock(AuditLogRepository.class);
+        chainService = new AuditChainService(repository);
+    }
+
+    /**
+     * Insert 3 entries. Manually corrupt previousHash of entry 2.
+     * Verify that verifyChain correctly identifies entry 2 as the tampered record.
+     */
+    @Test
+    void verifyChain_detectsTamperOnEntry2() {
+        LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+
+        // Entry 1 — genesis, correctly chained
+        AuditLog entry1 = new AuditLog();
+        entry1.setId(UUID.randomUUID());
+        entry1.setAction("LOGIN");
+        entry1.setUserId(1L);
+        entry1.setDescription("User logged in");
+        entry1.setTimestamp(base);
+        entry1.setPreviousHash(AuditChainService.GENESIS_HASH);
+        entry1.setEntryHash(chainService.computeHash(entry1, AuditChainService.GENESIS_HASH));
+
+        // Entry 2 — previousHash corrupted (simulates a DB-level deletion/edit attack)
+        AuditLog entry2 = new AuditLog();
+        entry2.setId(UUID.randomUUID());
+        entry2.setAction("CASE_CREATED");
+        entry2.setUserId(2L);
+        entry2.setDescription("New case filed");
+        entry2.setTimestamp(base.plusMinutes(1));
+        String attackerHash = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+        entry2.setPreviousHash(attackerHash);
+        entry2.setEntryHash(chainService.computeHash(entry2, attackerHash));
+
+        // Entry 3 — internally consistent with entry2 as stored, but chain from entry1 is broken
+        AuditLog entry3 = new AuditLog();
+        entry3.setId(UUID.randomUUID());
+        entry3.setAction("DOC_UPLOADED");
+        entry3.setUserId(1L);
+        entry3.setDescription("Evidence uploaded");
+        entry3.setTimestamp(base.plusMinutes(2));
+        entry3.setPreviousHash(entry2.getEntryHash());
+        entry3.setEntryHash(chainService.computeHash(entry3, entry2.getEntryHash()));
+
+        when(repository.findAllByOrderByTimestampAsc()).thenReturn(List.of(entry1, entry2, entry3));
+
+        List<Map<String, Object>> broken = chainService.verifyChain();
+
+        assertEquals(1, broken.size(), "Exactly one broken link expected");
+        assertEquals(entry2.getId().toString(), broken.get(0).get("id"),
+                "Entry 2 must be identified as the tampered record");
+    }
+
+    @Test
+    void verifyChain_returnsEmptyWhenChainIsIntact() {
+        LocalDateTime base = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+
+        AuditLog e1 = new AuditLog();
+        e1.setId(UUID.randomUUID());
+        e1.setAction("LOGIN");
+        e1.setUserId(1L);
+        e1.setDescription("User login");
+        e1.setTimestamp(base);
+        e1.setPreviousHash(AuditChainService.GENESIS_HASH);
+        e1.setEntryHash(chainService.computeHash(e1, AuditChainService.GENESIS_HASH));
+
+        AuditLog e2 = new AuditLog();
+        e2.setId(UUID.randomUUID());
+        e2.setAction("CASE_CREATED");
+        e2.setUserId(2L);
+        e2.setDescription("Case filed");
+        e2.setTimestamp(base.plusMinutes(1));
+        e2.setPreviousHash(e1.getEntryHash());
+        e2.setEntryHash(chainService.computeHash(e2, e1.getEntryHash()));
+
+        AuditLog e3 = new AuditLog();
+        e3.setId(UUID.randomUUID());
+        e3.setAction("DOC_UPLOADED");
+        e3.setUserId(1L);
+        e3.setDescription("Evidence");
+        e3.setTimestamp(base.plusMinutes(2));
+        e3.setPreviousHash(e2.getEntryHash());
+        e3.setEntryHash(chainService.computeHash(e3, e2.getEntryHash()));
+
+        when(repository.findAllByOrderByTimestampAsc()).thenReturn(List.of(e1, e2, e3));
+
+        assertTrue(chainService.verifyChain().isEmpty(), "Intact chain must return no broken links");
+    }
+
+    @Test
+    void appendEntry_setsGenesisHashWhenChainIsEmpty() {
+        when(repository.findTopByOrderByTimestampDesc()).thenReturn(Optional.empty());
+        when(repository.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        AuditLog log = new AuditLog();
+        log.setAction("LOGIN");
+        log.setUserId(1L);
+        log.setDescription("first entry");
+        log.setTimestamp(LocalDateTime.now());
+
+        AuditLog saved = chainService.appendEntry(log);
+
+        assertEquals(AuditChainService.GENESIS_HASH, saved.getPreviousHash());
+        assertNotNull(saved.getEntryHash());
+        assertEquals(64, saved.getEntryHash().length());
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR enhances the Document Management System by adding document search functionality with pagination and keyword-based filtering.

### Changes Made
- Added keyword-based document search in `DocumentRepository`
- Implemented `searchDocuments()` in `DocumentManagementService`
- Added `/documents/search` API endpoint in `DocumentManagementController`
- Supports searching documents by file name and category with pagination

Closes #1279

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests
- [ ] New and existing unit tests pass locally