### PR TITLE
fix: Add Vercel frontend URL to CORS fallback — resolves signup/login network error on production

### DIFF
--- a/backend/nyaysetu-backend/src/main/resources/application-prod.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application-prod.properties
@@ -21,7 +21,7 @@ spring.flyway.validate-on-migrate=true
 spring.flyway.ignore-missing-migrations=false
 
 # CORS - Strict origin from Env Var
-cors.allowed.origins=${CORS_ALLOWED_ORIGINS}
+cors.allowed.origins=${CORS_ALLOWED_ORIGINS:https://nyaysetu-lovat.vercel.app,http://localhost:5173}
 
 # AI Keys - Read from Env Vars
 groq.api.key=${GROQ_API_KEY}

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -50,7 +50,7 @@ jwt.expiration=${JWT_EXPIRATION_MS:86400000}
 
 # CORS Configuration
 # Ensure no trailing slashes in your environment variables if possible, though Spring usually handles it
-cors.allowed.origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:4174,http://localhost:3000}
+cors.allowed.origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:4174,http://localhost:3000,https://nyaysetu-lovat.vercel.app}
 
 # File Upload Configuration
 spring.servlet.multipart.enabled=true


### PR DESCRIPTION
## Summary
Fixes "Network error. Please check your internet connection." on the 
Vercel-deployed frontend by adding the production URL to the 
`cors.allowed.origins` property fallback.

Closes #1078 

## Root Cause
`SecurityConfig.java` had `https://nyaysetu-lovat.vercel.app` in a 
`defaultOrigins` list, but this list is only used when 
`cors.allowed.origins` is completely empty. Since the property always 
resolves to a non-empty localhost fallback, `defaultOrigins` is never 
applied — the Vercel URL was silently excluded from every CORS response.

## Fix
```
Fix 1 — application.properties 
# Before
cors.allowed.origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:4174,http://localhost:3000}

# After  
cors.allowed.origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:4174,http://localhost:3000,https://nyaysetu-lovat.vercel.app}
```
```
Fix 2 — application-prod.properties — add fallback with Vercel URL
# Before
cors.allowed.origins=${CORS_ALLOWED_ORIGINS}

# After  
cors.allowed.origins=${CORS_ALLOWED_ORIGINS:https://nyaysetu-lovat.vercel.app,http://localhost:5173}
```
This ensures that even if CORS_ALLOWED_ORIGINS is not set on Render, the Vercel URL is always included.

## Files Changed
`src/main/resources/application.properties`  and `src/main/resources/application-prod.properties` — 2 line changed

## Verified with curl (CORS preflight simulation)

**Before fix:**
- Vercel origin → `403 Invalid CORS request` ❌
- localhost:5173 → `200` ✅

**After fix:**
- Vercel origin → `200 Access-Control-Allow-Origin: https://nyaysetu-lovat.vercel.app` ✅
- Attacker origin → `403` still blocked ✅
- localhost:5173 → `200` still works ✅




## Note on Production (application-prod.properties)
`application-prod.properties` uses `${CORS_ALLOWED_ORIGINS}` with no 
fallback. If this env var is not set on Render, the Vercel URL was 
also missing. Both files are now fixed.

For production deployments, set this env var on Render:
```
CORS_ALLOWED_ORIGINS=https://nyaysetu-lovat.vercel.app,https://your-other-domain.com
```