### PR TITLE
feat(security): add Redis login rate limiting

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/AuthController.java
@@ -12,6 +12,10 @@ import com.nyaysetu.backend.service.*;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
@@ -43,6 +47,10 @@ public class AuthController {
     private final PasswordResetTokenRepository tokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final RedisRateLimitService redisRateLimitService;
+
+    @Value("${security.rate-limit.auth.login.trust-forwarded-headers:false}")
+    private boolean trustForwardedHeaders;
 
     @SecurityRequirements
     @PostMapping("/register")
@@ -91,7 +99,39 @@ public class AuthController {
 
     @SecurityRequirements
     @PostMapping("/login")
-    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest req) {
+    public ResponseEntity<?> login(
+            @Valid @RequestBody LoginRequest req,
+            HttpServletRequest request
+    ) {
+        String clientIp = resolveClientIp(request);
+
+        RedisRateLimitService.RateLimitResult rateLimit =
+                redisRateLimitService.consumeLoginAttempt(
+                        clientIp,
+                        req.getEmail()
+                );
+
+        if (!rateLimit.isAllowed()) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .header(
+                            HttpHeaders.RETRY_AFTER,
+                            String.valueOf(rateLimit.getRetryAfterSeconds())
+                    )
+                    .header(
+                            "X-RateLimit-Limit",
+                            String.valueOf(rateLimit.getLimit())
+                    )
+                    .header(
+                            "X-RateLimit-Remaining",
+                            String.valueOf(rateLimit.getRemaining())
+                    )
+                    .body(Map.of(
+                            "message",
+                            "Too many login attempts. Please try again later.",
+                            "retryAfter",
+                            rateLimit.getRetryAfterSeconds()
+                    ));
+        }
         log.debug("Login endpoint reached for email: {}", req.getEmail());
         try {
             User user1 = userRepository.findByEmail(req.getEmail())
@@ -299,6 +339,22 @@ public class AuthController {
         } catch (Exception e) {
             return ResponseEntity.status(400).body(Map.of("message", e.getMessage()));
         }
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+
+        if (trustForwardedHeaders && forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+
+        String realIp = request.getHeader("X-Real-IP");
+
+        if (trustForwardedHeaders && realIp != null && !realIp.isBlank()) {
+            return realIp.trim();
+        }
+
+        return request.getRemoteAddr();
     }
 
     @GetMapping("/test")

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/RedisRateLimitService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/RedisRateLimitService.java
@@ -1,0 +1,202 @@
+package com.nyaysetu.backend.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisRateLimitService {
+
+    @SuppressWarnings("rawtypes")
+    private static final DefaultRedisScript<List> LOGIN_RATE_LIMIT_SCRIPT = createScript();
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${security.rate-limit.auth.login.enabled:true}")
+    private boolean enabled;
+
+    @Value("${security.rate-limit.auth.login.ip.max-attempts:5}")
+    private int maxIpAttempts;
+
+    @Value("${security.rate-limit.auth.login.ip.window-seconds:60}")
+    private long ipWindowSeconds;
+
+    @Value("${security.rate-limit.auth.login.account.max-attempts:10}")
+    private int maxAccountAttempts;
+
+    @Value("${security.rate-limit.auth.login.account.window-seconds:900}")
+    private long accountWindowSeconds;
+
+    @Value("${security.rate-limit.auth.login.key-prefix:rate-limit:auth:login}")
+    private String keyPrefix;
+
+    @SuppressWarnings("rawtypes")
+    private static DefaultRedisScript<List> createScript() {
+        DefaultRedisScript<List> script = new DefaultRedisScript<>();
+        script.setResultType(List.class);
+        script.setScriptText(String.join(" ",
+                "local ipCount = redis.call('INCR', KEYS[1])",
+                "if tonumber(ipCount) == 1 then",
+                "redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1]))",
+                "end",
+                "local ipTtl = redis.call('TTL', KEYS[1])",
+                "if tonumber(ipTtl) < 0 then",
+                "redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1]))",
+                "ipTtl = tonumber(ARGV[1])",
+                "end",
+                "local accountCount = redis.call('INCR', KEYS[2])",
+                "if tonumber(accountCount) == 1 then",
+                "redis.call('EXPIRE', KEYS[2], tonumber(ARGV[2]))",
+                "end",
+                "local accountTtl = redis.call('TTL', KEYS[2])",
+                "if tonumber(accountTtl) < 0 then",
+                "redis.call('EXPIRE', KEYS[2], tonumber(ARGV[2]))",
+                "accountTtl = tonumber(ARGV[2])",
+                "end",
+                "return {ipCount, ipTtl, accountCount, accountTtl}"
+        ));
+        return script;
+    }
+
+    public RateLimitResult consumeLoginAttempt(String clientIp, String accountIdentifier) {
+        int effectiveLimit = Math.min(maxIpAttempts, maxAccountAttempts);
+
+        if (!enabled) {
+            return RateLimitResult.allowed(effectiveLimit, Math.max(0, effectiveLimit - 1));
+        }
+
+        String ipKey = keyPrefix + ":ip:" + sanitizeClientIp(clientIp);
+        String accountKey = keyPrefix + ":account:" + hashAccountIdentifier(accountIdentifier);
+
+        try {
+            List<?> result = redisTemplate.execute(
+                    LOGIN_RATE_LIMIT_SCRIPT,
+                    List.of(ipKey, accountKey),
+                    String.valueOf(ipWindowSeconds),
+                    String.valueOf(accountWindowSeconds)
+            );
+
+            if (result == null || result.size() < 4) {
+                log.warn("Redis returned an incomplete login rate-limit result; allowing request");
+                return RateLimitResult.allowed(effectiveLimit, Math.max(0, effectiveLimit - 1));
+            }
+
+            long ipCount = asLong(result.get(0));
+            long ipTtl = normalizeTtl(asLong(result.get(1)), ipWindowSeconds);
+            long accountCount = asLong(result.get(2));
+            long accountTtl = normalizeTtl(asLong(result.get(3)), accountWindowSeconds);
+
+            boolean ipBlocked = ipCount > maxIpAttempts;
+            boolean accountBlocked = accountCount > maxAccountAttempts;
+
+            if (!ipBlocked && !accountBlocked) {
+                int ipRemaining = (int) Math.max(0, maxIpAttempts - ipCount);
+                int accountRemaining = (int) Math.max(0, maxAccountAttempts - accountCount);
+
+                return RateLimitResult.allowed(
+                        effectiveLimit,
+                        Math.min(ipRemaining, accountRemaining)
+                );
+            }
+
+            long retryAfterSeconds = 0;
+            int blockingLimit = Integer.MAX_VALUE;
+
+            if (ipBlocked) {
+                retryAfterSeconds = Math.max(retryAfterSeconds, ipTtl);
+                blockingLimit = Math.min(blockingLimit, maxIpAttempts);
+            }
+
+            if (accountBlocked) {
+                retryAfterSeconds = Math.max(retryAfterSeconds, accountTtl);
+                blockingLimit = Math.min(blockingLimit, maxAccountAttempts);
+            }
+
+            return RateLimitResult.blocked(
+                    blockingLimit,
+                    Math.max(1, retryAfterSeconds)
+            );
+        } catch (Exception ex) {
+            log.warn(
+                    "Redis login rate-limit check failed; allowing authentication request",
+                    ex
+            );
+            return RateLimitResult.allowed(effectiveLimit, Math.max(0, effectiveLimit - 1));
+        }
+    }
+
+    private long asLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(String.valueOf(value));
+    }
+
+    private long normalizeTtl(long ttl, long configuredWindow) {
+        return ttl > 0 ? ttl : configuredWindow;
+    }
+
+    private String sanitizeClientIp(String clientIp) {
+        if (clientIp == null || clientIp.isBlank()) {
+            return "unknown";
+        }
+
+        return clientIp.trim().replaceAll("[^a-zA-Z0-9._:-]", "_");
+    }
+
+    private String hashAccountIdentifier(String accountIdentifier) {
+        String normalized = accountIdentifier == null
+                ? "unknown"
+                : accountIdentifier.trim().toLowerCase(Locale.ROOT);
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+
+    @Getter
+    public static class RateLimitResult {
+
+        private final boolean allowed;
+        private final int limit;
+        private final int remaining;
+        private final long retryAfterSeconds;
+
+        public RateLimitResult(
+                boolean allowed,
+                int limit,
+                int remaining,
+                long retryAfterSeconds
+        ) {
+            this.allowed = allowed;
+            this.limit = limit;
+            this.remaining = remaining;
+            this.retryAfterSeconds = retryAfterSeconds;
+        }
+
+        public static RateLimitResult allowed(int limit, int remaining) {
+            return new RateLimitResult(true, limit, remaining, 0);
+        }
+
+        public static RateLimitResult blocked(int limit, long retryAfterSeconds) {
+            return new RateLimitResult(false, limit, 0, retryAfterSeconds);
+        }
+    }
+}

--- a/backend/nyaysetu-backend/src/main/resources/application.properties
+++ b/backend/nyaysetu-backend/src/main/resources/application.properties
@@ -150,3 +150,12 @@ semantic-cache.legal.min-query-length=${SEMANTIC_CACHE_LEGAL_MIN_QUERY_LENGTH:8}
 # Redis connection used by semantic legal query cache
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
+
+# Redis-backed login rate limiting
+security.rate-limit.auth.login.enabled=${LOGIN_RATE_LIMIT_ENABLED:true}
+security.rate-limit.auth.login.ip.max-attempts=${LOGIN_RATE_LIMIT_IP_MAX_ATTEMPTS:5}
+security.rate-limit.auth.login.ip.window-seconds=${LOGIN_RATE_LIMIT_IP_WINDOW_SECONDS:60}
+security.rate-limit.auth.login.account.max-attempts=${LOGIN_RATE_LIMIT_ACCOUNT_MAX_ATTEMPTS:10}
+security.rate-limit.auth.login.account.window-seconds=${LOGIN_RATE_LIMIT_ACCOUNT_WINDOW_SECONDS:900}
+security.rate-limit.auth.login.key-prefix=${LOGIN_RATE_LIMIT_KEY_PREFIX:rate-limit:auth:login}
+security.rate-limit.auth.login.trust-forwarded-headers=${LOGIN_RATE_LIMIT_TRUST_FORWARDED_HEADERS:false}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/AuthControllerRateLimitTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/AuthControllerRateLimitTest.java
@@ -1,0 +1,180 @@
+package com.nyaysetu.backend.controller;
+
+import com.nyaysetu.backend.dto.LoginRequest;
+import com.nyaysetu.backend.repository.PasswordResetTokenRepository;
+import com.nyaysetu.backend.repository.UserRepository;
+import com.nyaysetu.backend.service.AuthService;
+import com.nyaysetu.backend.service.EmailService;
+import com.nyaysetu.backend.service.FaceRecognitionService;
+import com.nyaysetu.backend.service.JwtService;
+import com.nyaysetu.backend.service.RedisRateLimitService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerRateLimitTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private FaceRecognitionService faceRecognitionService;
+
+    @Mock
+    private PasswordResetTokenRepository tokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RedisRateLimitService redisRateLimitService;
+
+    @InjectMocks
+    private AuthController authController;
+
+    @Test
+    void loginReturnsTooManyRequestsBeforeAuthentication() {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("user@example.com");
+        loginRequest.setPassword("Secret123!");
+
+        MockHttpServletRequest request =
+                new MockHttpServletRequest();
+
+        request.setRemoteAddr("203.0.113.10");
+
+        when(redisRateLimitService.consumeLoginAttempt(
+                "203.0.113.10",
+                "user@example.com"
+        )).thenReturn(
+                RedisRateLimitService.RateLimitResult.blocked(
+                        5,
+                        42
+                )
+        );
+
+        ResponseEntity<?> response =
+                authController.login(loginRequest, request);
+
+        assertEquals(
+                HttpStatus.TOO_MANY_REQUESTS,
+                response.getStatusCode()
+        );
+
+        assertEquals(
+                "42",
+                response.getHeaders().getFirst(
+                        HttpHeaders.RETRY_AFTER
+                )
+        );
+
+        assertEquals(
+                "5",
+                response.getHeaders().getFirst(
+                        "X-RateLimit-Limit"
+                )
+        );
+
+        assertEquals(
+                "0",
+                response.getHeaders().getFirst(
+                        "X-RateLimit-Remaining"
+                )
+        );
+
+        assertInstanceOf(Map.class, response.getBody());
+
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+
+        assertEquals(
+                "Too many login attempts. Please try again later.",
+                body.get("message")
+        );
+
+        assertEquals(
+                42L,
+                body.get("retryAfter")
+        );
+
+        verifyNoInteractions(authenticationManager);
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    void loginUsesFirstForwardedClientIp() {
+        ReflectionTestUtils.setField(
+                authController,
+                "trustForwardedHeaders",
+                true
+        );
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("user@example.com");
+        loginRequest.setPassword("Secret123!");
+
+        MockHttpServletRequest request =
+                new MockHttpServletRequest();
+
+        request.setRemoteAddr("10.0.0.10");
+
+        request.addHeader(
+                "X-Forwarded-For",
+                "198.51.100.20, 10.0.0.10"
+        );
+
+        when(redisRateLimitService.consumeLoginAttempt(
+                "198.51.100.20",
+                "user@example.com"
+        )).thenReturn(
+                RedisRateLimitService.RateLimitResult.blocked(
+                        5,
+                        30
+                )
+        );
+
+        ResponseEntity<?> response =
+                authController.login(loginRequest, request);
+
+        assertEquals(
+                HttpStatus.TOO_MANY_REQUESTS,
+                response.getStatusCode()
+        );
+
+        verify(redisRateLimitService).consumeLoginAttempt(
+                "198.51.100.20",
+                "user@example.com"
+        );
+
+        verifyNoInteractions(authenticationManager);
+    }
+}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/RedisRateLimitServiceTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/RedisRateLimitServiceTest.java
@@ -1,0 +1,259 @@
+package com.nyaysetu.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class RedisRateLimitServiceTest {
+
+    private StringRedisTemplate redisTemplate;
+    private RedisRateLimitService service;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        service = new RedisRateLimitService(redisTemplate);
+
+        ReflectionTestUtils.setField(service, "enabled", true);
+        ReflectionTestUtils.setField(service, "maxIpAttempts", 5);
+        ReflectionTestUtils.setField(service, "ipWindowSeconds", 60L);
+        ReflectionTestUtils.setField(service, "maxAccountAttempts", 10);
+        ReflectionTestUtils.setField(service, "accountWindowSeconds", 900L);
+        ReflectionTestUtils.setField(
+                service,
+                "keyPrefix",
+                "rate-limit:auth:login"
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void allowsAttemptWhenBothLimitsHaveCapacity() {
+        doReturn(List.of(1L, 60L, 1L, 900L))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        RedisRateLimitService.RateLimitResult result =
+                service.consumeLoginAttempt(
+                        "192.0.2.10",
+                        "user@example.com"
+                );
+
+        assertTrue(result.isAllowed());
+        assertEquals(5, result.getLimit());
+        assertEquals(4, result.getRemaining());
+        assertEquals(0, result.getRetryAfterSeconds());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void blocksWhenIpLimitIsExceeded() {
+        doReturn(List.of(6L, 37L, 2L, 800L))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        RedisRateLimitService.RateLimitResult result =
+                service.consumeLoginAttempt(
+                        "192.0.2.10",
+                        "user@example.com"
+                );
+
+        assertFalse(result.isAllowed());
+        assertEquals(5, result.getLimit());
+        assertEquals(0, result.getRemaining());
+        assertEquals(37, result.getRetryAfterSeconds());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void blocksAccountAcrossDifferentClientIps() {
+        doReturn(List.of(1L, 55L, 11L, 420L))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        RedisRateLimitService.RateLimitResult result =
+                service.consumeLoginAttempt(
+                        "198.51.100.25",
+                        "victim@example.com"
+                );
+
+        assertFalse(result.isAllowed());
+        assertEquals(10, result.getLimit());
+        assertEquals(0, result.getRemaining());
+        assertEquals(420, result.getRetryAfterSeconds());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void usesPrivacySafeHashedAccountKey() {
+        doReturn(List.of(1L, 60L, 1L, 900L))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        service.consumeLoginAttempt(
+                "203.0.113.5",
+                "  User@Example.COM  "
+        );
+
+        ArgumentCaptor<List<String>> keysCaptor =
+                ArgumentCaptor.forClass(List.class);
+
+        verify(redisTemplate).execute(
+                any(RedisScript.class),
+                keysCaptor.capture(),
+                any(),
+                any()
+        );
+
+        List<String> keys = keysCaptor.getValue();
+
+        assertEquals(2, keys.size());
+        assertEquals(
+                "rate-limit:auth:login:ip:203.0.113.5",
+                keys.get(0)
+        );
+
+        assertFalse(keys.get(1).contains("User@Example.COM"));
+        assertFalse(keys.get(1).contains("user@example.com"));
+
+        assertTrue(
+                keys.get(1).matches(
+                        "rate-limit:auth:login:account:[a-f0-9]{64}"
+                )
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void normalizesEmailBeforeHashing() {
+        doReturn(List.of(1L, 60L, 1L, 900L))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        service.consumeLoginAttempt(
+                "192.0.2.1",
+                "User@Example.COM"
+        );
+
+        service.consumeLoginAttempt(
+                "192.0.2.2",
+                "  user@example.com  "
+        );
+
+        ArgumentCaptor<List<String>> keysCaptor =
+                ArgumentCaptor.forClass(List.class);
+
+        verify(redisTemplate, times(2)).execute(
+                any(RedisScript.class),
+                keysCaptor.capture(),
+                any(),
+                any()
+        );
+
+        List<List<String>> allKeys = keysCaptor.getAllValues();
+
+        assertEquals(
+                allKeys.get(0).get(1),
+                allKeys.get(1).get(1)
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void failsOpenWhenRedisIsUnavailable() {
+        doThrow(new RuntimeException("Redis unavailable"))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        RedisRateLimitService.RateLimitResult result =
+                service.consumeLoginAttempt(
+                        "192.0.2.10",
+                        "user@example.com"
+                );
+
+        assertTrue(result.isAllowed());
+        assertEquals(5, result.getLimit());
+        assertEquals(4, result.getRemaining());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void incompleteRedisResultFailsOpen() {
+        doReturn(List.of(1L))
+                .when(redisTemplate)
+                .execute(
+                        any(RedisScript.class),
+                        anyList(),
+                        any(),
+                        any()
+                );
+
+        RedisRateLimitService.RateLimitResult result =
+                service.consumeLoginAttempt(
+                        "192.0.2.10",
+                        "user@example.com"
+                );
+
+        assertTrue(result.isAllowed());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void disabledLimiterDoesNotCallRedis() {
+        ReflectionTestUtils.setField(service, "enabled", false);
+
+        RedisRateLimitService.RateLimitResult result =
+                service.consumeLoginAttempt(
+                        "192.0.2.10",
+                        "user@example.com"
+                );
+
+        assertTrue(result.isAllowed());
+
+        verify(redisTemplate, never()).execute(
+                any(RedisScript.class),
+                anyList(),
+                any(),
+                any()
+        );
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR adds Redis-backed rate limiting to the password-based login endpoint to protect it against brute-force and credential-stuffing attacks across distributed backend instances.

The implementation applies two independent limits:

* per-client-IP login attempts;
* per-account login attempts across multiple client IP addresses.

Account identifiers are normalized and SHA-256 hashed before being included in Redis keys, preventing plaintext email addresses from appearing in Redis key names.

Additional security and reliability improvements include:

* atomic counter and expiry updates using a Redis Lua script;
* configurable rate-limit capacities and time windows;
* HTTP `429 Too Many Requests` responses;
* `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` headers;
* fail-open handling when Redis is unavailable;
* optional forwarding-header support, disabled by default to prevent spoofed client IP headers;
* service and controller tests for the new behaviour.

Closes #838

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Configuration

```properties
security.rate-limit.auth.login.enabled=${LOGIN_RATE_LIMIT_ENABLED:true}
security.rate-limit.auth.login.ip.max-attempts=${LOGIN_RATE_LIMIT_IP_MAX_ATTEMPTS:5}
security.rate-limit.auth.login.ip.window-seconds=${LOGIN_RATE_LIMIT_IP_WINDOW_SECONDS:60}
security.rate-limit.auth.login.account.max-attempts=${LOGIN_RATE_LIMIT_ACCOUNT_MAX_ATTEMPTS:10}
security.rate-limit.auth.login.account.window-seconds=${LOGIN_RATE_LIMIT_ACCOUNT_WINDOW_SECONDS:900}
security.rate-limit.auth.login.key-prefix=${LOGIN_RATE_LIMIT_KEY_PREFIX:rate-limit:auth:login}
security.rate-limit.auth.login.trust-forwarded-headers=${LOGIN_RATE_LIMIT_TRUST_FORWARDED_HEADERS:false}
```

## Tests added

Test coverage was added for:

* allowing requests within both limits;
* blocking requests that exceed the per-IP limit;
* blocking account-level attacks across different IP addresses;
* case-insensitive email normalization;
* SHA-256-hashed account Redis keys;
* incomplete Redis script responses;
* Redis connection failures;
* disabled rate limiting;
* HTTP `429` status and response headers;
* trusted forwarding-header handling;
* preventing authentication and repository calls after a request is blocked.

## Validation note

`mvn -DskipTests compile` reaches compilation of the project sources but is blocked by a pre-existing issue on the clean upstream branch.

The project references missing `com.networknt.schema` classes in:

* `GroqResponseValidator`;
* `VakilFriendGroqValidatorService`.

No compiler errors were reported for `RedisRateLimitService` or `AuthController`, which are the production files changed by this PR.

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation/configuration
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

The final checkbox remains unchecked because the existing upstream compilation failure prevents the Maven test lifecycle from running successfully. The failure is unrelated to the files changed in this PR.
