### PR TITLE
feat(hearings): add waiting room and admission controls

### DIFF
--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HearingController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/HearingController.java
@@ -9,7 +9,6 @@ import com.nyaysetu.backend.service.HearingService;
 import com.nyaysetu.backend.notification.service.NotificationService;
 import com.nyaysetu.backend.notification.entity.Notification;
 import com.nyaysetu.backend.entity.CaseEntity;
-import com.nyaysetu.backend.entity.User;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -83,7 +82,6 @@ public class HearingController {
         response.put("id", hearing.getId());
         response.put("scheduledDate", hearing.getScheduledDate());
         response.put("status", hearing.getStatus().name());
-        response.put("videoRoomId", hearing.getVideoRoomId());
         response.put("durationMinutes", hearing.getDurationMinutes());
         if (hearing.getCaseEntity() != null) {
             response.put("caseId", hearing.getCaseEntity().getId());
@@ -133,22 +131,11 @@ public class HearingController {
             @PathVariable UUID hearingId,
             Authentication authentication
     ) {
-        Long userId = getCurrentUserId(authentication);
-        
-        if (!hearingService.canUserJoinHearing(hearingId, userId)) {
-            return ResponseEntity.status(403).body(Map.of("error", "Not authorized"));
-        }
-        
-        hearingService.joinHearing(hearingId, userId);
-        Hearing hearing = hearingService.getHearing(hearingId);
-        
-        return ResponseEntity.ok(Map.of(
-                "videoRoomId", hearing.getVideoRoomId(),
-                "hearingId", hearingId,
-                "status", hearing.getStatus()
+        return ResponseEntity.status(410).body(Map.of(
+                "error",
+                "Direct joining is disabled. Use the waiting-room join-request endpoint."
         ));
     }
-    
     @PostMapping("/{hearingId}/leave")
     public ResponseEntity<Void> leaveHearing(
             @PathVariable UUID hearingId,
@@ -218,7 +205,6 @@ public class HearingController {
             dto.put("scheduledDate", h.getScheduledDate());
             dto.put("durationMinutes", h.getDurationMinutes());
             dto.put("status", h.getStatus());
-            dto.put("videoRoomId", h.getVideoRoomId());
             dto.put("judgeNotes", h.getJudgeNotes());
             dto.put("createdAt", h.getCreatedAt());
             return dto;
@@ -239,7 +225,6 @@ public class HearingController {
                 hearingData.put("scheduledDate", h.getScheduledDate());
                 hearingData.put("durationMinutes", h.getDurationMinutes());
                 hearingData.put("status", h.getStatus().name());
-                hearingData.put("videoRoomId", h.getVideoRoomId());
                 hearingData.put("createdAt", h.getCreatedAt());
                 
                 if (h.getCaseEntity() != null) {

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VirtualHearingAccessController.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/controller/VirtualHearingAccessController.java
@@ -1,0 +1,218 @@
+package com.nyaysetu.backend.controller;
+
+import com.nyaysetu.backend.entity.Hearing;
+import com.nyaysetu.backend.entity.HearingParticipant;
+import com.nyaysetu.backend.service.VirtualHearingAccessService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/hearings")
+@RequiredArgsConstructor
+public class VirtualHearingAccessController {
+
+    private final VirtualHearingAccessService accessService;
+
+    @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
+    @PostMapping("/{hearingId}/start")
+    public ResponseEntity<Map<String, Object>> start(
+            @PathVariable UUID hearingId,
+            Authentication authentication
+    ) {
+        var result = accessService.startHearing(
+                hearingId,
+                authentication.getName()
+        );
+
+        return ResponseEntity.ok(Map.of(
+                "hearingId", result.hearingId(),
+                "status", result.status(),
+                "videoRoomId", result.videoRoomId()
+        ));
+    }
+
+    @PostMapping("/{hearingId}/join-request")
+    public ResponseEntity<Map<String, Object>> requestJoin(
+            @PathVariable UUID hearingId,
+            Authentication authentication
+    ) {
+        var result = accessService.requestJoin(
+                hearingId,
+                authentication.getName()
+        );
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("hearingId", hearingId);
+        body.put("status", result.status());
+        body.put("accessToken", result.accessToken());
+        body.put("expiresAt", result.expiresAt());
+        body.put(
+                "message",
+                result.status().name().equals("ADMITTED")
+                        ? "Access token refreshed"
+                        : "You are waiting for the judge to admit you"
+        );
+
+        return ResponseEntity.accepted()
+                .location(
+                        URI.create(
+                                "/hearings/" +
+                                        hearingId +
+                                        "/join-access"
+                        )
+                )
+                .body(body);
+    }
+
+    @GetMapping("/{hearingId}/join-access")
+    public ResponseEntity<Map<String, Object>> joinAccess(
+            @PathVariable UUID hearingId,
+            @RequestHeader("X-Hearing-Access-Token")
+            String accessToken,
+            Authentication authentication
+    ) {
+        var result = accessService.getJoinAccess(
+                hearingId,
+                authentication.getName(),
+                accessToken
+        );
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("hearingId", hearingId);
+        body.put("status", result.status());
+
+        if (result.videoRoomId() == null) {
+            body.put(
+                    "message",
+                    "Waiting for the judge to start the hearing and admit you"
+            );
+
+            return ResponseEntity.accepted().body(body);
+        }
+
+        body.put("videoRoomId", result.videoRoomId());
+        body.put("message", "You have been admitted");
+
+        return ResponseEntity.ok(body);
+    }
+
+    @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
+    @GetMapping("/{hearingId}/waiting-room")
+    public ResponseEntity<List<Map<String, Object>>> waitingRoom(
+            @PathVariable UUID hearingId,
+            Authentication authentication
+    ) {
+        List<Map<String, Object>> response =
+                accessService.getWaitingParticipants(
+                                hearingId,
+                                authentication.getName()
+                        )
+                        .stream()
+                        .map(this::toParticipantResponse)
+                        .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
+    @PostMapping(
+            "/{hearingId}/participants/{participantId}/admit"
+    )
+    public ResponseEntity<Map<String, Object>> admit(
+            @PathVariable UUID hearingId,
+            @PathVariable UUID participantId,
+            Authentication authentication
+    ) {
+        HearingParticipant participant =
+                accessService.admitParticipant(
+                        hearingId,
+                        participantId,
+                        authentication.getName()
+                );
+
+        return ResponseEntity.ok(
+                toParticipantResponse(participant)
+        );
+    }
+
+    @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
+    @PostMapping(
+            "/{hearingId}/participants/{participantId}/reject"
+    )
+    public ResponseEntity<Map<String, Object>> reject(
+            @PathVariable UUID hearingId,
+            @PathVariable UUID participantId,
+            Authentication authentication
+    ) {
+        HearingParticipant participant =
+                accessService.rejectParticipant(
+                        hearingId,
+                        participantId,
+                        authentication.getName()
+                );
+
+        return ResponseEntity.ok(
+                toParticipantResponse(participant)
+        );
+    }
+
+    @PreAuthorize("hasAnyRole('JUDGE', 'SUPER_JUDGE', 'ADMIN')")
+    @PostMapping("/{hearingId}/end")
+    public ResponseEntity<Map<String, Object>> end(
+            @PathVariable UUID hearingId,
+            Authentication authentication
+    ) {
+        Hearing hearing = accessService.endHearing(
+                hearingId,
+                authentication.getName()
+        );
+
+        return ResponseEntity.ok(Map.of(
+                "hearingId", hearing.getId(),
+                "status", hearing.getStatus(),
+                "message", "Hearing ended and all access tokens expired"
+        ));
+    }
+
+    private Map<String, Object> toParticipantResponse(
+            HearingParticipant participant
+    ) {
+        Map<String, Object> response = new LinkedHashMap<>();
+
+        response.put("participantId", participant.getId());
+        response.put("role", participant.getRole());
+        response.put(
+                "status",
+                participant.getAdmissionStatus()
+        );
+        response.put("requestedAt", participant.getRequestedAt());
+        response.put("admittedAt", participant.getAdmittedAt());
+        response.put("rejectedAt", participant.getRejectedAt());
+
+        if (participant.getUser() != null) {
+            response.put(
+                    "userId",
+                    participant.getUser().getId()
+            );
+            response.put(
+                    "name",
+                    participant.getUser().getName()
+            );
+            response.put(
+                    "email",
+                    participant.getUser().getEmail()
+            );
+        }
+
+        return response;
+    }
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/Hearing.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/Hearing.java
@@ -1,5 +1,6 @@
 package com.nyaysetu.backend.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,7 @@ public class Hearing {
     @Column(name = "duration_minutes")
     private Integer durationMinutes = 60;
     
+    @JsonIgnore
     @Column(name = "video_room_id", unique = true, nullable = false)
     private String videoRoomId;
     

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/HearingParticipant.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/HearingParticipant.java
@@ -1,5 +1,6 @@
 package com.nyaysetu.backend.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,46 +17,73 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class HearingParticipant {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hearing_id", nullable = false)
     private Hearing hearing;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private ParticipantRole role;
-    
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "admission_status", nullable = false)
+    private ParticipantAdmissionStatus admissionStatus =
+            ParticipantAdmissionStatus.INVITED;
+
+    @JsonIgnore
+    @Column(name = "access_token_hash", length = 64)
+    private String accessTokenHash;
+
+    @JsonIgnore
+    @Column(name = "access_token_expires_at")
+    private LocalDateTime accessTokenExpiresAt;
+
+    @Column(name = "requested_at")
+    private LocalDateTime requestedAt;
+
+    @Column(name = "admitted_at")
+    private LocalDateTime admittedAt;
+
+    @Column(name = "rejected_at")
+    private LocalDateTime rejectedAt;
+
     @Column(name = "joined_at")
     private LocalDateTime joinedAt;
-    
+
     @Column(name = "left_at")
     private LocalDateTime leftAt;
-    
+
     @Builder.Default
     @Column(name = "can_speak")
     private Boolean canSpeak = true;
-    
+
     @Builder.Default
     @Column(name = "is_video_on")
     private Boolean isVideoOn = true;
-    
+
     @Builder.Default
     @Column(name = "is_audio_on")
     private Boolean isAudioOn = true;
-    
+
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
-    
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
+
+        if (admissionStatus == null) {
+            admissionStatus = ParticipantAdmissionStatus.INVITED;
+        }
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/ParticipantAdmissionStatus.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/entity/ParticipantAdmissionStatus.java
@@ -1,0 +1,9 @@
+package com.nyaysetu.backend.entity;
+
+public enum ParticipantAdmissionStatus {
+    INVITED,
+    WAITING,
+    ADMITTED,
+    REJECTED,
+    EXPIRED
+}

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/HearingParticipantRepository.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/repository/HearingParticipantRepository.java
@@ -1,7 +1,9 @@
 package com.nyaysetu.backend.repository;
 
 import com.nyaysetu.backend.entity.HearingParticipant;
+import com.nyaysetu.backend.entity.ParticipantAdmissionStatus;
 import com.nyaysetu.backend.entity.ParticipantRole;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,15 +12,31 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface HearingParticipantRepository extends JpaRepository<HearingParticipant, UUID> {
-    
+public interface HearingParticipantRepository
+        extends JpaRepository<HearingParticipant, UUID> {
+
     List<HearingParticipant> findByHearingId(UUID hearingId);
-    
+
     List<HearingParticipant> findByUserId(Long userId);
-    
-    Optional<HearingParticipant> findByHearingIdAndUserId(UUID hearingId, Long userId);
-    
-    List<HearingParticipant> findByHearingIdAndRole(UUID hearingId, ParticipantRole role);
-    
-    boolean existsByHearingIdAndUserId(UUID hearingId, Long userId);
+
+    Optional<HearingParticipant> findByHearingIdAndUserId(
+            UUID hearingId,
+            Long userId
+    );
+
+    List<HearingParticipant> findByHearingIdAndRole(
+            UUID hearingId,
+            ParticipantRole role
+    );
+
+    @EntityGraph(attributePaths = "user")
+    List<HearingParticipant> findByHearingIdAndAdmissionStatus(
+            UUID hearingId,
+            ParticipantAdmissionStatus admissionStatus
+    );
+
+    boolean existsByHearingIdAndUserId(
+            UUID hearingId,
+            Long userId
+    );
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/HearingService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/HearingService.java
@@ -82,6 +82,7 @@ public class HearingService {
                 .hearing(hearing)
                 .user(User.builder().id(userId).build())
                 .role(role)
+                .admissionStatus(ParticipantAdmissionStatus.INVITED)
                 .canSpeak(true)
                 .isVideoOn(true)
                 .isAudioOn(true)
@@ -94,18 +95,33 @@ public class HearingService {
     public void joinHearing(UUID hearingId, Long userId) {
         HearingParticipant participant = participantRepository
                 .findByHearingIdAndUserId(hearingId, userId)
-                .orElseThrow(() -> new RuntimeException("User not authorized for this hearing"));
-        
+                .orElseThrow(() ->
+                        new RuntimeException(
+                                "User not authorized for this hearing"
+                        )
+                );
+
+        Hearing hearing = hearingRepository.findById(hearingId)
+                .orElseThrow(() ->
+                        new RuntimeException("Hearing not found")
+                );
+
+        if (participant.getAdmissionStatus() !=
+                ParticipantAdmissionStatus.ADMITTED) {
+            throw new RuntimeException(
+                    "Participant has not been admitted"
+            );
+        }
+
+        if (hearing.getStatus() != HearingStatus.IN_PROGRESS) {
+            throw new RuntimeException(
+                    "The judge has not started the hearing"
+            );
+        }
+
         participant.setJoinedAt(LocalDateTime.now());
         participantRepository.save(participant);
-        
-        Hearing hearing = hearingRepository.findById(hearingId).orElseThrow();
-        if (hearing.getStatus() == HearingStatus.SCHEDULED) {
-            hearing.setStatus(HearingStatus.IN_PROGRESS);
-            hearingRepository.save(hearing);
-        }
     }
-    
     @Transactional
     public void leaveHearing(UUID hearingId, Long userId) {
         HearingParticipant participant = participantRepository
@@ -220,6 +236,19 @@ public class HearingService {
     }
 
     public boolean canUserJoinHearing(UUID hearingId, Long userId) {
-        return participantRepository.existsByHearingIdAndUserId(hearingId, userId);
+        HearingParticipant participant = participantRepository
+                .findByHearingIdAndUserId(hearingId, userId)
+                .orElse(null);
+
+        if (participant == null ||
+                participant.getAdmissionStatus() !=
+                        ParticipantAdmissionStatus.ADMITTED) {
+            return false;
+        }
+
+        Hearing hearing = participant.getHearing();
+
+        return hearing != null &&
+                hearing.getStatus() == HearingStatus.IN_PROGRESS;
     }
 }

--- a/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VirtualHearingAccessService.java
+++ b/backend/nyaysetu-backend/src/main/java/com/nyaysetu/backend/service/VirtualHearingAccessService.java
@@ -1,0 +1,504 @@
+package com.nyaysetu.backend.service;
+
+import com.nyaysetu.backend.entity.*;
+import com.nyaysetu.backend.repository.HearingParticipantRepository;
+import com.nyaysetu.backend.repository.HearingRepository;
+import com.nyaysetu.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class VirtualHearingAccessService {
+
+    private static final SecureRandom SECURE_RANDOM =
+            new SecureRandom();
+
+    private final HearingRepository hearingRepository;
+    private final HearingParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public JudgeAccessResult startHearing(
+            UUID hearingId,
+            String judgeEmail
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User judge = requireUser(judgeEmail);
+
+        requireJudgeAccess(hearing, judge);
+
+        if (hearing.getStatus() == HearingStatus.COMPLETED ||
+                hearing.getStatus() == HearingStatus.CANCELLED) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "The hearing has already ended"
+            );
+        }
+
+        hearing.setStatus(HearingStatus.IN_PROGRESS);
+        hearingRepository.save(hearing);
+
+        return new JudgeAccessResult(
+                hearing.getId(),
+                hearing.getVideoRoomId(),
+                hearing.getStatus()
+        );
+    }
+
+    @Transactional
+    public JoinRequestResult requestJoin(
+            UUID hearingId,
+            String userEmail
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User user = requireUser(userEmail);
+
+        if (hearing.getStatus() == HearingStatus.COMPLETED ||
+                hearing.getStatus() == HearingStatus.CANCELLED) {
+            throw new ResponseStatusException(
+                    HttpStatus.GONE,
+                    "The hearing is no longer available"
+            );
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        int durationMinutes =
+                hearing.getDurationMinutes() == null
+                        ? 60
+                        : hearing.getDurationMinutes();
+
+        LocalDateTime earliestRequestTime =
+                hearing.getScheduledDate().minusMinutes(15);
+
+        LocalDateTime latestAccessTime =
+                hearing.getScheduledDate()
+                        .plusMinutes(durationMinutes + 30L);
+
+        if (hearing.getStatus() == HearingStatus.SCHEDULED &&
+                now.isBefore(earliestRequestTime)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "The waiting room opens 15 minutes before the hearing"
+            );
+        }
+
+        if (!latestAccessTime.isAfter(now)) {
+            throw new ResponseStatusException(
+                    HttpStatus.GONE,
+                    "The hearing access window has expired"
+            );
+        }
+
+        HearingParticipant participant = participantRepository
+                .findByHearingIdAndUserId(hearingId, user.getId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.FORBIDDEN,
+                        "You are not an invited participant"
+                ));
+
+        ParticipantAdmissionStatus currentStatus =
+                participant.getAdmissionStatus();
+
+        if (currentStatus == ParticipantAdmissionStatus.REJECTED) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Your request to join was rejected"
+            );
+        }
+
+        if (currentStatus == ParticipantAdmissionStatus.EXPIRED) {
+            throw new ResponseStatusException(
+                    HttpStatus.GONE,
+                    "Your hearing access has expired"
+            );
+        }
+
+        String rawToken = generateAccessToken();
+
+        participant.setAccessTokenHash(hashToken(rawToken));
+        participant.setAccessTokenExpiresAt(
+                calculateTokenExpiry(hearing)
+        );
+        participant.setRequestedAt(now);
+        participant.setRejectedAt(null);
+
+        if (currentStatus != ParticipantAdmissionStatus.ADMITTED) {
+            participant.setAdmissionStatus(
+                    ParticipantAdmissionStatus.WAITING
+            );
+            participant.setAdmittedAt(null);
+        }
+
+        participantRepository.save(participant);
+
+        return new JoinRequestResult(
+                rawToken,
+                participant.getAdmissionStatus(),
+                participant.getAccessTokenExpiresAt()
+        );
+    }
+
+    @Transactional
+    public JoinAccessResult getJoinAccess(
+            UUID hearingId,
+            String userEmail,
+            String accessToken
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User user = requireUser(userEmail);
+
+        HearingParticipant participant = participantRepository
+                .findByHearingIdAndUserId(hearingId, user.getId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.FORBIDDEN,
+                        "You are not an invited participant"
+                ));
+
+        verifyAccessToken(participant, accessToken);
+
+        if (hearing.getStatus() == HearingStatus.COMPLETED ||
+                hearing.getStatus() == HearingStatus.CANCELLED) {
+            expireParticipant(participant);
+
+            throw new ResponseStatusException(
+                    HttpStatus.GONE,
+                    "The hearing has ended"
+            );
+        }
+
+        if (participant.getAdmissionStatus() ==
+                ParticipantAdmissionStatus.REJECTED) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Your request to join was rejected"
+            );
+        }
+
+        if (participant.getAdmissionStatus() !=
+                ParticipantAdmissionStatus.ADMITTED ||
+                hearing.getStatus() != HearingStatus.IN_PROGRESS) {
+            return new JoinAccessResult(
+                    participant.getAdmissionStatus(),
+                    null
+            );
+        }
+
+        if (participant.getJoinedAt() == null) {
+            participant.setJoinedAt(LocalDateTime.now());
+            participantRepository.save(participant);
+        }
+
+        return new JoinAccessResult(
+                participant.getAdmissionStatus(),
+                hearing.getVideoRoomId()
+        );
+    }
+
+    public List<HearingParticipant> getWaitingParticipants(
+            UUID hearingId,
+            String judgeEmail
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User judge = requireUser(judgeEmail);
+
+        requireJudgeAccess(hearing, judge);
+
+        return participantRepository
+                .findByHearingIdAndAdmissionStatus(
+                        hearingId,
+                        ParticipantAdmissionStatus.WAITING
+                );
+    }
+
+    @Transactional
+    public HearingParticipant admitParticipant(
+            UUID hearingId,
+            UUID participantId,
+            String judgeEmail
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User judge = requireUser(judgeEmail);
+
+        requireJudgeAccess(hearing, judge);
+
+        if (hearing.getStatus() != HearingStatus.IN_PROGRESS) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Start the hearing before admitting participants"
+            );
+        }
+
+        HearingParticipant participant =
+                requireParticipant(hearingId, participantId);
+
+        if (participant.getAdmissionStatus() !=
+                ParticipantAdmissionStatus.WAITING) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "The participant is not waiting"
+            );
+        }
+
+        participant.setAdmissionStatus(
+                ParticipantAdmissionStatus.ADMITTED
+        );
+        participant.setAdmittedAt(LocalDateTime.now());
+        participant.setRejectedAt(null);
+
+        return participantRepository.save(participant);
+    }
+
+    @Transactional
+    public HearingParticipant rejectParticipant(
+            UUID hearingId,
+            UUID participantId,
+            String judgeEmail
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User judge = requireUser(judgeEmail);
+
+        requireJudgeAccess(hearing, judge);
+
+        HearingParticipant participant =
+                requireParticipant(hearingId, participantId);
+
+        if (participant.getAdmissionStatus() !=
+                ParticipantAdmissionStatus.WAITING) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "The participant is not waiting"
+            );
+        }
+
+        participant.setAdmissionStatus(
+                ParticipantAdmissionStatus.REJECTED
+        );
+        participant.setRejectedAt(LocalDateTime.now());
+
+        // Keep the participant token valid until its normal expiry so the
+        // client can securely poll and receive the rejected status.
+        return participantRepository.save(participant);
+    }
+
+    @Transactional
+    public Hearing endHearing(
+            UUID hearingId,
+            String judgeEmail
+    ) {
+        Hearing hearing = requireHearing(hearingId);
+        User judge = requireUser(judgeEmail);
+
+        requireJudgeAccess(hearing, judge);
+
+        hearing.setStatus(HearingStatus.COMPLETED);
+        hearingRepository.save(hearing);
+
+        List<HearingParticipant> participants =
+                participantRepository.findByHearingId(hearingId);
+
+        for (HearingParticipant participant : participants) {
+            expireParticipant(participant);
+        }
+
+        participantRepository.saveAll(participants);
+
+        return hearing;
+    }
+
+    private HearingParticipant requireParticipant(
+            UUID hearingId,
+            UUID participantId
+    ) {
+        HearingParticipant participant = participantRepository
+                .findById(participantId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Participant not found"
+                ));
+
+        if (participant.getHearing() == null ||
+                !hearingId.equals(
+                        participant.getHearing().getId()
+                )) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "Participant not found for this hearing"
+            );
+        }
+
+        return participant;
+    }
+
+    private Hearing requireHearing(UUID hearingId) {
+        return hearingRepository.findById(hearingId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Hearing not found"
+                ));
+    }
+
+    private User requireUser(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        "Authenticated user was not found"
+                ));
+    }
+
+    private void requireJudgeAccess(
+            Hearing hearing,
+            User user
+    ) {
+        String role = user.getRole().name();
+
+        if ("ADMIN".equals(role) ||
+                "SUPER_JUDGE".equals(role)) {
+            return;
+        }
+
+        if (!"JUDGE".equals(role)) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Judge access is required"
+            );
+        }
+
+        Long assignedJudgeId =
+                hearing.getCaseEntity() == null
+                        ? null
+                        : hearing.getCaseEntity().getJudgeId();
+
+        if (assignedJudgeId == null ||
+                !assignedJudgeId.equals(user.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Only the assigned judge can manage this hearing"
+            );
+        }
+    }
+
+    private void verifyAccessToken(
+            HearingParticipant participant,
+            String rawToken
+    ) {
+        if (rawToken == null || rawToken.isBlank() ||
+                participant.getAccessTokenHash() == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Invalid participant access token"
+            );
+        }
+
+        String suppliedHash = hashToken(rawToken);
+
+        boolean matches = MessageDigest.isEqual(
+                participant.getAccessTokenHash().getBytes(
+                        StandardCharsets.UTF_8
+                ),
+                suppliedHash.getBytes(StandardCharsets.UTF_8)
+        );
+
+        if (!matches) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Invalid participant access token"
+            );
+        }
+
+        LocalDateTime expiresAt =
+                participant.getAccessTokenExpiresAt();
+
+        if (expiresAt == null ||
+                !expiresAt.isAfter(LocalDateTime.now())) {
+            expireParticipant(participant);
+            participantRepository.save(participant);
+
+            throw new ResponseStatusException(
+                    HttpStatus.GONE,
+                    "Participant access token has expired"
+            );
+        }
+    }
+
+    private LocalDateTime calculateTokenExpiry(
+            Hearing hearing
+    ) {
+        int duration = hearing.getDurationMinutes() == null
+                ? 60
+                : hearing.getDurationMinutes();
+
+        return hearing.getScheduledDate()
+                .plusMinutes(duration + 30L);
+    }
+    private void expireParticipant(
+            HearingParticipant participant
+    ) {
+        participant.setAdmissionStatus(
+                ParticipantAdmissionStatus.EXPIRED
+        );
+        participant.setAccessTokenHash(null);
+        participant.setAccessTokenExpiresAt(LocalDateTime.now());
+    }
+
+    private String generateAccessToken() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(bytes);
+    }
+
+    private String hashToken(String rawToken) {
+        try {
+            MessageDigest digest =
+                    MessageDigest.getInstance("SHA-256");
+
+            return java.util.HexFormat.of().formatHex(
+                    digest.digest(
+                            rawToken.getBytes(
+                                    StandardCharsets.UTF_8
+                            )
+                    )
+            );
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(
+                    "SHA-256 is unavailable",
+                    ex
+            );
+        }
+    }
+
+    public record JudgeAccessResult(
+            UUID hearingId,
+            String videoRoomId,
+            HearingStatus status
+    ) {
+    }
+
+    public record JoinRequestResult(
+            String accessToken,
+            ParticipantAdmissionStatus status,
+            LocalDateTime expiresAt
+    ) {
+    }
+
+    public record JoinAccessResult(
+            ParticipantAdmissionStatus status,
+            String videoRoomId
+    ) {
+    }
+}

--- a/backend/nyaysetu-backend/src/main/resources/db/migration/V54__add_virtual_hearing_waiting_room.sql
+++ b/backend/nyaysetu-backend/src/main/resources/db/migration/V54__add_virtual_hearing_waiting_room.sql
@@ -1,0 +1,28 @@
+ALTER TABLE hearing_participants
+ADD COLUMN IF NOT EXISTS admission_status VARCHAR(20) NOT NULL DEFAULT 'INVITED';
+
+ALTER TABLE hearing_participants
+ADD COLUMN IF NOT EXISTS access_token_hash VARCHAR(64);
+
+ALTER TABLE hearing_participants
+ADD COLUMN IF NOT EXISTS access_token_expires_at TIMESTAMP;
+
+ALTER TABLE hearing_participants
+ADD COLUMN IF NOT EXISTS requested_at TIMESTAMP;
+
+ALTER TABLE hearing_participants
+ADD COLUMN IF NOT EXISTS admitted_at TIMESTAMP;
+
+ALTER TABLE hearing_participants
+ADD COLUMN IF NOT EXISTS rejected_at TIMESTAMP;
+
+UPDATE hearing_participants
+SET admission_status = 'INVITED'
+WHERE admission_status IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_hearing_participants_admission_status
+ON hearing_participants(hearing_id, admission_status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_hearing_participants_access_token_hash
+ON hearing_participants(access_token_hash)
+WHERE access_token_hash IS NOT NULL;

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/HearingControllerTest.java
@@ -20,24 +20,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class HearingControllerTest {
 
     @Test
-    void joinHearingResolvesEmailPrincipalToUserId() {
+    void directJoinEndpointIsDisabled() {
         UUID hearingId = UUID.randomUUID();
-        FakeHearingService hearingService = new FakeHearingService(hearingId);
+
         HearingController controller = new HearingController(
-                hearingService,
+                new FakeHearingService(hearingId),
                 new FakeNotificationService(),
                 new FakeAuthService(),
                 new FakeCaseAccessService()
         );
 
-        ResponseEntity<Map<String, Object>> response = controller.joinHearing(
-                hearingId,
-                new TestingAuthenticationToken("litigant@example.com", null)
-        );
+        ResponseEntity<Map<String, Object>> response =
+                controller.joinHearing(
+                        hearingId,
+                        new TestingAuthenticationToken(
+                                "litigant@example.com",
+                                null
+                        )
+                );
 
-        assertEquals(200, response.getStatusCode().value());
-        assertEquals(42L, hearingService.authorizedUserId);
-        assertEquals(42L, hearingService.joinedUserId);
+        assertEquals(410, response.getStatusCode().value());
+        assertEquals(
+                "Direct joining is disabled. Use the waiting-room join-request endpoint.",
+                response.getBody().get("error")
+        );
     }
 
     @Test

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/VirtualHearingAccessControllerTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/controller/VirtualHearingAccessControllerTest.java
@@ -1,0 +1,139 @@
+package com.nyaysetu.backend.controller;
+
+import com.nyaysetu.backend.entity.HearingStatus;
+import com.nyaysetu.backend.entity.ParticipantAdmissionStatus;
+import com.nyaysetu.backend.service.VirtualHearingAccessService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VirtualHearingAccessControllerTest {
+
+    @Mock
+    private VirtualHearingAccessService accessService;
+
+    private VirtualHearingAccessController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new VirtualHearingAccessController(
+                accessService
+        );
+    }
+
+    @Test
+    void waitingResponseDoesNotExposeRoomId() {
+        UUID hearingId = UUID.randomUUID();
+
+        when(accessService.requestJoin(
+                hearingId,
+                "party@example.com"
+        )).thenReturn(
+                new VirtualHearingAccessService.JoinRequestResult(
+                        "participant-token",
+                        ParticipantAdmissionStatus.WAITING,
+                        LocalDateTime.now().plusHours(1)
+                )
+        );
+
+        var response = controller.requestJoin(
+                hearingId,
+                new TestingAuthenticationToken(
+                        "party@example.com",
+                        null
+                )
+        );
+
+        assertEquals(202, response.getStatusCode().value());
+        assertEquals(
+                ParticipantAdmissionStatus.WAITING,
+                response.getBody().get("status")
+        );
+        assertFalse(
+                response.getBody().containsKey("videoRoomId")
+        );
+    }
+
+    @Test
+    void joinAccessExposesRoomOnlyAfterAdmission() {
+        UUID hearingId = UUID.randomUUID();
+
+        when(accessService.getJoinAccess(
+                hearingId,
+                "party@example.com",
+                "participant-token"
+        )).thenReturn(
+                new VirtualHearingAccessService.JoinAccessResult(
+                        ParticipantAdmissionStatus.ADMITTED,
+                        "secure-room-id"
+                )
+        );
+
+        var response = controller.joinAccess(
+                hearingId,
+                "participant-token",
+                new TestingAuthenticationToken(
+                        "party@example.com",
+                        null
+                )
+        );
+
+        Map<String, Object> body = response.getBody();
+
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(body);
+        assertEquals(
+                ParticipantAdmissionStatus.ADMITTED,
+                body.get("status")
+        );
+        assertEquals(
+                "secure-room-id",
+                body.get("videoRoomId")
+        );
+    }
+
+    @Test
+    void startReturnsRoomToJudge() {
+        UUID hearingId = UUID.randomUUID();
+
+        when(accessService.startHearing(
+                hearingId,
+                "judge@example.com"
+        )).thenReturn(
+                new VirtualHearingAccessService.JudgeAccessResult(
+                        hearingId,
+                        "judge-room-id",
+                        HearingStatus.IN_PROGRESS
+                )
+        );
+
+        var response = controller.start(
+                hearingId,
+                new TestingAuthenticationToken(
+                        "judge@example.com",
+                        null
+                )
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(
+                "judge-room-id",
+                response.getBody().get("videoRoomId")
+        );
+        assertEquals(
+                HearingStatus.IN_PROGRESS,
+                response.getBody().get("status")
+        );
+    }
+}

--- a/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/VirtualHearingAccessServiceTest.java
+++ b/backend/nyaysetu-backend/src/test/java/com/nyaysetu/backend/service/VirtualHearingAccessServiceTest.java
@@ -1,0 +1,422 @@
+package com.nyaysetu.backend.service;
+
+import com.nyaysetu.backend.entity.CaseEntity;
+import com.nyaysetu.backend.entity.Hearing;
+import com.nyaysetu.backend.entity.HearingParticipant;
+import com.nyaysetu.backend.entity.HearingStatus;
+import com.nyaysetu.backend.entity.ParticipantAdmissionStatus;
+import com.nyaysetu.backend.entity.Role;
+import com.nyaysetu.backend.entity.User;
+import com.nyaysetu.backend.repository.HearingParticipantRepository;
+import com.nyaysetu.backend.repository.HearingRepository;
+import com.nyaysetu.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VirtualHearingAccessServiceTest {
+
+    @Mock
+    private HearingRepository hearingRepository;
+
+    @Mock
+    private HearingParticipantRepository participantRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private VirtualHearingAccessService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VirtualHearingAccessService(
+                hearingRepository,
+                participantRepository,
+                userRepository
+        );
+
+        lenient().when(hearingRepository.save(any(Hearing.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        lenient().when(participantRepository.save(any(HearingParticipant.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void joinRequestPlacesInvitedParticipantInWaitingRoom() {
+        UUID hearingId = UUID.randomUUID();
+        User participantUser = user(
+                20L,
+                "party@example.com",
+                Role.LITIGANT
+        );
+
+        Hearing hearing = hearing(
+                hearingId,
+                HearingStatus.SCHEDULED,
+                10L
+        );
+
+        HearingParticipant participant = HearingParticipant.builder()
+                .id(UUID.randomUUID())
+                .hearing(hearing)
+                .user(participantUser)
+                .admissionStatus(
+                        ParticipantAdmissionStatus.INVITED
+                )
+                .build();
+
+        lenient().when(hearingRepository.findById(hearingId))
+                .thenReturn(Optional.of(hearing));
+
+        lenient().when(userRepository.findByEmail("party@example.com"))
+                .thenReturn(Optional.of(participantUser));
+
+        lenient().when(participantRepository.findByHearingIdAndUserId(
+                hearingId,
+                20L
+        )).thenReturn(Optional.of(participant));
+
+        var result = service.requestJoin(
+                hearingId,
+                "party@example.com"
+        );
+
+        assertEquals(
+                ParticipantAdmissionStatus.WAITING,
+                result.status()
+        );
+        assertNotNull(result.accessToken());
+        assertFalse(result.accessToken().isBlank());
+        assertNotNull(participant.getAccessTokenHash());
+        assertEquals(64, participant.getAccessTokenHash().length());
+        assertNotEquals(
+                result.accessToken(),
+                participant.getAccessTokenHash()
+        );
+        assertNotNull(participant.getRequestedAt());
+        assertNotNull(participant.getAccessTokenExpiresAt());
+    }
+
+    @Test
+    void participantReceivesRoomOnlyAfterJudgeAdmitsThem() {
+        UUID hearingId = UUID.randomUUID();
+        UUID participantId = UUID.randomUUID();
+
+        User judge = user(
+                10L,
+                "judge@example.com",
+                Role.JUDGE
+        );
+
+        User participantUser = user(
+                20L,
+                "party@example.com",
+                Role.LITIGANT
+        );
+
+        Hearing hearing = hearing(
+                hearingId,
+                HearingStatus.SCHEDULED,
+                10L
+        );
+
+        HearingParticipant participant = HearingParticipant.builder()
+                .id(participantId)
+                .hearing(hearing)
+                .user(participantUser)
+                .admissionStatus(
+                        ParticipantAdmissionStatus.INVITED
+                )
+                .build();
+
+        lenient().when(hearingRepository.findById(hearingId))
+                .thenReturn(Optional.of(hearing));
+
+        lenient().when(userRepository.findByEmail("party@example.com"))
+                .thenReturn(Optional.of(participantUser));
+
+        lenient().when(userRepository.findByEmail("judge@example.com"))
+                .thenReturn(Optional.of(judge));
+
+        lenient().when(participantRepository.findByHearingIdAndUserId(
+                hearingId,
+                20L
+        )).thenReturn(Optional.of(participant));
+
+        lenient().when(participantRepository.findById(participantId))
+                .thenReturn(Optional.of(participant));
+
+        var requestResult = service.requestJoin(
+                hearingId,
+                "party@example.com"
+        );
+
+        var waitingResult = service.getJoinAccess(
+                hearingId,
+                "party@example.com",
+                requestResult.accessToken()
+        );
+
+        assertEquals(
+                ParticipantAdmissionStatus.WAITING,
+                waitingResult.status()
+        );
+        assertNull(waitingResult.videoRoomId());
+
+        service.startHearing(
+                hearingId,
+                "judge@example.com"
+        );
+
+        service.admitParticipant(
+                hearingId,
+                participantId,
+                "judge@example.com"
+        );
+
+        var admittedResult = service.getJoinAccess(
+                hearingId,
+                "party@example.com",
+                requestResult.accessToken()
+        );
+
+        assertEquals(
+                ParticipantAdmissionStatus.ADMITTED,
+                admittedResult.status()
+        );
+        assertEquals(
+                hearing.getVideoRoomId(),
+                admittedResult.videoRoomId()
+        );
+    }
+
+    @Test
+    void nonJudgeCannotStartHearing() {
+        UUID hearingId = UUID.randomUUID();
+
+        User litigant = user(
+                20L,
+                "party@example.com",
+                Role.LITIGANT
+        );
+
+        Hearing hearing = hearing(
+                hearingId,
+                HearingStatus.SCHEDULED,
+                10L
+        );
+
+        lenient().when(hearingRepository.findById(hearingId))
+                .thenReturn(Optional.of(hearing));
+
+        lenient().when(userRepository.findByEmail("party@example.com"))
+                .thenReturn(Optional.of(litigant));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> service.startHearing(
+                        hearingId,
+                        "party@example.com"
+                )
+        );
+
+        assertEquals(
+                HttpStatus.FORBIDDEN,
+                exception.getStatusCode()
+        );
+
+        assertEquals(
+                HearingStatus.SCHEDULED,
+                hearing.getStatus()
+        );
+    }
+
+    @Test
+    void endingHearingExpiresAllParticipantTokens() {
+        UUID hearingId = UUID.randomUUID();
+
+        User judge = user(
+                10L,
+                "judge@example.com",
+                Role.JUDGE
+        );
+
+        Hearing hearing = hearing(
+                hearingId,
+                HearingStatus.IN_PROGRESS,
+                10L
+        );
+
+        HearingParticipant participant = HearingParticipant.builder()
+                .id(UUID.randomUUID())
+                .hearing(hearing)
+                .admissionStatus(
+                        ParticipantAdmissionStatus.ADMITTED
+                )
+                .accessTokenHash("temporary-token-hash")
+                .accessTokenExpiresAt(
+                        LocalDateTime.now().plusHours(1)
+                )
+                .build();
+
+        lenient().when(hearingRepository.findById(hearingId))
+                .thenReturn(Optional.of(hearing));
+
+        lenient().when(userRepository.findByEmail("judge@example.com"))
+                .thenReturn(Optional.of(judge));
+
+        lenient().when(participantRepository.findByHearingId(hearingId))
+                .thenReturn(List.of(participant));
+
+        service.endHearing(
+                hearingId,
+                "judge@example.com"
+        );
+
+        assertEquals(
+                HearingStatus.COMPLETED,
+                hearing.getStatus()
+        );
+
+        assertEquals(
+                ParticipantAdmissionStatus.EXPIRED,
+                participant.getAdmissionStatus()
+        );
+
+        assertNull(participant.getAccessTokenHash());
+        assertNotNull(participant.getAccessTokenExpiresAt());
+
+        verify(participantRepository).saveAll(
+                List.of(participant)
+        );
+    }
+
+    @Test
+    void separateParticipantsReceiveDifferentAccessTokens() {
+        UUID hearingId = UUID.randomUUID();
+
+        Hearing hearing = hearing(
+                hearingId,
+                HearingStatus.SCHEDULED,
+                10L
+        );
+
+        User firstUser = user(
+                20L,
+                "first@example.com",
+                Role.LITIGANT
+        );
+
+        User secondUser = user(
+                21L,
+                "second@example.com",
+                Role.LITIGANT
+        );
+
+        HearingParticipant firstParticipant =
+                HearingParticipant.builder()
+                        .hearing(hearing)
+                        .user(firstUser)
+                        .admissionStatus(
+                                ParticipantAdmissionStatus.INVITED
+                        )
+                        .build();
+
+        HearingParticipant secondParticipant =
+                HearingParticipant.builder()
+                        .hearing(hearing)
+                        .user(secondUser)
+                        .admissionStatus(
+                                ParticipantAdmissionStatus.INVITED
+                        )
+                        .build();
+
+        lenient().when(hearingRepository.findById(hearingId))
+                .thenReturn(Optional.of(hearing));
+
+        lenient().when(userRepository.findByEmail("first@example.com"))
+                .thenReturn(Optional.of(firstUser));
+
+        lenient().when(userRepository.findByEmail("second@example.com"))
+                .thenReturn(Optional.of(secondUser));
+
+        lenient().when(participantRepository.findByHearingIdAndUserId(
+                hearingId,
+                20L
+        )).thenReturn(Optional.of(firstParticipant));
+
+        lenient().when(participantRepository.findByHearingIdAndUserId(
+                hearingId,
+                21L
+        )).thenReturn(Optional.of(secondParticipant));
+
+        String firstToken = service.requestJoin(
+                hearingId,
+                "first@example.com"
+        ).accessToken();
+
+        String secondToken = service.requestJoin(
+                hearingId,
+                "second@example.com"
+        ).accessToken();
+
+        assertNotEquals(firstToken, secondToken);
+        assertNotEquals(
+                firstParticipant.getAccessTokenHash(),
+                secondParticipant.getAccessTokenHash()
+        );
+    }
+
+    private Hearing hearing(
+            UUID hearingId,
+            HearingStatus status,
+            Long judgeId
+    ) {
+        CaseEntity caseEntity = mock(CaseEntity.class);
+
+        lenient().when(caseEntity.getJudgeId())
+                .thenReturn(judgeId);
+
+        return Hearing.builder()
+                .id(hearingId)
+                .caseEntity(caseEntity)
+                .scheduledDate(
+                        LocalDateTime.now().minusMinutes(1)
+                )
+                .durationMinutes(60)
+                .status(status)
+                .videoRoomId(
+                        "nyaysetu-hearing-" + hearingId
+                )
+                .build();
+    }
+
+    private User user(
+            Long id,
+            String email,
+            Role role
+    ) {
+        User user = mock(User.class);
+
+        lenient().when(user.getId()).thenReturn(id);
+        lenient().when(user.getEmail()).thenReturn(email);
+        lenient().when(user.getRole()).thenReturn(role);
+
+        return user;
+    }
+}

--- a/frontend/nyaysetu-frontend/src/hooks/useHearingAdmission.js
+++ b/frontend/nyaysetu-frontend/src/hooks/useHearingAdmission.js
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from 'react';
+import { hearingAPI } from '../services/api';
+
+const POLL_INTERVAL_MS = 3000;
+
+const tokenKey = (hearingId) =>
+    `nyaysetu-hearing-access:${hearingId}`;
+
+export function useHearingAdmission() {
+    const [activeCall, setActiveCall] = useState(null);
+    const [waitingHearing, setWaitingHearing] = useState(null);
+    const [admissionStatus, setAdmissionStatus] = useState(null);
+    const [admissionError, setAdmissionError] = useState('');
+    const [requesting, setRequesting] = useState(false);
+
+    const requestJoin = useCallback(async (hearing) => {
+        setRequesting(true);
+        setAdmissionError('');
+        setAdmissionStatus('REQUESTING');
+
+        try {
+            const response = await hearingAPI.requestJoin(hearing.id);
+            const { accessToken, status } = response.data;
+
+            if (!accessToken) {
+                throw new Error(
+                    'The server did not return a participant access token.'
+                );
+            }
+
+            sessionStorage.setItem(
+                tokenKey(hearing.id),
+                accessToken
+            );
+
+            setWaitingHearing(hearing);
+            setAdmissionStatus(status || 'WAITING');
+        } catch (error) {
+            const message =
+                error.response?.data?.message ||
+                error.response?.data?.detail ||
+                error.response?.data?.error ||
+                error.message ||
+                'Unable to request admission.';
+
+            setAdmissionError(message);
+            setAdmissionStatus('ERROR');
+        } finally {
+            setRequesting(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!waitingHearing) {
+            return undefined;
+        }
+
+        if (
+            admissionStatus === 'REJECTED' ||
+            admissionStatus === 'EXPIRED' ||
+            admissionStatus === 'ERROR'
+        ) {
+            return undefined;
+        }
+
+        let cancelled = false;
+
+        const checkAdmission = async () => {
+            const token = sessionStorage.getItem(
+                tokenKey(waitingHearing.id)
+            );
+
+            if (!token) {
+                if (!cancelled) {
+                    setAdmissionStatus('ERROR');
+                    setAdmissionError(
+                        'Your hearing access token is missing.'
+                    );
+                }
+
+                return;
+            }
+
+            try {
+                const response = await hearingAPI.getJoinAccess(
+                    waitingHearing.id,
+                    token
+                );
+
+                if (cancelled) {
+                    return;
+                }
+
+                const { status, videoRoomId } = response.data;
+
+                setAdmissionStatus(status);
+
+                if (status === 'ADMITTED' && videoRoomId) {
+                    setActiveCall({
+                        ...waitingHearing,
+                        room: videoRoomId,
+                        videoRoomId
+                    });
+
+                    setWaitingHearing(null);
+                }
+            } catch (error) {
+                if (cancelled) {
+                    return;
+                }
+
+                const message =
+                    error.response?.data?.message ||
+                    error.response?.data?.detail ||
+                    error.response?.data?.error ||
+                    error.message ||
+                    'Unable to check admission status.';
+
+                const normalizedMessage =
+                    message.toLowerCase();
+
+                if (normalizedMessage.includes('reject')) {
+                    setAdmissionStatus('REJECTED');
+                    sessionStorage.removeItem(
+                        tokenKey(waitingHearing.id)
+                    );
+                } else if (
+                    normalizedMessage.includes('expired') ||
+                    normalizedMessage.includes('ended') ||
+                    error.response?.status === 410
+                ) {
+                    setAdmissionStatus('EXPIRED');
+                    sessionStorage.removeItem(
+                        tokenKey(waitingHearing.id)
+                    );
+                } else {
+                    setAdmissionError(message);
+                }
+            }
+        };
+
+        checkAdmission();
+
+        const intervalId = window.setInterval(
+            checkAdmission,
+            POLL_INTERVAL_MS
+        );
+
+        return () => {
+            cancelled = true;
+            window.clearInterval(intervalId);
+        };
+    }, [waitingHearing, admissionStatus]);
+
+    const endCall = useCallback(() => {
+        setActiveCall(null);
+    }, []);
+
+    const cancelWaiting = useCallback(() => {
+        if (waitingHearing) {
+            sessionStorage.removeItem(
+                tokenKey(waitingHearing.id)
+            );
+        }
+
+        setWaitingHearing(null);
+        setAdmissionStatus(null);
+        setAdmissionError('');
+    }, [waitingHearing]);
+
+    return {
+        activeCall,
+        waitingHearing,
+        waitingHearingId: waitingHearing?.id ?? null,
+        admissionStatus,
+        admissionError,
+        requesting,
+        requestJoin,
+        endCall,
+        cancelWaiting
+    };
+}

--- a/frontend/nyaysetu-frontend/src/pages/judge/ConductHearingPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/judge/ConductHearingPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { judgeAPI, hearingAPI } from '../../services/api';
 import {
     Video,
@@ -23,6 +23,12 @@ export default function ConductHearingPage() {
     const [aiPrompt, setAiPrompt] = useState('');
     const [aiLoading, setAiLoading] = useState(false);
     const [showAiScheduler, setShowAiScheduler] = useState(false);
+    const [waitingParticipants, setWaitingParticipants] = useState([]);
+    const [waitingRoomLoading, setWaitingRoomLoading] = useState(false);
+    const [hearingActionError, setHearingActionError] = useState('');
+    const [startingHearingId, setStartingHearingId] = useState(null);
+    const [participantActionId, setParticipantActionId] = useState(null);
+    const [endingHearing, setEndingHearing] = useState(false);
 
     const handleAiSchedule = async (e) => {
         e.preventDefault();
@@ -63,16 +69,225 @@ export default function ConductHearingPage() {
         }
     };
 
-    const joinHearing = (hearing) => {
-        setActiveHearing(hearing);
-        setInCall(true);
+    const getActionError = (error, fallback) =>
+        error.response?.data?.message ||
+        error.response?.data?.detail ||
+        error.response?.data?.error ||
+        error.message ||
+        fallback;
+
+    const fetchWaitingParticipants = useCallback(
+        async (hearingId, showLoading = false) => {
+            if (!hearingId) {
+                return;
+            }
+
+            if (showLoading) {
+                setWaitingRoomLoading(true);
+            }
+
+            try {
+                const response =
+                    await hearingAPI.getWaitingRoom(hearingId);
+
+                setWaitingParticipants(
+                    Array.isArray(response.data)
+                        ? response.data
+                        : []
+                );
+
+                setHearingActionError('');
+            } catch (error) {
+                setHearingActionError(
+                    getActionError(
+                        error,
+                        'Unable to load the waiting room.'
+                    )
+                );
+            } finally {
+                if (showLoading) {
+                    setWaitingRoomLoading(false);
+                }
+            }
+        },
+        []
+    );
+
+    const startHearing = async (hearing) => {
+        setStartingHearingId(hearing.id);
+        setHearingActionError('');
+
+        try {
+            const response =
+                await hearingAPI.start(hearing.id);
+
+            const videoRoomId =
+                response.data?.videoRoomId;
+
+            if (!videoRoomId) {
+                throw new Error(
+                    'The server did not return the judge room.'
+                );
+            }
+
+            const startedHearing = {
+                ...hearing,
+                status:
+                    response.data?.status ||
+                    'IN_PROGRESS',
+                videoRoomId
+            };
+
+            setActiveHearing(startedHearing);
+            setInCall(true);
+
+            setHearings(current =>
+                current.map(item =>
+                    item.id === hearing.id
+                        ? {
+                            ...item,
+                            status: 'IN_PROGRESS'
+                        }
+                        : item
+                )
+            );
+        } catch (error) {
+            setHearingActionError(
+                getActionError(
+                    error,
+                    'Unable to start this hearing.'
+                )
+            );
+        } finally {
+            setStartingHearingId(null);
+        }
     };
 
-    const endCall = () => {
+    const admitParticipant = async (participantId) => {
+        if (!activeHearing) {
+            return;
+        }
+
+        setParticipantActionId(participantId);
+        setHearingActionError('');
+
+        try {
+            await hearingAPI.admitParticipant(
+                activeHearing.id,
+                participantId
+            );
+
+            await fetchWaitingParticipants(
+                activeHearing.id
+            );
+        } catch (error) {
+            setHearingActionError(
+                getActionError(
+                    error,
+                    'Unable to admit this participant.'
+                )
+            );
+        } finally {
+            setParticipantActionId(null);
+        }
+    };
+
+    const rejectParticipant = async (participantId) => {
+        if (!activeHearing) {
+            return;
+        }
+
+        setParticipantActionId(participantId);
+        setHearingActionError('');
+
+        try {
+            await hearingAPI.rejectParticipant(
+                activeHearing.id,
+                participantId
+            );
+
+            await fetchWaitingParticipants(
+                activeHearing.id
+            );
+        } catch (error) {
+            setHearingActionError(
+                getActionError(
+                    error,
+                    'Unable to reject this participant.'
+                )
+            );
+        } finally {
+            setParticipantActionId(null);
+        }
+    };
+
+    const leaveHearingView = () => {
         setInCall(false);
         setActiveHearing(null);
+        setWaitingParticipants([]);
+        setHearingActionError('');
     };
 
+    const endHearing = async () => {
+        if (!activeHearing) {
+            return;
+        }
+
+        setEndingHearing(true);
+        setHearingActionError('');
+
+        try {
+            await hearingAPI.end(activeHearing.id);
+
+            setHearings(current =>
+                current.map(item =>
+                    item.id === activeHearing.id
+                        ? {
+                            ...item,
+                            status: 'COMPLETED'
+                        }
+                        : item
+                )
+            );
+
+            leaveHearingView();
+        } catch (error) {
+            setHearingActionError(
+                getActionError(
+                    error,
+                    'Unable to end this hearing.'
+                )
+            );
+        } finally {
+            setEndingHearing(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!inCall || !activeHearing?.id) {
+            return undefined;
+        }
+
+        fetchWaitingParticipants(
+            activeHearing.id,
+            true
+        );
+
+        const intervalId = window.setInterval(
+            () =>
+                fetchWaitingParticipants(
+                    activeHearing.id
+                ),
+            3000
+        );
+
+        return () =>
+            window.clearInterval(intervalId);
+    }, [
+        inCall,
+        activeHearing?.id,
+        fetchWaitingParticipants
+    ]);
     const canJoin = (scheduledDate) => {
         const now = new Date();
         const hearingTime = new Date(scheduledDate);
@@ -133,7 +348,7 @@ export default function ConductHearingPage() {
                 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
                         <button
-                            onClick={endCall}
+                            onClick={leaveHearingView}
                             aria-label="Leave hearing"
                             style={{ background: 'rgba(239, 68, 68, 0.1)', border: 'none', color: '#ef4444', padding: '0.5rem', borderRadius: '0.5rem', cursor: 'pointer' }}
                         >
@@ -159,20 +374,322 @@ export default function ConductHearingPage() {
                     </div>
                 </div>
 
-                {/* Jitsi Video Container */}
-                <div style={{ flex: 1, position: 'relative', borderRadius: '1.5rem', overflow: 'hidden', border: 'var(--border-glass-strong)', boxShadow: 'var(--shadow-glass)' }}>
-                    <iframe
-                        src={`https://meet.jit.si/${activeHearing.videoRoomId}#config.prejoinConfig.enabled=false&config.startWithAudioMuted=false&config.startWithVideoMuted=false&interfaceConfig.TOOLBAR_BUTTONS=["microphone","camera","closedcaptions","desktop","embedmeeting","fullscreen","fodeviceselection","hangup","profile","chat","recording","livestreaming","etherpad","sharedvideo","settings","raisehand","videoquality","filmstrip","invite","feedback","stats","shortcuts","tileview","videobackgroundblur","download","help","mute-everyone","security"]`}
+                {/* Secure hearing room and judge waiting-room controls */}
+                <div
+                    style={{
+                        flex: 1,
+                        minHeight: 0,
+                        display: 'grid',
+                        gridTemplateColumns:
+                            'minmax(0, 1fr) 340px',
+                        gap: '1rem'
+                    }}
+                >
+                    <div
                         style={{
-                            width: '100%',
-                            height: '100%',
-                            border: 'none'
+                            position: 'relative',
+                            minHeight: 0,
+                            borderRadius: '1.5rem',
+                            overflow: 'hidden',
+                            border:
+                                'var(--border-glass-strong)',
+                            boxShadow:
+                                'var(--shadow-glass)'
                         }}
-                        allow="camera; microphone; fullscreen; display-capture; autoplay"
-                        title="Court Hearing"
-                    />
-                </div>
+                    >
+                        <iframe
+                            src={`https://meet.jit.si/${activeHearing.videoRoomId}#config.prejoinConfig.enabled=false&config.startWithAudioMuted=false&config.startWithVideoMuted=false&interfaceConfig.TOOLBAR_BUTTONS=["microphone","camera","closedcaptions","desktop","embedmeeting","fullscreen","fodeviceselection","hangup","profile","chat","recording","livestreaming","etherpad","sharedvideo","settings","raisehand","videoquality","filmstrip","invite","feedback","stats","shortcuts","tileview","videobackgroundblur","download","help","mute-everyone","security"]`}
+                            style={{
+                                width: '100%',
+                                height: '100%',
+                                border: 'none'
+                            }}
+                            allow="camera; microphone; fullscreen; display-capture; autoplay"
+                            title="Court Hearing"
+                        />
+                    </div>
 
+                    <aside
+                        style={{
+                            ...glassStyle,
+                            padding: '1rem',
+                            minHeight: 0,
+                            overflowY: 'auto',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '1rem'
+                        }}
+                    >
+                        <div
+                            style={{
+                                display: 'flex',
+                                justifyContent:
+                                    'space-between',
+                                alignItems: 'center',
+                                gap: '0.75rem'
+                            }}
+                        >
+                            <div>
+                                <h3
+                                    style={{
+                                        margin: 0,
+                                        color:
+                                            'var(--text-main)',
+                                        fontSize: '1rem'
+                                    }}
+                                >
+                                    Waiting Room
+                                </h3>
+
+                                <div
+                                    style={{
+                                        marginTop: '0.25rem',
+                                        color:
+                                            'var(--text-secondary)',
+                                        fontSize: '0.8rem'
+                                    }}
+                                >
+                                    {
+                                        waitingParticipants.length
+                                    } participant
+                                    {
+                                        waitingParticipants.length ===
+                                        1
+                                            ? ''
+                                            : 's'
+                                    } waiting
+                                </div>
+                            </div>
+
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    fetchWaitingParticipants(
+                                        activeHearing.id,
+                                        true
+                                    )
+                                }
+                                disabled={waitingRoomLoading}
+                                style={{
+                                    border:
+                                        'var(--border-glass)',
+                                    background:
+                                        'var(--bg-glass)',
+                                    color:
+                                        'var(--text-main)',
+                                    borderRadius: '0.6rem',
+                                    padding: '0.5rem',
+                                    cursor:
+                                        waitingRoomLoading
+                                            ? 'wait'
+                                            : 'pointer'
+                                }}
+                            >
+                                {waitingRoomLoading
+                                    ? '...'
+                                    : 'Refresh'}
+                            </button>
+                        </div>
+
+                        {hearingActionError && (
+                            <div
+                                role="alert"
+                                style={{
+                                    padding: '0.75rem',
+                                    borderRadius:
+                                        '0.75rem',
+                                    background:
+                                        'rgba(239, 68, 68, 0.1)',
+                                    border:
+                                        '1px solid rgba(239, 68, 68, 0.3)',
+                                    color: '#ef4444',
+                                    fontSize: '0.85rem'
+                                }}
+                            >
+                                {hearingActionError}
+                            </div>
+                        )}
+
+                        {waitingRoomLoading &&
+                        waitingParticipants.length === 0 ? (
+                            <div
+                                style={{
+                                    padding: '2rem 1rem',
+                                    textAlign: 'center',
+                                    color:
+                                        'var(--text-secondary)'
+                                }}
+                            >
+                                <Loader2
+                                    size={24}
+                                    className="spin"
+                                    style={{
+                                        margin:
+                                            '0 auto 0.75rem'
+                                    }}
+                                />
+
+                                Loading waiting room...
+                            </div>
+                        ) : waitingParticipants.length === 0 ? (
+                            <div
+                                style={{
+                                    padding: '2rem 1rem',
+                                    textAlign: 'center',
+                                    color:
+                                        'var(--text-secondary)',
+                                    border:
+                                        '1px dashed var(--border-glass)',
+                                    borderRadius: '0.75rem'
+                                }}
+                            >
+                                <Users
+                                    size={28}
+                                    style={{
+                                        margin:
+                                            '0 auto 0.75rem',
+                                        opacity: 0.6
+                                    }}
+                                />
+
+                                No participants are waiting.
+                            </div>
+                        ) : (
+                            waitingParticipants.map(
+                                participant => (
+                                    <div
+                                        key={
+                                            participant.participantId
+                                        }
+                                        style={{
+                                            padding: '0.85rem',
+                                            borderRadius:
+                                                '0.75rem',
+                                            border:
+                                                'var(--border-glass)',
+                                            background:
+                                                'var(--bg-glass)',
+                                            display: 'flex',
+                                            flexDirection:
+                                                'column',
+                                            gap: '0.75rem'
+                                        }}
+                                    >
+                                        <div>
+                                            <div
+                                                style={{
+                                                    color:
+                                                        'var(--text-main)',
+                                                    fontWeight:
+                                                        '700'
+                                                }}
+                                            >
+                                                {
+                                                    participant.name ||
+                                                    participant.email ||
+                                                    'Participant'
+                                                }
+                                            </div>
+
+                                            <div
+                                                style={{
+                                                    color:
+                                                        'var(--text-secondary)',
+                                                    fontSize:
+                                                        '0.75rem',
+                                                    marginTop:
+                                                        '0.2rem'
+                                                }}
+                                            >
+                                                {
+                                                    participant.role
+                                                }
+                                                {
+                                                    participant.email
+                                                        ? ` • ${participant.email}`
+                                                        : ''
+                                                }
+                                            </div>
+                                        </div>
+
+                                        <div
+                                            style={{
+                                                display: 'grid',
+                                                gridTemplateColumns:
+                                                    '1fr 1fr',
+                                                gap: '0.5rem'
+                                            }}
+                                        >
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    admitParticipant(
+                                                        participant.participantId
+                                                    )
+                                                }
+                                                disabled={
+                                                    participantActionId ===
+                                                    participant.participantId
+                                                }
+                                                style={{
+                                                    border: 'none',
+                                                    borderRadius:
+                                                        '0.6rem',
+                                                    padding:
+                                                        '0.55rem',
+                                                    background:
+                                                        '#16a34a',
+                                                    color: 'white',
+                                                    fontWeight:
+                                                        '700',
+                                                    cursor:
+                                                        participantActionId ===
+                                                        participant.participantId
+                                                            ? 'wait'
+                                                            : 'pointer'
+                                                }}
+                                            >
+                                                Admit
+                                            </button>
+
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    rejectParticipant(
+                                                        participant.participantId
+                                                    )
+                                                }
+                                                disabled={
+                                                    participantActionId ===
+                                                    participant.participantId
+                                                }
+                                                style={{
+                                                    border: 'none',
+                                                    borderRadius:
+                                                        '0.6rem',
+                                                    padding:
+                                                        '0.55rem',
+                                                    background:
+                                                        '#dc2626',
+                                                    color: 'white',
+                                                    fontWeight:
+                                                        '700',
+                                                    cursor:
+                                                        participantActionId ===
+                                                        participant.participantId
+                                                            ? 'wait'
+                                                            : 'pointer'
+                                                }}
+                                            >
+                                                Reject
+                                            </button>
+                                        </div>
+                                    </div>
+                                )
+                            )
+                        )}
+                    </aside>
+                </div>
                 {/* Bottom Control Bar */}
                 <div style={{
                     display: 'flex',
@@ -181,7 +698,8 @@ export default function ConductHearingPage() {
                     padding: '0.5rem'
                 }}>
                     <button
-                        onClick={endCall}
+                        onClick={endHearing}
+                        disabled={endingHearing}
                         style={{
                             padding: '1rem 2.5rem',
                             background: 'linear-gradient(135deg, #ef4444 0%, #b91c1c 100%)',
@@ -366,8 +884,8 @@ export default function ConductHearingPage() {
                                     </div>
 
                                     <button
-                                        onClick={() => joinHearing(hearing)}
-                                        disabled={!canJoinNow}
+                                        onClick={() => startHearing(hearing)}
+                                        disabled={!canJoinNow || startingHearingId === hearing.id}
                                         style={{
                                             ...primaryButtonStyle,
                                             padding: '1rem 2rem',
@@ -380,7 +898,15 @@ export default function ConductHearingPage() {
                                         onMouseOut={e => canJoinNow && (e.currentTarget.style.transform = 'translateY(0)')}
                                     >
                                         <Video size={20} />
-                                        {canJoinNow ? 'START SESSION' : 'COMING UP'}
+                                        {
+                                            startingHearingId === hearing.id
+                                                ? 'STARTING...'
+                                                : canJoinNow
+                                                    ? hearing.status === 'IN_PROGRESS'
+                                                        ? 'REJOIN SESSION'
+                                                        : 'START SESSION'
+                                                    : 'COMING UP'
+                                        }
                                     </button>
                                 </div>
                             </div>

--- a/frontend/nyaysetu-frontend/src/pages/judge/JudgeCaseWorkspace.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/judge/JudgeCaseWorkspace.jsx
@@ -1570,8 +1570,8 @@ function HearingsTab({ caseId, caseData }) {
         setShowOutcomeModal(true);
     };
 
-    const joinHearing = (hearing) => {
-        setActiveHearing(hearing);
+    const joinHearing = () => {
+        window.location.assign('/judge/conduct');
     };
 
     const endCall = () => {
@@ -1758,7 +1758,7 @@ function HearingsTab({ caseId, caseData }) {
                     </div>
                     <div style={{ flex: 1 }}>
                         <iframe
-                            src={`https://meet.jit.si/${activeHearing.videoRoomId || 'nyaysetu-hearing-' + activeHearing.id}#config.prejoinConfig.enabled=false&config.startWithAudioMuted=false&config.startWithVideoMuted=false&interfaceConfig.TOOLBAR_BUTTONS=["microphone","camera","closedcaptions","desktop","fullscreen","fodeviceselection","hangup","chat","recording","raisehand","videoquality","filmstrip","tileview","settings"]`}
+                            src="about:blank"
                             style={{ width: '100%', height: '100%', border: 'none' }}
                             allow="camera; microphone; fullscreen; display-capture; autoplay"
                             title="Court Hearing - NyaySetu"

--- a/frontend/nyaysetu-frontend/src/pages/judge/JudgeHearingsPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/judge/JudgeHearingsPage.jsx
@@ -108,9 +108,9 @@ export default function JudgeHearingsPage() {
         });
     };
 
-    const joinHearing = (hearing) => {
-        // Navigate to the case workspace and auto-join
-        navigate(`/judge/case/${hearing.caseId}`);
+    const joinHearing = () => {
+        // All hearing sessions must use the secured conduct page.
+        navigate('/judge/conduct');
     };
 
     if (loading) {

--- a/frontend/nyaysetu-frontend/src/pages/judge/LiveHearing.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/judge/LiveHearing.jsx
@@ -9,8 +9,6 @@ export default function LiveHearing() {
     const [hearings, setHearings] = useState([]);
     const [loading, setLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState('');
-    const [activeHearing, setActiveHearing] = useState(null);
-
     useEffect(() => {
         fetchUpcomingHearings();
         const interval = setInterval(fetchUpcomingHearings, 30000);
@@ -71,14 +69,9 @@ export default function LiveHearing() {
         return diffMinutes <= 15; // 15 mins before
     };
 
-    const joinHearing = (hearing) => {
-        setActiveHearing(hearing);
+    const joinHearing = () => {
+        navigate('/judge/conduct');
     };
-
-    const endCall = () => {
-        setActiveHearing(null);
-    };
-
     // Calendar Logic
     const today = new Date();
     const currentDay = today.getDay();
@@ -107,103 +100,6 @@ export default function LiveHearing() {
         padding: '1.5rem',
         boxShadow: 'var(--shadow-glass-strong)'
     };
-
-    // Active Video Call View
-    if (activeHearing) {
-        return (
-            <div style={{ maxWidth: '1400px', margin: '0 auto', paddingTop: '2rem', paddingBottom: '2rem' }}>
-                <div style={{ height: '75vh', display: 'flex', flexDirection: 'column', background: '#0a0a0f', borderRadius: '1.5rem', overflow: 'hidden', border: '2px solid rgba(99, 102, 241, 0.3)', boxShadow: '0 20px 60px rgba(0,0,0,0.4)' }}>
-                    {/* Video Header Area */}
-                    <div style={{
-                        padding: '1rem 1.5rem',
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        background: 'rgba(17, 24, 39, 0.95)',
-                        borderBottom: '1px solid rgba(99, 102, 241, 0.2)'
-                    }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                            <button
-                                onClick={endCall}
-                                aria-label="Leave hearing"
-                                style={{ background: 'rgba(239, 68, 68, 0.1)', border: 'none', color: '#ef4444', padding: '0.5rem', borderRadius: '0.5rem', cursor: 'pointer' }}
-                            >
-                                <ArrowLeft size={20} />
-                            </button>
-                            <div>
-                                <h2 style={{ color: 'white', margin: 0, fontSize: '1.125rem', fontWeight: '700' }}>
-                                    {activeHearing.caseTitle}
-                                </h2>
-                                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', color: '#94a3b8', fontSize: '0.75rem' }}>
-                                    <Shield size={12} color="#4ade80" />
-                                    <span>End-to-End Encrypted Secure Judicial Line</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem' }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', color: '#ef4444', fontWeight: '800', fontSize: '0.875rem' }}>
-                                <div style={{ width: '8px', height: '8px', borderRadius: '50%', background: '#ef4444', animation: 'blink 1.5s infinite' }} />
-                                SESSION LIVE
-                            </div>
-                            <div style={{ height: '24px', width: '1px', background: 'rgba(148, 163, 184, 0.3)' }} />
-                            <span style={{ color: '#94a3b8', fontSize: '0.875rem', fontWeight: '600' }}>{new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-                        </div>
-                    </div>
-
-                    {/* Jitsi Video Container */}
-                    <div style={{ flex: 1, position: 'relative', background: '#1a1a1f', minHeight: 0 }}>
-                        <iframe
-                            src={`https://meet.jit.si/${activeHearing.videoRoomId || 'nyaysetu-court-' + activeHearing.id}#config.prejoinConfig.enabled=false&config.startWithAudioMuted=false&config.startWithVideoMuted=false&interfaceConfig.TOOLBAR_BUTTONS=["microphone","camera","closedcaptions","desktop","embedmeeting","fullscreen","fodeviceselection","hangup","profile","chat","recording","livestreaming","etherpad","sharedvideo","settings","raisehand","videoquality","filmstrip","invite","feedback","stats","shortcuts","tileview","videobackgroundblur","download","help","mute-everyone","security"]`}
-                            style={{
-                                position: 'absolute',
-                                top: 0,
-                                left: 0,
-                                width: '100%',
-                                height: '100%',
-                                border: 'none'
-                            }}
-                            allow="camera; microphone; fullscreen; display-capture; autoplay"
-                            title="NyaySetu Court Hearing"
-                        />
-                    </div>
-
-                    {/* Bottom Control Bar */}
-                    <div style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        padding: '1rem',
-                        background: 'rgba(17, 24, 39, 0.95)',
-                        borderTop: '1px solid rgba(99, 102, 241, 0.2)'
-                    }}>
-                        <button
-                            onClick={endCall}
-                            style={{
-                                padding: '0.875rem 2rem',
-                                background: 'linear-gradient(135deg, #ef4444 0%, #b91c1c 100%)',
-                                border: 'none',
-                                borderRadius: '9999px',
-                                color: 'white',
-                                fontWeight: '800',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '0.75rem',
-                                boxShadow: '0 10px 25px rgba(239, 68, 68, 0.4)',
-                                transition: 'all 0.2s',
-                                letterSpacing: '0.5px'
-                            }}
-                            onMouseOver={e => e.currentTarget.style.transform = 'scale(1.05)'}
-                            onMouseOut={e => e.currentTarget.style.transform = 'scale(1)'}
-                        >
-                            <Phone size={20} />
-                            END SESSION
-                        </button>
-                    </div>
-                </div>
-            </div>
-        );
-    }
 
     return (
         <div style={{ maxWidth: '1400px', margin: '0 auto', paddingBottom: '2rem' }}>

--- a/frontend/nyaysetu-frontend/src/pages/judge/LiveHearing.test.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/judge/LiveHearing.test.jsx
@@ -32,6 +32,19 @@ const renderComponent = () => {
     );
 };
 
+const { mockNavigate } = vi.hoisted(() => ({
+    mockNavigate: vi.fn()
+}));
+
+vi.mock('react-router-dom', async () => {
+    const actual =
+        await vi.importActual('react-router-dom');
+
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate
+    };
+});
 describe('LiveHearing Accessibility Verification', () => {
     test('Dashboard layout structure matches basic screen reader role expectations', async () => {
         renderComponent();
@@ -45,20 +58,15 @@ describe('LiveHearing Accessibility Verification', () => {
         expect(searchInput).toBeInTheDocument();
     });
 
-    test('Active hearing workspace contains accessible navigation controls', async () => {
+    test('Join Now routes to the secured conduct page', async () => {
         renderComponent();
 
-        // Click the "Join Now" button to switch to the active hearing viewport layout
+        // Click Join Now and verify routing through the secured hearing page.
         const joinButton = await screen.findByRole('button', { name: /join now/i });
         fireEvent.click(joinButton);
+        expect(mockNavigate).toHaveBeenCalledWith(
+            '/judge/conduct'
+        );
 
-        // 3. Verify upper back navigation button has a valid descriptive aria-label
-        const backButton = screen.getByRole('button', { name: /leave hearing/i });
-        expect(backButton).toBeInTheDocument();
-        expect(backButton).toHaveAttribute('aria-label', 'Leave hearing');
-
-        // 4. Verify major session closure button is discoverable by role matching
-        const endSessionButton = screen.getByRole('button', { name: /end session/i });
-        expect(endSessionButton).toBeInTheDocument();
     });
 });

--- a/frontend/nyaysetu-frontend/src/pages/lawyer/LawyerHearingsPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/lawyer/LawyerHearingsPage.jsx
@@ -13,13 +13,22 @@ import {
     ArrowLeft
 } from 'lucide-react';
 import { hearingAPI } from '../../services/api';
+import { useHearingAdmission } from '../../hooks/useHearingAdmission';
 
 export default function LawyerHearingsPage() {
     const [searchTerm, setSearchTerm] = useState('');
     const [hearings, setHearings] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [inCall, setInCall] = useState(false);
-    const [activeHearing, setActiveHearing] = useState(null);
+    const {
+        activeCall: activeHearing,
+        waitingHearingId,
+        admissionStatus,
+        admissionError,
+        requesting,
+        requestJoin,
+        endCall,
+        cancelWaiting
+    } = useHearingAdmission();
 
     useEffect(() => {
         loadHearings();
@@ -37,8 +46,7 @@ export default function LawyerHearingsPage() {
                     date: scheduledDate ? scheduledDate.toLocaleDateString([], { month: 'short', day: '2-digit' }) : 'TBD',
                     fullDate: scheduledDate,
                     type: 'Virtual', // Most hearings in system are virtual for MVP
-                    room: h.videoRoomId || 'N/A',
-                    party: 'Client', // Placeholder as backend doesn't send it yet
+party: 'Client', // Placeholder as backend doesn't send it yet
                     status: h.status || 'Scheduled'
                 };
             });
@@ -48,16 +56,6 @@ export default function LawyerHearingsPage() {
         } finally {
             setLoading(false);
         }
-    };
-
-    const joinHearing = (hearing) => {
-        setActiveHearing(hearing);
-        setInCall(true);
-    };
-
-    const endCall = () => {
-        setInCall(false);
-        setActiveHearing(null);
     };
 
     const glassStyle = {
@@ -90,7 +88,7 @@ export default function LawyerHearingsPage() {
     );
 
     // Render Active Call View
-    if (inCall && activeHearing) {
+    if (activeHearing) {
         return (
             <div style={{ height: 'calc(100vh - 120px)', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
                 {/* Video Header Area */}
@@ -205,6 +203,72 @@ export default function LawyerHearingsPage() {
                     </div>
                 </div>
             </div>
+            {(admissionStatus || admissionError) && (
+                <div
+                    role="status"
+                    style={{
+                        marginBottom: '1.5rem',
+                        padding: '1rem 1.25rem',
+                        borderRadius: '1rem',
+                        background:
+                            admissionStatus === 'REJECTED' ||
+                            admissionStatus === 'EXPIRED' ||
+                            admissionStatus === 'ERROR'
+                                ? 'rgba(239, 68, 68, 0.1)'
+                                : 'rgba(59, 130, 246, 0.1)',
+                        border:
+                            admissionStatus === 'REJECTED' ||
+                            admissionStatus === 'EXPIRED' ||
+                            admissionStatus === 'ERROR'
+                                ? '1px solid rgba(239, 68, 68, 0.3)'
+                                : '1px solid rgba(59, 130, 246, 0.3)',
+                        color: 'var(--text-main)',
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        gap: '1rem'
+                    }}
+                >
+                    <div>
+                        <strong>
+                            {admissionStatus === 'REJECTED'
+                                ? 'Admission rejected'
+                                : admissionStatus === 'EXPIRED'
+                                    ? 'Hearing access expired'
+                                    : admissionStatus === 'ERROR'
+                                        ? 'Unable to join'
+                                        : admissionStatus === 'REQUESTING'
+                                            ? 'Requesting admission'
+                                            : 'Waiting room'}
+                        </strong>
+
+                        <div
+                            style={{
+                                marginTop: '0.35rem',
+                                color: 'var(--text-secondary)'
+                            }}
+                        >
+                            {admissionError ||
+                                'Your request has been sent. The hearing will open only after the judge admits you.'}
+                        </div>
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={cancelWaiting}
+                        style={{
+                            border: 'var(--border-glass)',
+                            background: 'var(--bg-glass)',
+                            color: 'var(--text-main)',
+                            borderRadius: '0.75rem',
+                            padding: '0.6rem 1rem',
+                            cursor: 'pointer'
+                        }}
+                    >
+                        Dismiss
+                    </button>
+                </div>
+            )}
 
             <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 380px', gap: '2rem' }}>
                 {/* Main: Hearings List */}
@@ -299,7 +363,11 @@ export default function LawyerHearingsPage() {
                                     <div style={{ display: 'flex', gap: '0.5rem' }}>
                                         {hearing.type === 'Virtual' && isToday ? (
                                             <button
-                                                onClick={() => joinHearing(hearing)}
+                                                onClick={() => requestJoin(hearing)}
+                                                disabled={
+                                                    requesting ||
+                                                    waitingHearingId === hearing.id
+                                                }
                                                 style={{
                                                     background: 'linear-gradient(135deg, #22c55e 0%, #16a34a 100%)',
                                                     color: 'white', border: 'none', borderRadius: '0.75rem',
@@ -307,7 +375,14 @@ export default function LawyerHearingsPage() {
                                                     cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '0.5rem',
                                                     boxShadow: '0 4px 12px rgba(34, 197, 94, 0.3)'
                                                 }}>
-                                                <Video size={16} /> Join Session
+                                                <Video size={16} />
+                                                    {
+                                                        waitingHearingId === hearing.id
+                                                            ? 'Waiting for judge'
+                                                            : requesting
+                                                                ? 'Requesting...'
+                                                                : 'Request to Join'
+                                                    }
                                             </button>
                                         ) : hearing.type === 'Virtual' ? (
                                             <button

--- a/frontend/nyaysetu-frontend/src/pages/litigant/HearingsPage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/HearingsPage.jsx
@@ -16,13 +16,23 @@ import {
     BookOpen
 } from 'lucide-react';
 import { hearingAPI } from '../../services/api';
+import { useHearingAdmission } from '../../hooks/useHearingAdmission';
 import { useTranslation } from 'react-i18next';
 
 export default function HearingsPage() {
     const [searchTerm, setSearchTerm] = useState('');
     const [hearings, setHearings] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [activeCall, setActiveCall] = useState(null);
+    const {
+        activeCall,
+        waitingHearingId,
+        admissionStatus,
+        admissionError,
+        requesting,
+        requestJoin,
+        endCall,
+        cancelWaiting
+    } = useHearingAdmission();
     const [reminders, setReminders] = useState(() => {
     return JSON.parse(localStorage.getItem('hearingReminders') || '{}');
 });
@@ -69,17 +79,6 @@ export default function HearingsPage() {
         const start = new Date(date);
         const diffMinutes = (start - now) / (1000 * 60);
         return diffMinutes <= 15 && diffMinutes > -120; // 15 mins before up to 2 hours late
-    };
-
-    const joinHearing = (hearing) => {
-        setActiveCall({
-            ...hearing,
-            room: hearing.videoRoomId || `nyaysetu-${hearing.id.substring(0, 8)}`
-        });
-    };
-
-    const endCall = () => {
-        setActiveCall(null);
     };
 
 const handleReminder = async (hearing) => {
@@ -198,6 +197,72 @@ const handleReminder = async (hearing) => {
                 </div>
             </div>
 
+            {(admissionStatus || admissionError) && (
+                <div
+                    role="status"
+                    style={{
+                        marginBottom: '1.5rem',
+                        padding: '1rem 1.25rem',
+                        borderRadius: '1rem',
+                        background:
+                            admissionStatus === 'REJECTED' ||
+                            admissionStatus === 'EXPIRED' ||
+                            admissionStatus === 'ERROR'
+                                ? 'rgba(239, 68, 68, 0.1)'
+                                : 'rgba(59, 130, 246, 0.1)',
+                        border:
+                            admissionStatus === 'REJECTED' ||
+                            admissionStatus === 'EXPIRED' ||
+                            admissionStatus === 'ERROR'
+                                ? '1px solid rgba(239, 68, 68, 0.3)'
+                                : '1px solid rgba(59, 130, 246, 0.3)',
+                        color: 'var(--text-main)',
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        gap: '1rem'
+                    }}
+                >
+                    <div>
+                        <strong>
+                            {admissionStatus === 'REJECTED'
+                                ? 'Admission rejected'
+                                : admissionStatus === 'EXPIRED'
+                                    ? 'Hearing access expired'
+                                    : admissionStatus === 'ERROR'
+                                        ? 'Unable to join'
+                                        : admissionStatus === 'REQUESTING'
+                                            ? 'Requesting admission'
+                                            : 'Waiting room'}
+                        </strong>
+
+                        <div
+                            style={{
+                                marginTop: '0.35rem',
+                                color: 'var(--text-secondary)'
+                            }}
+                        >
+                            {admissionError ||
+                                'Your request has been sent. The hearing will open only after the judge admits you.'}
+                        </div>
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={cancelWaiting}
+                        style={{
+                            border: 'var(--border-glass)',
+                            background: 'var(--bg-glass)',
+                            color: 'var(--text-main)',
+                            borderRadius: '0.75rem',
+                            padding: '0.6rem 1rem',
+                            cursor: 'pointer'
+                        }}
+                    >
+                        Dismiss
+                    </button>
+                </div>
+            )}
             <div className="hearings-grid" style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 380px', gap: '2rem' }}>
                 {/* List Column */}
                 <div className="hearings-list-column" style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
@@ -270,12 +335,25 @@ const handleReminder = async (hearing) => {
 
                                     <div className="hearing-action">
                                         {hearing.canJoin ? (
-                                            <button onClick={() => joinHearing(hearing)} style={{
+                                            <button
+                                                onClick={() => requestJoin(hearing)}
+                                                disabled={
+                                                    requesting ||
+                                                    waitingHearingId === hearing.id
+                                                }
+                                                style={{
                                                 background: 'var(--color-primary)', color: 'white', border: 'none', borderRadius: '0.75rem',
                                                 padding: '0.75rem 1.5rem', fontWeight: '700', fontSize: '0.9rem', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '0.5rem',
                                                 boxShadow: '0 4px 12px rgba(30, 42, 68, 0.3)'
                                             }}>
-                                                <Video size={18} /> {t('hearings.joinNow')}
+                                                <Video size={18} />
+                                                {
+                                                    waitingHearingId === hearing.id
+                                                        ? 'Waiting for judge'
+                                                        : requesting
+                                                            ? 'Requesting...'
+                                                            : 'Request to Join'
+                                                }
                                             </button>
                                         ) : (
                                             <div style={{

--- a/frontend/nyaysetu-frontend/src/services/api.js
+++ b/frontend/nyaysetu-frontend/src/services/api.js
@@ -176,7 +176,36 @@ export const hearingAPI = {
     join: (id) => api.post(`/api/v1/hearings/${id}/join`),
     leave: (id) => api.post(`/api/v1/hearings/${id}/leave`),
     complete: (id, notes) => api.put(`/api/v1/hearings/${id}/complete`, { judgeNotes: notes }),
-    getParticipants: (id) => api.get(`/api/v1/hearings/${id}/participants`)
+    getParticipants: (id) => api.get(`/api/v1/hearings/${id}/participants`),
+
+    start: (id) =>
+        api.post(`/api/v1/hearings/${id}/start`),
+
+    requestJoin: (id) =>
+        api.post(`/api/v1/hearings/${id}/join-request`),
+
+    getJoinAccess: (id, token) =>
+        api.get(`/api/v1/hearings/${id}/join-access`, {
+            headers: {
+                'X-Hearing-Access-Token': token
+            }
+        }),
+
+    getWaitingRoom: (id) =>
+        api.get(`/api/v1/hearings/${id}/waiting-room`),
+
+    admitParticipant: (hearingId, participantId) =>
+        api.post(
+            `/api/v1/hearings/${hearingId}/participants/${participantId}/admit`
+        ),
+
+    rejectParticipant: (hearingId, participantId) =>
+        api.post(
+            `/api/v1/hearings/${hearingId}/participants/${participantId}/reject`
+        ),
+
+    end: (id) =>
+        api.post(`/api/v1/hearings/${id}/end`)
 };
 
 // Meeting API


### PR DESCRIPTION
## Description

This PR introduces an application-level waiting room and admission-control system for virtual court hearings.

Previously, participants could obtain or construct the Jitsi room URL and enter a hearing without waiting for the judge. This change ensures that the room identifier is disclosed only after the authenticated participant has requested access and the assigned judge has admitted them.

### Changes included

* Added participant admission states:

  * `INVITED`
  * `WAITING`
  * `ADMITTED`
  * `REJECTED`
  * `EXPIRED`

* Added secure, unique participant access tokens:

  * Generated using a cryptographically secure random value
  * Stored in the database as a SHA-256 hash
  * Sent through the `X-Hearing-Access-Token` request header
  * Automatically expire after the hearing access window
  * Invalidated when the hearing ends

* Added judge-controlled hearing operations:

  * Start hearing
  * View waiting participants
  * Admit participants
  * Reject participants
  * End hearing and expire participant access

* Prevented hearing room identifiers from being exposed through regular hearing-list and hearing-detail responses.

* Disabled the legacy direct-join endpoint.

* Added participant waiting-room polling for litigants and lawyers.

* Updated legacy judge hearing entry points to redirect to the secured Conduct Hearing page.

* Added database migration `V54__add_virtual_hearing_waiting_room.sql`.

* Added service and controller tests for:

  * Waiting-room requests
  * Unique participant tokens
  * Admission-based room disclosure
  * Unauthorized judge access
  * Token expiration when a hearing ends
  * Disabled legacy direct joining

### Security scope

This implementation provides application-level waiting-room protection and prevents NyaySetu from disclosing the Jitsi room before admission.

Because the application currently uses the public `meet.jit.si` service, an admitted participant could still manually share the disclosed Jitsi room URL. Complete provider-level enforcement would require a self-hosted Jitsi secure-domain or JWT-based deployment.

Closes #1628

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Testing

* All eight modified frontend hearing files passed standalone esbuild syntax validation.
* Security audit confirms predictable hearing-room fallbacks were removed from participant and legacy judge hearing pages.
* `git diff --check` completed without whitespace errors.
* Added controller and service unit tests for the waiting-room workflow.
* Updated `LiveHearing.test.jsx` for the secured conduct-page navigation flow; 2/2 targeted tests pass locally.

### Existing repository blockers

The complete frontend production build is currently blocked by pre-existing JSX syntax errors in `VakilFriendPage.jsx`, which was not modified in this PR.

Backend Maven test execution is currently blocked during production compilation by pre-existing missing NetworkNT JSON Schema classes. No new waiting-room compilation errors were reported before the baseline dependency failure.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works