### PR TITLE
feat: add document search endpoint with pagination and keyword filtering

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/DocumentManagementController.java
@@ -173,6 +173,17 @@ public class DocumentManagementController {
         return ResponseEntity.ok(documents);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<Page<DocumentDto>> searchDocuments(
+            @RequestParam String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<DocumentDto> documents =
+                documentManagementService.searchDocuments(keyword, pageable);
+
+        return ResponseEntity.ok(documents);
+    }
+
     @GetMapping("/user/cases")
     public ResponseEntity<Page<CaseSummaryDto>> getUserCases(
             Authentication authentication,

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/DocumentRepository.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/DocumentRepository.java
@@ -32,4 +32,9 @@ public interface DocumentRepository extends JpaRepository<DocumentEntity, UUID> 
         WHERE d.caseId = :caseId
     """)
     List<DocumentDto> findCaseDocumentsWithDetails(UUID caseId);
+        Page<DocumentEntity> findByFileNameContainingIgnoreCaseOrCategoryContainingIgnoreCase(
+            String fileName,
+            String category,
+            Pageable pageable
+    );
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/DocumentManagementService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/DocumentManagementService.java
@@ -77,6 +77,16 @@ public class DocumentManagementService {
                 .map(this::convertToDto);
     }
 
+    public Page<DocumentDto> searchDocuments(String keyword, Pageable pageable) {
+        return documentRepository
+                .findByFileNameContainingIgnoreCaseOrCategoryContainingIgnoreCase(
+                        keyword,
+                        keyword,
+                        pageable
+                )
+                .map(this::convertToDto);
+    }
+
     public List<DocumentDto> getCaseDocuments(UUID caseId) {
         return documentRepository.findCaseDocumentsWithDetails(caseId);
     }


### PR DESCRIPTION
# Pull Request

## Description

This PR enhances the Document Management System by adding keyword-based document search with pagination.

### Changes Made
- Added document search repository method using file name and category.
- Implemented `searchDocuments()` in `DocumentManagementService`.
- Added `/documents/search` REST API endpoint in `DocumentManagementController`.
- Supports paginated search results for efficient document retrieval.

Closes #1279

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my feature works
- [ ] New and existing unit tests pass locally with my changes