### PR TITLE
fix: derive sender from Authentication and add case access check in M…

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/MessageController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/MessageController.java
@@ -2,10 +2,14 @@ package com.nyaysetu.backend.controller;
 
 import com.nyaysetu.backend.dto.SendMessageRequest;
 import com.nyaysetu.backend.entity.CaseMessage;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.service.AuthService;
+import com.nyaysetu.backend.service.CaseAccessService;
 import com.nyaysetu.backend.service.MessageService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,13 +22,18 @@ import java.util.UUID;
 public class MessageController {
 
     private final MessageService messageService;
+    private final AuthService authService;
+    private final CaseAccessService caseAccessService;
 
     @PostMapping
     public CaseMessage sendMessage(
             @PathVariable UUID caseId,
-            @Valid @RequestBody SendMessageRequest request
+            @Valid @RequestBody SendMessageRequest request,
+            Authentication authentication
     ) {
-        return messageService.sendMessage(caseId, request);
+        User user = authService.findByEmail(authentication.getName());
+        caseAccessService.requireCaseAccess(caseId, user);
+        return messageService.sendMessage(caseId, user.getId(), request);
     }
 
     @GetMapping

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/SendMessageRequest.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/dto/SendMessageRequest.java
@@ -1,15 +1,11 @@
 package com.nyaysetu.backend.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class SendMessageRequest {
-
-    @NotNull(message = "Sender ID is required")
-    private Long senderId;
 
     @NotBlank(message = "Message cannot be empty")
     private String message;

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/MessageService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/MessageService.java
@@ -21,14 +21,14 @@ public class MessageService {
     private final CaseMessageRepository messageRepository;
     private final CaseTimelineService timelineService;
 
-    public CaseMessage sendMessage(UUID caseId, SendMessageRequest dto) {
+    public CaseMessage sendMessage(UUID caseId, Long senderId, SendMessageRequest dto) {
 
         CaseEntity caseEntity = caseRepository.findById(caseId)
                 .orElseThrow(() -> new NotFoundException("Case not found: " + caseId));
 
         CaseMessage msg = CaseMessage.builder()
                 .legalCaseId(caseId)
-                .senderId(dto.getSenderId())
+                .senderId(senderId)
                 .message(dto.getMessage())
                 .type(dto.getType() != null ? dto.getType() : "TEXT")
                 .attachmentUrl(dto.getAttachmentUrl())


### PR DESCRIPTION
## Description
`MessageController` is missing case-level access control, and `SendMessageRequest.senderId` is a plain client-supplied `Long` instead of being derived from the authenticated principal. Combined, this means an unauthenticated-for-that-case caller can both read any case's message thread and post messages into it as an arbitrary user ID — including impersonating a judge or opposing counsel. In a legal-correspondence log this is an integrity problem, not just a privacy one: a fabricated message can be permanently attributed to the wrong party.

This is the same bug class already flagged in #1291 (MeetingService accepting a client-controlled `userId`), just in a different controller.

This PR:
- Adds an ownership/participant check on the case before any read or write in `MessageController`, matching the pattern used elsewhere (e.g. `VakilFriendController`'s `validateSessionOwnership`).
- Removes `senderId` from the client-supplied `SendMessageRequest` payload and derives the sender from `Authentication` on the server side instead, so a message can only ever be attributed to the actual authenticated caller.

Closes #1581

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes