### PR TITLE
fix(ui): use correct CSS variables in DocumentGeneratePage for dark mode (fixes #676)

### DIFF
--- a/frontend/nyaysetu-frontend/src/pages/litigant/DocumentGeneratePage.jsx
+++ b/frontend/nyaysetu-frontend/src/pages/litigant/DocumentGeneratePage.jsx
@@ -296,7 +296,7 @@ const DocumentGeneratePage = () => {
 
     const cardStyle = {
         background: 'var(--bg-surface)',
-        border: '1px solid var(--color-border)',
+        border: '1px solid var(--border-light)',
         borderRadius: '1rem',
         padding: '1.5rem',
     };
@@ -304,7 +304,7 @@ const DocumentGeneratePage = () => {
     const inputStyle = {
         width: '100%',
         padding: '0.75rem 1rem',
-        border: 'var(--color-border)',
+        border: 'var(--border-light)',
         borderRadius: '0.5rem',
         fontSize: '0.9rem',
         outline: 'none',
@@ -349,7 +349,7 @@ const DocumentGeneratePage = () => {
     return (
         <div style={{
             height: 'calc(100vh - 64px)',
-            background: 'var(--color-bg-alt)',
+            background: 'var(--bg-main)',
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
@@ -358,20 +358,20 @@ const DocumentGeneratePage = () => {
             <header style={{
                 padding: '1rem 1.5rem',
                 background: 'var(--bg-surface)',
-                borderBottom: '1px solid var(--color-border)',
+                borderBottom: '1px solid var(--border-light)',
                 display: 'flex',
                 alignItems: 'center',
                 gap: '1rem',
             }}>
                 <button
                     onClick={() => step > 1 ? setStep(step - 1) : navigate(-1)}
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-muted)' }}
+                    style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)' }}
                 >
                     <ArrowLeft size={20} />
                 </button>
                 <div style={{ flex: 1 }}>
                     <h1 style={{ fontSize: '1.25rem', fontWeight: 600, margin: 0 }}>Generate Legal Document</h1>
-                    <p style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', margin: 0 }}>
+                    <p style={{ fontSize: '0.8rem', color: 'var(--text-muted)', margin: 0 }}>
                         AI-powered document generation using Indian legal corpus
                     </p>
                 </div>
@@ -382,7 +382,7 @@ const DocumentGeneratePage = () => {
                             width: s === step ? '2rem' : '0.5rem',
                             height: '0.5rem',
                             borderRadius: '0.25rem',
-                            background: s <= step ? 'var(--color-primary)' : 'var(--color-border)',
+                            background: s <= step ? 'var(--color-primary)' : 'var(--border-light)',
                             transition: 'all 0.3s',
                         }} />
                     ))}
@@ -422,7 +422,7 @@ const DocumentGeneratePage = () => {
                                             style={{
                                                 ...cardStyle,
                                                 cursor: 'pointer',
-                                                borderColor: selectedType === docType.id ? docType.color : '#E5E7EB',
+                                                borderColor: selectedType === docType.id ? docType.color : 'var(--border-light)',
                                                 transition: 'all 0.2s',
                                             }}
                                         >
@@ -745,7 +745,7 @@ const DocumentGeneratePage = () => {
                                 <div style={{
                                     display: 'flex', justifyContent: 'space-between', alignItems: 'center',
                                     marginBottom: '1rem', paddingBottom: '0.75rem',
-                                    borderBottom: '1px solid var(--color-border)',
+                                    borderBottom: '1px solid var(--border-light)',
                                 }}>
                                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                                         <FileText size={18} color="var(--color-primary)" />
@@ -765,7 +765,7 @@ const DocumentGeneratePage = () => {
                                         width: '100%',
                                         minHeight: '400px',
                                         padding: '1rem',
-                                        border: '1px solid var(--color-border)',
+                                        border: '1px solid var(--border-light)',
                                         borderRadius: '0.5rem',
                                         fontFamily: '"Courier New", Courier, monospace',
                                         fontSize: '0.88rem',


### PR DESCRIPTION
This PR fixes the UI bugs reported in #676. DocumentGeneratePage.jsx was incorrectly using non-existent CSS variables (--color-bg-alt, --color-border, etc.) which caused it to fall back to hardcoded white backgrounds in dark mode. I have updated it to use the correct global.css theme variables (--bg-main, --border-light, --text-muted). Note: The 'Forensic Analysis' sidebar issue mentioned in the issue seems to have been already resolved in the current main branch, so this PR only contains the dark mode fix.